### PR TITLE
Publish releases from CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ node('osx_vegas') {
   stage('Publish') {
     withCredentials([[$class: 'StringBinding', credentialsId: 'github-release-token', variable: 'GH_TOKEN']]) {
       sh '''
-        npm run release
+        ./node_modules/.bin/build --publish onTagOrDraft
       '''
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,26 @@
+#!groovy
+
+node('osx_vegas') {
+  stage('Checkout') {
+    checkout([
+      $class: 'GitSCM',
+      branches: scm.branches,
+      gitTool: 'native git',
+      extensions: scm.extensions + [[$class: 'CleanCheckout'], [$class: 'CloneOption', depth: 0, noTags: false, reference: '', shallow: false]],
+      userRemoteConfigs: scm.userRemoteConfigs
+    ])
+  }
+
+  stage('Build') {
+    sh '''
+      npm install --quiet
+      npm run build
+    '''
+  }
+
+  stage('Publish') {
+    sh '''
+      npm run release
+    '''
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,10 +19,12 @@ node('osx_vegas') {
   }
 
   stage('Publish') {
-    withCredentials([[$class: 'StringBinding', credentialsId: 'github-release-token', variable: 'GH_TOKEN']]) {
-      sh '''
-        ./node_modules/.bin/build --publish onTagOrDraft
-      '''
+    if (env.BRANCH_NAME == "master") {
+      withCredentials([[$class: 'StringBinding', credentialsId: 'github-release-token', variable: 'GH_TOKEN']]) {
+        sh '''
+          ./node_modules/.bin/build --publish onTagOrDraft
+        '''
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,10 +21,10 @@ node('osx_vegas') {
   stage('Publish') {
     if (env.BRANCH_NAME == "master") {
       withCredentials([[$class: 'StringBinding', credentialsId: 'github-release-token', variable: 'GH_TOKEN']]) {
-        sh './node_modules/.bin/build --publish onTagOrDraft'
+        sh './node_modules/.bin/electron-builder --publish onTagOrDraft'
       }
     } else {
-      sh './node_modules/.bin/build --publish never'
+      sh './node_modules/.bin/electron-builder --publish never'
     }
 
     archiveArtifacts "dist/${getPackageBuildProductName()}-${getPackageVersion()}.dmg"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ node('osx_vegas') {
       sh './node_modules/.bin/build --publish never'
     }
 
-    archiveArtifacts "dist/${getPackageVersion()}-${getPackageVersion()}.dmg"
+    archiveArtifacts "dist/${getPackageBuildProductName()}-${getPackageVersion()}.dmg"
   }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,8 +19,10 @@ node('osx_vegas') {
   }
 
   stage('Publish') {
-    sh '''
-      npm run release
-    '''
+    withCredentials([[$class: 'StringBinding', credentialsId: 'github-release-token', variable: 'GH_TOKEN']]) {
+      sh '''
+        npm run release
+      '''
+    }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,10 +21,20 @@ node('osx_vegas') {
   stage('Publish') {
     if (env.BRANCH_NAME == "master") {
       withCredentials([[$class: 'StringBinding', credentialsId: 'github-release-token', variable: 'GH_TOKEN']]) {
-        sh '''
-          ./node_modules/.bin/build --publish onTagOrDraft
-        '''
+        sh './node_modules/.bin/build --publish onTagOrDraft'
       }
+    } else {
+      sh './node_modules/.bin/build --publish never'
     }
+
+    archiveArtifacts "dist/${getPackageVersion()}-${getPackageVersion()}.dmg"
   }
+}
+
+def getPackageBuildProductName() {
+  return sh(returnStdout: true, script:"node -e \"console.log(require('./package.json').build.productName)\"").trim()
+}
+
+def getPackageVersion() {
+  return sh(returnStdout: true, script:"node -e \"console.log(require('./package.json').version)\"").trim()
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build": "tsc && node-sass ./static/styles.scss ./build/styles.css",
     "start": "electron ./build/main.js",
     "dist": "electron-builder --dir",
-    "release": "build"
+    "release": "build --publish onTagOrDraft"
   },
   "dependencies": {
     "react": "^15.6.1",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "lint": "tslint --project tsconfig.json --type-check --force",
     "build": "tsc && node-sass ./static/styles.scss ./build/styles.css",
     "start": "electron ./build/main.js",
-    "dist": "electron-builder --dir",
-    "release": "build --publish onTagOrDraft"
+    "dist": "electron-builder --dir"
   },
   "dependencies": {
     "react": "^15.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realm-studio",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.2",
   "description": "A tool for everything Realm.",
   "author": "Realm Inc.",
   "repository": "https://github.com/realm/realm-studio",
@@ -19,8 +19,11 @@
       "./package.json"
     ],
     "mac": {
-      "category": "public.app-category.developer-tools",
-      "target": "dir"
+      "category": "public.app-category.developer-tools"
+    },
+    "publish": {
+      "provider": "github",
+      "private": true
     }
   },
   "scripts": {
@@ -28,8 +31,8 @@
     "lint": "tslint --project tsconfig.json --type-check --force",
     "build": "tsc && node-sass ./static/styles.scss ./build/styles.css",
     "start": "electron ./build/main.js",
-    "pack": "electron-builder --dir",
-    "dist": "electron-builder"
+    "dist": "electron-builder --dir",
+    "release": "build"
   },
   "dependencies": {
     "react": "^15.6.1",


### PR DESCRIPTION
This PR adds CI job that builds and publishes the results to Github releases.

A proposed workflow looks like this:

1. Everytime the version in `package.json` changes in `master` CI drafts a release on Github and publishes results to that draft.
2. All other commits to `master` update the draft and publish new artefacts.
3. Once release is ready it's published manually on Github (by pressing "Publish" button on draft).
4. After draft is released other commits to `master` don't update its artefacts.

All artefacts are always published on Jenkins's job for every commit on any branch.

This workflow allows having the latest artefacts available for download and testing + automates release process. One bad thing - build takes around 15 minutes (only for mac) but it doesn't look like we can do anything with that :(

Fixes https://github.com/realm/realm-studio/issues/5.