### PR TITLE
Made the devDependency on ROS less specific

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "node-sass": "^4.5.3",
     "null-loader": "^0.1.1",
     "react-hot-loader": "^3.0.0-beta.7",
-    "realm-object-server": "^2.0.0-alpha.17",
+    "realm-object-server": "^2.0.0-alpha",
     "resolve-url-loader": "^2.1.0",
     "sass-lint": "^1.10.2",
     "sass-loader": "^6.0.6",


### PR DESCRIPTION
Instead of a dependency on a specific version of ROS alpha, any 2.0.0-alpha would go