### PR TITLE
Better optional handling in browser

### DIFF
--- a/src/ui/realm-browser/HeaderCell.tsx
+++ b/src/ui/realm-browser/HeaderCell.tsx
@@ -22,7 +22,7 @@ export const getPropertyDisplayed = (property: Realm.ObjectSchemaProperty) => {
   }
 
   if (property.optional) {
-    typeDesc += " (optional)";
+    typeDesc += "?";
   }
 
   return typeDesc;

--- a/src/ui/realm-browser/HeaderCell.tsx
+++ b/src/ui/realm-browser/HeaderCell.tsx
@@ -7,25 +7,20 @@ const HANDLE_WIDTH = 8;
 const HANDLE_OFFSET = HANDLE_WIDTH / 2;
 
 export const getPropertyDisplayed = (property: Realm.ObjectSchemaProperty) => {
-  let typeDesc;
+  const propDesc = () => {
+    switch (property.type) {
+      case "list":
+        return `${property.objectType}[]`;
+      case "object":
+      case "linkingObjects":
+        return property.objectType;
+      default:
+        return property.type;
+    }
+  };
+  const optionalPostfix = () => property.optional ? "?" : "";
 
-  switch (property.type) {
-    case "list":
-      typeDesc = `${property.objectType}[]`;
-      break;
-    case "object":
-    case "linkingObjects":
-      typeDesc = property.objectType;
-      break;
-    default:
-      typeDesc = property.type;
-  }
-
-  if (property.optional) {
-    typeDesc += "?";
-  }
-
-  return typeDesc;
+  return propDesc() + optionalPostfix();
 };
 
 export const HeaderCell = ({

--- a/src/ui/realm-browser/HeaderCell.tsx
+++ b/src/ui/realm-browser/HeaderCell.tsx
@@ -7,15 +7,25 @@ const HANDLE_WIDTH = 8;
 const HANDLE_OFFSET = HANDLE_WIDTH / 2;
 
 export const getPropertyDisplayed = (property: Realm.ObjectSchemaProperty) => {
-  if (property.type === "list") {
-    return `${property.objectType}[]`;
-  } else if (property.type === "linkingObjects") {
-    return property.objectType;
-  } else if (property.type === "object") {
-    return property.objectType;
-  } else {
-    return property.type;
+  let typeDesc;
+
+  switch (property.type) {
+    case "list":
+      typeDesc = `${property.objectType}[]`;
+      break;
+    case "object":
+    case "linkingObjects":
+      typeDesc = property.objectType;
+      break;
+    default:
+      typeDesc = property.type;
   }
+
+  if (property.optional) {
+    typeDesc += " (optional)";
+  }
+
+  return typeDesc;
 };
 
 export const HeaderCell = ({

--- a/src/ui/realm-browser/HeaderCell.tsx
+++ b/src/ui/realm-browser/HeaderCell.tsx
@@ -6,21 +6,24 @@ import * as Realm from "realm";
 const HANDLE_WIDTH = 8;
 const HANDLE_OFFSET = HANDLE_WIDTH / 2;
 
-export const getPropertyDisplayed = (property: Realm.ObjectSchemaProperty) => {
-  const propDesc = () => {
-    switch (property.type) {
-      case "list":
-        return `${property.objectType}[]`;
-      case "object":
-      case "linkingObjects":
-        return property.objectType;
-      default:
-        return property.type;
-    }
-  };
-  const optionalPostfix = () => property.optional ? "?" : "";
+const getPropertyDescription = (property: Realm.ObjectSchemaProperty) => {
+  switch (property.type) {
+    case "list":
+      return `${property.objectType}[]`;
+    case "object":
+    case "linkingObjects":
+      return property.objectType;
+    default:
+      return property.type;
+  }
+};
 
-  return propDesc() + optionalPostfix();
+const getPropertyPostfix = (property: Realm.ObjectSchemaProperty) => {
+  return property.optional ? "?" : "";
+};
+
+export const getPropertyDisplayed = (property: Realm.ObjectSchemaProperty) => {
+  return getPropertyDescription(property) + getPropertyPostfix(property);
 };
 
 export const HeaderCell = ({

--- a/src/ui/realm-browser/RealmBrowser.scss
+++ b/src/ui/realm-browser/RealmBrowser.scss
@@ -109,6 +109,10 @@ $realm-browser-header-handle-width: 8px;
       border: 0;
       white-space: nowrap;
 
+      &--null {
+        color: $color-elephant;
+      }
+
       &--disabled {
         color: $color-elephant;
       }

--- a/src/ui/realm-browser/types/StringCell.tsx
+++ b/src/ui/realm-browser/types/StringCell.tsx
@@ -30,14 +30,10 @@ export const StringCell = ({
         />
     ) : (
         <div
-            className={value === null
-            ? classnames("form-control",
-                         "form-control-sm",
-                         "RealmBrowser__Content__Input",
-                         "RealmBrowser__Content__Input--null")
-            : classnames("form-control",
-                         "form-control-sm",
-                         "RealmBrowser__Content__Input")}
+            className={classnames("form-control",
+                                  "form-control-sm",
+                                  "RealmBrowser__Content__Input",
+                                  {"RealmBrowser__Content__Input--null": value === null})}
             onClick={onFocus}
         >
             {value === null ? "null" : value.toString()}

--- a/src/ui/realm-browser/types/StringCell.tsx
+++ b/src/ui/realm-browser/types/StringCell.tsx
@@ -30,10 +30,17 @@ export const StringCell = ({
         />
     ) : (
         <div
-            className={classnames("form-control", "form-control-sm", "RealmBrowser__Content__Input")}
+            className={value === null
+            ? classnames("form-control",
+                         "form-control-sm",
+                         "RealmBrowser__Content__Input",
+                         "RealmBrowser__Content__Input--null")
+            : classnames("form-control",
+                         "form-control-sm",
+                         "RealmBrowser__Content__Input")}
             onClick={onFocus}
         >
-            {value === null ? "" : value.toString()}
+            {value === null ? "null" : value.toString()}
         </div>
     );
 }


### PR DESCRIPTION
Adds type annotations in the header for optionals, and shows `null` values rendered in the cells.

From:

![screen shot 2017-09-19 at 7 35 10 pm](https://user-images.githubusercontent.com/69422/30624356-c2d23bf0-9d71-11e7-8961-8369001ff579.png)

To:

![screen shot 2017-09-19 at 7 36 58 pm](https://user-images.githubusercontent.com/69422/30624378-efa2c9d8-9d71-11e7-89be-fb3407b0a845.png)
