### PR TITLE
Edit object references

### DIFF
--- a/src/ui/realm-browser/Cell.tsx
+++ b/src/ui/realm-browser/Cell.tsx
@@ -9,7 +9,7 @@ import { StringCellContainer } from './types/StringCellContainer';
 
 export const Cell = ({
   onUpdateValue,
-  onListCellClick,
+  onCellClick,
   property,
   style,
   value,
@@ -18,7 +18,7 @@ export const Cell = ({
   onContextMenu,
 }: {
   onUpdateValue: (value: string) => void;
-  onListCellClick: (property: Realm.ObjectSchemaProperty, value: any) => void;
+  onCellClick: (property: Realm.ObjectSchemaProperty, value: any) => void;
   property: Realm.ObjectSchemaProperty;
   style: React.CSSProperties;
   value: any;
@@ -40,6 +40,7 @@ export const Cell = ({
           value={value}
           onUpdateValue={onUpdateValue}
           onContextMenu={onContextMenu}
+          onClick={onCellClick}
         />
       );
       break;
@@ -50,7 +51,7 @@ export const Cell = ({
           onContextMenu={onContextMenu}
           property={property}
           value={value}
-          onClick={onListCellClick}
+          onClick={onCellClick}
         />
       );
       break;
@@ -60,7 +61,7 @@ export const Cell = ({
           onContextMenu={onContextMenu}
           property={property}
           value={value}
-          onClick={onListCellClick}
+          onClick={onCellClick}
         />
       );
       break;

--- a/src/ui/realm-browser/Content.tsx
+++ b/src/ui/realm-browser/Content.tsx
@@ -25,25 +25,35 @@ export const Content = ({
   sort,
   onSortClick,
   onContextMenu,
+  onRowClick,
 }: {
   columnWidths: number[];
   gridContentRef: (grid: Grid) => void;
   gridHeaderRef: (grid: Grid) => void;
-  onCellChange: (object: any, propertyName: string, value: string) => void;
-  onListCellClick: (
+  onCellChange?: (object: any, propertyName: string, value: string) => void;
+  onListCellClick?: (
     object: any,
     property: Realm.ObjectSchemaProperty,
     value: any,
   ) => void;
   onColumnWidthChanged: (index: number, width: number) => void;
   schema: Realm.ObjectSchema | null;
-  rowToHighlight: number | null;
+  rowToHighlight?: number | null;
   data: Realm.Results<any> | any;
   query: string | null;
   onQueryChange: (e: React.SyntheticEvent<any>) => void;
   sort: string | null;
   onSortClick: (property: string) => void;
-  onContextMenu: (e: React.SyntheticEvent<any>, object: any) => void;
+  onContextMenu?: (
+    e: React.SyntheticEvent<any>,
+    object: any,
+    property: Realm.ObjectSchemaProperty,
+  ) => void;
+  onRowClick?: (
+    object: any,
+    property: Realm.ObjectSchemaProperty,
+    value: any,
+  ) => void;
 }) => {
   if (schema) {
     // Generate the columns from the schemas properties
@@ -64,7 +74,8 @@ export const Content = ({
         style: React.CSSProperties;
       }) => {
         const object = data[rowIndex];
-        return (
+
+        const cell = (
           <Cell
             key={key}
             width={columnWidths[columnIndex]}
@@ -72,17 +83,31 @@ export const Content = ({
             onListCellClick={(
               property: Realm.ObjectSchemaProperty, // tslint:disable-line:no-shadowed-variable
               value: any,
-            ) => {
-              onListCellClick(object, property, value);
-            }}
+            ) => onListCellClick && onListCellClick(object, property, value)}
             value={object[propertyName]}
             property={property}
-            onUpdateValue={value => {
-              onCellChange(object, propertyName, value);
-            }}
+            onUpdateValue={value =>
+              onCellChange && onCellChange(object, propertyName, value)}
             isHighlight={rowToHighlight === rowIndex}
-            onContextMenu={e => onContextMenu(e, object)}
+            onContextMenu={e =>
+              onContextMenu && onContextMenu(e, object, property)}
           />
+        );
+
+        return onRowClick ? (
+          <div
+            key={key}
+            style={{ userSelect: 'none', cursor: 'pointer' }}
+            onClick={e => {
+              e.stopPropagation();
+              e.preventDefault();
+              onRowClick(object, property, object[propertyName]);
+            }}
+          >
+            {cell}
+          </div>
+        ) : (
+          cell
         );
       };
     });

--- a/src/ui/realm-browser/Content.tsx
+++ b/src/ui/realm-browser/Content.tsx
@@ -39,7 +39,7 @@ export const Content = ({
   ) => void;
   onColumnWidthChanged: (index: number, width: number) => void;
   schema: Realm.ObjectSchema | null;
-  rowToHighlight?: number | null;
+  rowToHighlight?: number;
   data: Realm.Results<any> | any;
   query: string | null;
   onQueryChange: (e: React.SyntheticEvent<any>) => void;

--- a/src/ui/realm-browser/Content.tsx
+++ b/src/ui/realm-browser/Content.tsx
@@ -15,7 +15,7 @@ export const Content = ({
   gridContentRef,
   gridHeaderRef,
   onCellChange,
-  onListCellClick,
+  onCellClick,
   onColumnWidthChanged,
   schema,
   rowToHighlight,
@@ -25,16 +25,16 @@ export const Content = ({
   sort,
   onSortClick,
   onContextMenu,
-  onRowClick,
 }: {
   columnWidths: number[];
   gridContentRef: (grid: Grid) => void;
   gridHeaderRef: (grid: Grid) => void;
   onCellChange?: (object: any, propertyName: string, value: string) => void;
-  onListCellClick?: (
+  onCellClick?: (
     object: any,
     property: Realm.ObjectSchemaProperty,
     value: any,
+    rowIndex: number,
   ) => void;
   onColumnWidthChanged: (index: number, width: number) => void;
   schema: Realm.ObjectSchema | null;
@@ -48,11 +48,6 @@ export const Content = ({
     e: React.SyntheticEvent<any>,
     object: any,
     property: Realm.ObjectSchemaProperty,
-  ) => void;
-  onRowClick?: (
-    object: any,
-    property: Realm.ObjectSchemaProperty,
-    value: any,
   ) => void;
 }) => {
   if (schema) {
@@ -75,15 +70,15 @@ export const Content = ({
       }) => {
         const object = data[rowIndex];
 
-        const cell = (
+        return (
           <Cell
             key={key}
             width={columnWidths[columnIndex]}
             style={style}
-            onListCellClick={(
+            onCellClick={(
               property: Realm.ObjectSchemaProperty, // tslint:disable-line:no-shadowed-variable
               value: any,
-            ) => onListCellClick && onListCellClick(object, property, value)}
+            ) => onCellClick && onCellClick(object, property, value, rowIndex)}
             value={object[propertyName]}
             property={property}
             onUpdateValue={value =>
@@ -92,22 +87,6 @@ export const Content = ({
             onContextMenu={e =>
               onContextMenu && onContextMenu(e, object, property)}
           />
-        );
-
-        return onRowClick ? (
-          <div
-            key={key}
-            style={{ userSelect: 'none', cursor: 'pointer' }}
-            onClick={e => {
-              e.stopPropagation();
-              e.preventDefault();
-              onRowClick(object, property, object[propertyName]);
-            }}
-          >
-            {cell}
-          </div>
-        ) : (
-          cell
         );
       };
     });

--- a/src/ui/realm-browser/Content.tsx
+++ b/src/ui/realm-browser/Content.tsx
@@ -35,6 +35,7 @@ export const Content = ({
     property: Realm.ObjectSchemaProperty,
     value: any,
     rowIndex: number,
+    columnIndex: number,
   ) => void;
   onColumnWidthChanged: (index: number, width: number) => void;
   schema: Realm.ObjectSchema | null;
@@ -78,7 +79,9 @@ export const Content = ({
             onCellClick={(
               property: Realm.ObjectSchemaProperty, // tslint:disable-line:no-shadowed-variable
               value: any,
-            ) => onCellClick && onCellClick(object, property, value, rowIndex)}
+            ) =>
+              onCellClick &&
+              onCellClick(object, property, value, rowIndex, columnIndex)}
             value={object[propertyName]}
             property={property}
             onUpdateValue={value =>

--- a/src/ui/realm-browser/ContentContainer.tsx
+++ b/src/ui/realm-browser/ContentContainer.tsx
@@ -15,7 +15,7 @@ export interface IContentContainerProps {
     columnIndex: number,
   ) => void;
   schema: Realm.ObjectSchema | null;
-  rowToHighlight?: number | null;
+  rowToHighlight?: number;
   columnToHighlight?: number;
   data: Realm.Results<any> | any;
   onContextMenu?: (

--- a/src/ui/realm-browser/ContentContainer.tsx
+++ b/src/ui/realm-browser/ContentContainer.tsx
@@ -11,10 +11,12 @@ export interface IContentContainerProps {
     object: any,
     property: Realm.ObjectSchemaProperty,
     value: any,
-    index: number,
+    rowIndex: number,
+    columnIndex: number,
   ) => void;
   schema: Realm.ObjectSchema | null;
   rowToHighlight?: number | null;
+  columnToHighlight?: number;
   data: Realm.Results<any> | any;
   onContextMenu?: (
     e: React.SyntheticEvent<any>,
@@ -106,10 +108,11 @@ export class ContentContainer extends React.Component<
     if (
       this.gridContent &&
       this.props.rowToHighlight &&
-      this.props.rowToHighlight !== prevProps.rowToHighlight
+      (this.props.rowToHighlight !== prevProps.rowToHighlight ||
+        this.props.columnToHighlight !== prevProps.columnToHighlight)
     ) {
       this.gridContent.scrollToCell({
-        columnIndex: 0,
+        columnIndex: this.props.columnToHighlight || 0,
         rowIndex: this.props.rowToHighlight,
       });
     }

--- a/src/ui/realm-browser/ContentContainer.tsx
+++ b/src/ui/realm-browser/ContentContainer.tsx
@@ -7,15 +7,11 @@ const MINIMUM_COLUMN_WIDTH = 20;
 
 export interface IContentContainerProps {
   onCellChange?: (object: any, propertyName: string, value: string) => void;
-  onListCellClick?: (
+  onCellClick?: (
     object: any,
     property: Realm.ObjectSchemaProperty,
     value: any,
-  ) => void;
-  onRowClick?: (
-    object: any,
-    property: Realm.ObjectSchemaProperty,
-    value: any,
+    index: number,
   ) => void;
   schema: Realm.ObjectSchema | null;
   rowToHighlight?: number | null;

--- a/src/ui/realm-browser/ContentContainer.tsx
+++ b/src/ui/realm-browser/ContentContainer.tsx
@@ -6,16 +6,25 @@ import { Content } from './Content';
 const MINIMUM_COLUMN_WIDTH = 20;
 
 export interface IContentContainerProps {
-  onCellChange: (object: any, propertyName: string, value: string) => void;
-  onListCellClick: (
+  onCellChange?: (object: any, propertyName: string, value: string) => void;
+  onListCellClick?: (
+    object: any,
+    property: Realm.ObjectSchemaProperty,
+    value: any,
+  ) => void;
+  onRowClick?: (
     object: any,
     property: Realm.ObjectSchemaProperty,
     value: any,
   ) => void;
   schema: Realm.ObjectSchema | null;
-  rowToHighlight: number | null;
+  rowToHighlight?: number | null;
   data: Realm.Results<any> | any;
-  onContextMenu: (e: React.SyntheticEvent<any>, object: any) => void;
+  onContextMenu?: (
+    e: React.SyntheticEvent<any>,
+    object: any,
+    property: Realm.ObjectSchemaProperty,
+  ) => void;
 }
 
 export class ContentContainer extends React.Component<
@@ -82,6 +91,12 @@ export class ContentContainer extends React.Component<
         data={this.filteredData}
       />
     );
+  }
+
+  public componentWillMount() {
+    if (this.props.schema) {
+      this.setDefaultColumnWidths(this.props.schema);
+    }
   }
 
   public componentWillReceiveProps(props: IContentContainerProps) {

--- a/src/ui/realm-browser/RealmBrowser.scss
+++ b/src/ui/realm-browser/RealmBrowser.scss
@@ -256,6 +256,10 @@ $realm-browser-header-icon-space: 24px;
       &--disabled {
         color: $color-elephant;
       }
+
+      &--unselectable {
+        user-select: none;
+      }
     }
 
     &__Link {

--- a/src/ui/realm-browser/RealmBrowser.scss
+++ b/src/ui/realm-browser/RealmBrowser.scss
@@ -121,12 +121,12 @@ $realm-browser-header-icon-space: 24px;
     flex-direction: column;
   }
 
-  &__SelectObject{
-    min-height:300px;
-    flex: 1 1 0;
+  &__SelectObject {
     display: flex;
     flex-direction: column;
-    padding:0;
+    flex: 1 1 0;
+    min-height: 300px;
+    padding: 0;
   }
 
   &__Tabs {

--- a/src/ui/realm-browser/RealmBrowser.scss
+++ b/src/ui/realm-browser/RealmBrowser.scss
@@ -121,6 +121,14 @@ $realm-browser-header-icon-space: 24px;
     flex-direction: column;
   }
 
+  &__SelectObject{
+    min-height:300px;
+    flex: 1 1 0;
+    display: flex;
+    flex-direction: column;
+    padding:0;
+  }
+
   &__Tabs {
     min-height: 42px;
   }

--- a/src/ui/realm-browser/RealmBrowser.tsx
+++ b/src/ui/realm-browser/RealmBrowser.tsx
@@ -42,10 +42,10 @@ export const RealmBrowser = ({
     columnIndex: number,
   ) => void;
   schemas: Realm.ObjectSchema[];
-  rowToHighlight: number | null;
+  rowToHighlight?: number;
   columnToHighlight?: number;
-  selectedSchemaName?: string | null;
-  list: IList | null;
+  selectedSchemaName?: string;
+  list?: IList;
   onContextMenu: (
     e: React.SyntheticEvent<any>,
     object: any,
@@ -53,10 +53,10 @@ export const RealmBrowser = ({
   ) => void;
   contextMenu: any;
   onContextMenuClose: () => void;
-  confirmModal: {
+  confirmModal?: {
     yes: () => void;
     no: () => void;
-  } | null;
+  };
   selectObject?: any;
   closeSelectObject: () => void;
   updateObjectReference: (object: any) => void;

--- a/src/ui/realm-browser/RealmBrowser.tsx
+++ b/src/ui/realm-browser/RealmBrowser.tsx
@@ -14,7 +14,7 @@ export const RealmBrowser = ({
   getSelectedSchema,
   onCellChange,
   onSchemaSelected,
-  onListCellClick,
+  onCellClick,
   schemas,
   rowToHighlight,
   getSelectedData,
@@ -33,10 +33,11 @@ export const RealmBrowser = ({
   getSelectedSchema: () => Realm.ObjectSchema | null;
   onCellChange: (object: any, propertyName: string, value: string) => void;
   onSchemaSelected: (name: string, objectToScroll: any) => void;
-  onListCellClick: (
+  onCellClick: (
     object: any,
     property: Realm.ObjectSchemaProperty,
     value: any,
+    index: number,
   ) => void;
   schemas: Realm.ObjectSchema[];
   rowToHighlight: number | null;
@@ -71,7 +72,7 @@ export const RealmBrowser = ({
         <ContentContainer
           schema={getSelectedSchema()}
           onCellChange={onCellChange}
-          onListCellClick={onListCellClick}
+          onCellClick={onCellClick}
           rowToHighlight={rowToHighlight}
           data={values}
           onContextMenu={onContextMenu}

--- a/src/ui/realm-browser/RealmBrowser.tsx
+++ b/src/ui/realm-browser/RealmBrowser.tsx
@@ -17,6 +17,7 @@ export const RealmBrowser = ({
   onCellClick,
   schemas,
   rowToHighlight,
+  columnToHighlight,
   getSelectedData,
   selectedSchemaName,
   list,
@@ -37,10 +38,12 @@ export const RealmBrowser = ({
     object: any,
     property: Realm.ObjectSchemaProperty,
     value: any,
-    index: number,
+    rowIndex: number,
+    columnIndex: number,
   ) => void;
   schemas: Realm.ObjectSchema[];
   rowToHighlight: number | null;
+  columnToHighlight?: number;
   selectedSchemaName?: string | null;
   list: IList | null;
   onContextMenu: (
@@ -73,6 +76,7 @@ export const RealmBrowser = ({
           schema={getSelectedSchema()}
           onCellChange={onCellChange}
           onCellClick={onCellClick}
+          columnToHighlight={columnToHighlight}
           rowToHighlight={rowToHighlight}
           data={values}
           onContextMenu={onContextMenu}

--- a/src/ui/realm-browser/RealmBrowser.tsx
+++ b/src/ui/realm-browser/RealmBrowser.tsx
@@ -6,6 +6,7 @@ import { ContextMenu } from '../reusable/context-menu';
 import { ContentContainer } from './ContentContainer';
 import './RealmBrowser.scss';
 import { IList } from './RealmBrowserContainer';
+import { SelectObject } from './SelectObject';
 import { Sidebar } from './Sidebar';
 
 export const RealmBrowser = ({
@@ -23,6 +24,9 @@ export const RealmBrowser = ({
   contextMenu,
   onContextMenuClose,
   confirmModal,
+  selectObject,
+  closeSelectObject,
+  updateObjectReference,
 }: {
   getSchemaLength: (name: string) => number;
   getSelectedData: () => any;
@@ -38,13 +42,20 @@ export const RealmBrowser = ({
   rowToHighlight: number | null;
   selectedSchemaName?: string | null;
   list: IList | null;
-  onContextMenu: (e: React.SyntheticEvent<any>, object: any) => void;
+  onContextMenu: (
+    e: React.SyntheticEvent<any>,
+    object: any,
+    property: Realm.ObjectSchemaProperty,
+  ) => void;
   contextMenu: any;
   onContextMenuClose: () => void;
   confirmModal: {
     yes: () => void;
     no: () => void;
   } | null;
+  selectObject?: any;
+  closeSelectObject: () => void;
+  updateObjectReference: (object: any) => void;
 }) => {
   const values = getSelectedData();
   return (
@@ -76,6 +87,17 @@ export const RealmBrowser = ({
           status={true}
           yes={confirmModal.yes}
           no={confirmModal.no}
+        />
+      )}
+      {selectObject && (
+        <SelectObject
+          status={true}
+          schema={selectObject.schema}
+          data={selectObject.data}
+          optional={selectObject.optional}
+          schemaName={selectObject.schemaName}
+          updateReference={updateObjectReference}
+          close={closeSelectObject}
         />
       )}
     </div>

--- a/src/ui/realm-browser/RealmBrowserContainer.tsx
+++ b/src/ui/realm-browser/RealmBrowserContainer.tsx
@@ -53,6 +53,7 @@ export class RealmBrowserContainer extends React.Component<
   IState
 > {
   private realm: Realm;
+  private clickTimeout?: any;
 
   constructor() {
     super();
@@ -138,7 +139,27 @@ export class RealmBrowserContainer extends React.Component<
     }
   };
 
-  public onListCellClick = (
+  public onCellClick = (
+    object: any,
+    property: Realm.ObjectSchemaProperty,
+    value: any,
+    index: number,
+  ) => {
+    this.setState({ rowToHighlight: index });
+
+    if (this.clickTimeout) {
+      clearTimeout(this.clickTimeout);
+      this.onCellDoubleClick(object, property, value);
+      this.clickTimeout = null;
+    } else {
+      this.clickTimeout = setTimeout(() => {
+        this.onCellSingleClick(object, property, value);
+        this.clickTimeout = null;
+      }, 200);
+    }
+  };
+
+  public onCellSingleClick = (
     object: any,
     property: Realm.ObjectSchemaProperty,
     value: any,
@@ -151,7 +172,7 @@ export class RealmBrowserContainer extends React.Component<
         property,
       };
       this.setState({ list, selectedSchemaName: 'list', rowToHighlight: null });
-    } else {
+    } else if (property.type === 'object') {
       if (value) {
         const index = this.realm
           .objects(property.objectType || '')
@@ -162,6 +183,16 @@ export class RealmBrowserContainer extends React.Component<
           rowToHighlight: index,
         });
       }
+    }
+  };
+
+  public onCellDoubleClick = (
+    object: any,
+    property: Realm.ObjectSchemaProperty,
+    value: any,
+  ) => {
+    if (property.type === 'object') {
+      this.openSelectObject(object, property);
     }
   };
 

--- a/src/ui/realm-browser/RealmBrowserContainer.tsx
+++ b/src/ui/realm-browser/RealmBrowserContainer.tsx
@@ -25,14 +25,14 @@ export interface IList {
 
 export interface IState {
   schemas: Realm.ObjectSchema[];
-  list: IList | null;
-  selectedSchemaName?: string | null;
-  rowToHighlight: number | null;
+  list?: IList;
+  selectedSchemaName?: string;
+  rowToHighlight?: number;
   columnToHighlight?: number;
-  confirmModal: {
+  confirmModal?: {
     yes: () => void;
     no: () => void;
-  } | null;
+  };
   contextMenu: {
     x: number;
     y: number;
@@ -60,12 +60,12 @@ export class RealmBrowserContainer extends React.Component<
     super();
     this.state = {
       schemas: [],
-      list: null,
-      selectedSchemaName: null,
-      rowToHighlight: null,
+      list: undefined,
+      selectedSchemaName: undefined,
+      rowToHighlight: undefined,
       columnToHighlight: undefined,
       contextMenu: null,
-      confirmModal: null,
+      confirmModal: undefined,
       selectObject: null,
     };
   }
@@ -118,8 +118,12 @@ export class RealmBrowserContainer extends React.Component<
     if (selectedSchemaName !== name) {
       const rowToHighlight = objectToScroll
         ? this.realm.objects(name).indexOf(objectToScroll)
-        : null;
-      this.setState({ selectedSchemaName: name, list: null, rowToHighlight });
+        : undefined;
+      this.setState({
+        selectedSchemaName: name,
+        list: undefined,
+        rowToHighlight,
+      });
     }
   };
 
@@ -177,7 +181,7 @@ export class RealmBrowserContainer extends React.Component<
       this.setState({
         list,
         selectedSchemaName: 'list',
-        rowToHighlight: null,
+        rowToHighlight: undefined,
         columnToHighlight: undefined,
       });
     } else if (property.type === 'object') {
@@ -187,7 +191,7 @@ export class RealmBrowserContainer extends React.Component<
           .indexOf(value);
         this.setState({
           selectedSchemaName: property.objectType,
-          list: null,
+          list: undefined,
           rowToHighlight: index,
           columnToHighlight: 0,
         });
@@ -218,12 +222,7 @@ export class RealmBrowserContainer extends React.Component<
       ? list.data.indexOf(object)
       : this.realm.objects(object.objectSchema().name).indexOf(object);
 
-    const actions = [
-      {
-        label: 'Delete',
-        onClick: () => this.openConfirmModal(object),
-      },
-    ];
+    const actions = [];
 
     if (property.type === 'object') {
       actions.push({
@@ -231,6 +230,11 @@ export class RealmBrowserContainer extends React.Component<
         onClick: () => this.openSelectObject(object, property),
       });
     }
+
+    actions.push({
+      label: 'Delete',
+      onClick: () => this.openConfirmModal(object),
+    });
 
     this.setState({
       rowToHighlight: index,
@@ -281,14 +285,14 @@ export class RealmBrowserContainer extends React.Component<
     this.setState({
       confirmModal: {
         yes: () => this.deleteObject(object),
-        no: () => this.setState({ confirmModal: null }),
+        no: () => this.setState({ confirmModal: undefined }),
       },
     });
   };
 
   public deleteObject = (object: Realm.Object) => {
     this.realm.write(() => this.realm.delete(object));
-    this.setState({ rowToHighlight: null, confirmModal: null });
+    this.setState({ rowToHighlight: undefined, confirmModal: undefined });
   };
 
   public onContextMenuClose = (): void => {

--- a/src/ui/realm-browser/RealmBrowserContainer.tsx
+++ b/src/ui/realm-browser/RealmBrowserContainer.tsx
@@ -28,6 +28,7 @@ export interface IState {
   list: IList | null;
   selectedSchemaName?: string | null;
   rowToHighlight: number | null;
+  columnToHighlight?: number;
   confirmModal: {
     yes: () => void;
     no: () => void;
@@ -62,6 +63,7 @@ export class RealmBrowserContainer extends React.Component<
       list: null,
       selectedSchemaName: null,
       rowToHighlight: null,
+      columnToHighlight: undefined,
       contextMenu: null,
       confirmModal: null,
       selectObject: null,
@@ -143,9 +145,10 @@ export class RealmBrowserContainer extends React.Component<
     object: any,
     property: Realm.ObjectSchemaProperty,
     value: any,
-    index: number,
+    rowIndex: number,
+    columnIndex: number,
   ) => {
-    this.setState({ rowToHighlight: index });
+    this.setState({ rowToHighlight: rowIndex, columnToHighlight: columnIndex });
 
     if (this.clickTimeout) {
       clearTimeout(this.clickTimeout);
@@ -171,7 +174,12 @@ export class RealmBrowserContainer extends React.Component<
         parent: object,
         property,
       };
-      this.setState({ list, selectedSchemaName: 'list', rowToHighlight: null });
+      this.setState({
+        list,
+        selectedSchemaName: 'list',
+        rowToHighlight: null,
+        columnToHighlight: undefined,
+      });
     } else if (property.type === 'object') {
       if (value) {
         const index = this.realm
@@ -181,6 +189,7 @@ export class RealmBrowserContainer extends React.Component<
           selectedSchemaName: property.objectType,
           list: null,
           rowToHighlight: index,
+          columnToHighlight: 0,
         });
       }
     }

--- a/src/ui/realm-browser/SelectObject.tsx
+++ b/src/ui/realm-browser/SelectObject.tsx
@@ -12,37 +12,56 @@ export interface IProps {
   optional: boolean;
 }
 
-export const SelectObject = ({
-  status,
-  schema,
-  data,
-  close,
-  updateReference,
-  schemaName,
-  optional,
-}: IProps) => (
-  <Modal size="lg" isOpen={status} toggle={close} className="ConfirmModal">
-    <ModalHeader toggle={close}>Select a new {schemaName}</ModalHeader>
-    <ModalBody className="RealmBrowser__SelectObject">
-      {data &&
-        schema && (
-          <ContentContainer
-            schema={schema}
-            data={data}
-            onRowClick={updateReference}
-            onListCellClick={updateReference}
-          />
-        )}
-    </ModalBody>
-    <ModalFooter>
-      {optional && (
-        <Button color="primary" onClick={() => updateReference(null)}>
-          Set to null
-        </Button>
-      )}
-      <Button color="secondary" onClick={close}>
-        Close
-      </Button>
-    </ModalFooter>
-  </Modal>
-);
+export interface IState {
+  rowToHighlight?: number;
+  objectToAdd?: Realm.ObjectSchema;
+}
+
+export class SelectObject extends React.Component<IProps, IState> {
+  public state = {
+    rowToHighlight: undefined,
+    objectToAdd: undefined,
+  };
+
+  public onCellClick = (
+    object: any,
+    property: Realm.ObjectSchemaProperty,
+    value: any,
+    index: number,
+  ) => {
+    this.setState({ rowToHighlight: index, objectToAdd: object });
+  };
+
+  public setNewValue = () => this.props.updateReference(this.state.objectToAdd);
+
+  public render() {
+    const { status, schema, data, close, schemaName, optional } = this.props;
+    const { rowToHighlight, objectToAdd } = this.state;
+    return (
+      <Modal size="lg" isOpen={status} toggle={close} className="ConfirmModal">
+        <ModalHeader toggle={close}>Select a new {schemaName}</ModalHeader>
+        <ModalBody className="RealmBrowser__SelectObject">
+          {data &&
+            schema && (
+              <ContentContainer
+                schema={schema}
+                data={data}
+                onCellClick={this.onCellClick}
+                rowToHighlight={rowToHighlight}
+              />
+            )}
+        </ModalBody>
+        <ModalFooter>
+          {optional && (
+            <Button color="primary" onClick={this.setNewValue}>
+              Set {!objectToAdd && 'to null'}
+            </Button>
+          )}
+          <Button color="secondary" onClick={close}>
+            Close
+          </Button>
+        </ModalFooter>
+      </Modal>
+    );
+  }
+}

--- a/src/ui/realm-browser/SelectObject.tsx
+++ b/src/ui/realm-browser/SelectObject.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
+import { ContentContainer } from './ContentContainer';
+
+export interface IProps {
+  status: boolean;
+  schema: Realm.ObjectSchema;
+  data: Realm.Results<any> | any;
+  close: () => void;
+  schemaName: string;
+  updateReference: (object: any) => void;
+  optional: boolean;
+}
+
+export const SelectObject = ({
+  status,
+  schema,
+  data,
+  close,
+  updateReference,
+  schemaName,
+  optional,
+}: IProps) => (
+  <Modal size="lg" isOpen={status} toggle={close} className="ConfirmModal">
+    <ModalHeader toggle={close}>Select a new {schemaName}</ModalHeader>
+    <ModalBody className="RealmBrowser__SelectObject">
+      {data &&
+        schema && (
+          <ContentContainer
+            schema={schema}
+            data={data}
+            onRowClick={updateReference}
+            onListCellClick={updateReference}
+          />
+        )}
+    </ModalBody>
+    <ModalFooter>
+      {optional && (
+        <Button color="primary" onClick={() => updateReference(null)}>
+          Set to null
+        </Button>
+      )}
+      <Button color="secondary" onClick={close}>
+        Close
+      </Button>
+    </ModalFooter>
+  </Modal>
+);

--- a/src/ui/realm-browser/SelectObject.tsx
+++ b/src/ui/realm-browser/SelectObject.tsx
@@ -14,12 +14,14 @@ export interface IProps {
 
 export interface IState {
   rowToHighlight?: number;
+  columnToHighlight?: number;
   objectToAdd?: Realm.ObjectSchema;
 }
 
 export class SelectObject extends React.Component<IProps, IState> {
   public state = {
     rowToHighlight: undefined,
+    columnToHighlight: undefined,
     objectToAdd: undefined,
   };
 
@@ -27,16 +29,21 @@ export class SelectObject extends React.Component<IProps, IState> {
     object: any,
     property: Realm.ObjectSchemaProperty,
     value: any,
-    index: number,
+    rowIndex: number,
+    columnIndex: number,
   ) => {
-    this.setState({ rowToHighlight: index, objectToAdd: object });
+    this.setState({
+      rowToHighlight: rowIndex,
+      columnToHighlight: columnIndex,
+      objectToAdd: object,
+    });
   };
 
   public setNewValue = () => this.props.updateReference(this.state.objectToAdd);
 
   public render() {
     const { status, schema, data, close, schemaName, optional } = this.props;
-    const { rowToHighlight, objectToAdd } = this.state;
+    const { rowToHighlight, objectToAdd, columnToHighlight } = this.state;
     return (
       <Modal size="lg" isOpen={status} toggle={close} className="ConfirmModal">
         <ModalHeader toggle={close}>Select a new {schemaName}</ModalHeader>
@@ -48,6 +55,7 @@ export class SelectObject extends React.Component<IProps, IState> {
                 data={data}
                 onCellClick={this.onCellClick}
                 rowToHighlight={rowToHighlight}
+                columnToHighlight={columnToHighlight}
               />
             )}
         </ModalBody>

--- a/src/ui/realm-browser/Sidebar.tsx
+++ b/src/ui/realm-browser/Sidebar.tsx
@@ -16,9 +16,9 @@ export const Sidebar = ({
 }: {
   onSchemaSelected: (name: string, objectToScroll?: any) => void;
   schemas: Realm.ObjectSchema[];
-  selectedSchemaName?: string | null;
+  selectedSchemaName?: string;
   getSchemaLength: (name: string) => number;
-  list: IList | null;
+  list?: IList;
 }) => (
   <div className="RealmBrowser__Sidebar">
     <div className="RealmBrowser__Sidebar__Header">Classes</div>

--- a/src/ui/realm-browser/types/StringCell.tsx
+++ b/src/ui/realm-browser/types/StringCell.tsx
@@ -10,14 +10,18 @@ export const StringCell = ({
   value,
   temporalValue,
   onContextMenu,
+  onClick,
+  property,
 }: {
   isEditing: boolean;
   onChange: (newValue: string) => void;
   onBlur: (input: HTMLInputElement) => void;
+  property: Realm.ObjectSchemaProperty;
   onFocus: () => void;
   value: string;
   temporalValue: string;
   onContextMenu: (e: React.SyntheticEvent<any>) => void;
+  onClick: (property: Realm.ObjectSchemaProperty, value: any) => void;
 }) => {
   let textInput: HTMLInputElement;
   return isEditing ? (
@@ -32,6 +36,7 @@ export const StringCell = ({
       onBlur={e => onBlur(textInput)}
       onKeyPress={e => e.key === 'Enter' && onBlur(textInput)}
       onContextMenu={onContextMenu}
+      autoFocus={true}
     />
   ) : (
     <div
@@ -39,9 +44,11 @@ export const StringCell = ({
         'form-control',
         'form-control-sm',
         'RealmBrowser__Content__Input',
+        'RealmBrowser__Content__Input--unselectable',
         { 'RealmBrowser__Content__Input--null': value === null },
       )}
-      onClick={onFocus}
+      onClick={() => onClick(property, value)}
+      onDoubleClick={onFocus}
       onContextMenu={onContextMenu}
     >
       {value === null ? 'null' : value.toString()}

--- a/src/ui/realm-browser/types/StringCellContainer.tsx
+++ b/src/ui/realm-browser/types/StringCellContainer.tsx
@@ -9,6 +9,7 @@ export interface IStringCellContainerProps {
   property: Realm.ObjectSchemaProperty;
   value: string;
   onContextMenu: (e: React.SyntheticEvent<any>) => void;
+  onClick: (property: Realm.ObjectSchemaProperty, value: any) => void;
 }
 
 export class StringCellContainer extends React.Component<
@@ -38,12 +39,14 @@ export class StringCellContainer extends React.Component<
   }
 
   public render() {
-    const { value, onContextMenu } = this.props;
+    const { value, onContextMenu, onClick, property } = this.props;
 
     return (
       <StringCell
         onContextMenu={onContextMenu}
         value={value}
+        onClick={onClick}
+        property={property}
         {...this.state}
         {...this}
       />


### PR DESCRIPTION
Closes #168 and closes #37.

Summary

1. You can edit an object reference by double clicking on it or right click + “Update reference”.
2. When the modal is open, a list with the current possible references appears and the “Ok” button displays “Set to null”.
3. Once you select a new object, the button will change from ‘Set to null’ to ‘Set’. 

Additional changes which are not related to this PR:

1. Table: Enable row selection on click and editing on double click.
2. Row highlighting: Add missing columnIndex.
3. Edit cell: Add missing autofocus.