### PR TITLE
Edit list of object references #2

### DIFF
--- a/src/ui/realm-browser/ContentContainer.tsx
+++ b/src/ui/realm-browser/ContentContainer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Draggable, { DraggableData } from 'react-draggable';
 import { Grid } from 'react-virtualized';
 
 import { ILoadingProgress } from '../reusable/loading-overlay';
@@ -25,6 +26,8 @@ export interface IContentContainerProps {
     object: any,
     property: Realm.ObjectSchemaProperty,
   ) => void;
+  onCellChangeOrder?: (currentIndex: number, newIndex: number) => void;
+  setRowToHighlight?: (row: number, column?: number) => void;
 }
 
 export class ContentContainer extends React.Component<
@@ -33,6 +36,10 @@ export class ContentContainer extends React.Component<
     columnWidths: number[];
     query: string | null;
     sort: string | null;
+    draggingCell?: {
+      y: number;
+      index: number;
+    };
   }
 > {
   // A reference to the grid inside the content container is needed to resize collumns
@@ -45,6 +52,7 @@ export class ContentContainer extends React.Component<
       columnWidths: [],
       query: null,
       sort: null,
+      draggingCell: undefined,
     };
   }
 
@@ -88,7 +96,7 @@ export class ContentContainer extends React.Component<
         {...this.state}
         {...this.props}
         {...this}
-        data={this.filteredData}
+        draggable={!!this.props.onCellChangeOrder}
       />
     );
   }
@@ -119,6 +127,39 @@ export class ContentContainer extends React.Component<
       });
     }
   }
+
+  public onDragStart = (row: number, column: number) => {
+    if (this.props.setRowToHighlight) {
+      this.props.setRowToHighlight(row, column);
+    }
+  };
+
+  public onDrag = (e: any, ui: DraggableData, index: number) => {
+    this.setState({
+      draggingCell: {
+        index,
+        y: ui.lastY,
+      },
+    });
+  };
+
+  public onDragEnd = (e: any, ui: any) => {
+    const { onCellChangeOrder } = this.props;
+    const { draggingCell } = this.state;
+
+    if (draggingCell && onCellChangeOrder) {
+      const rowHeight = 26;
+      const currentIndex = draggingCell.index;
+      const newIndex = draggingCell.index + ui.lastY / rowHeight;
+
+      if (onCellChangeOrder) {
+        onCellChangeOrder(currentIndex, newIndex);
+      }
+
+      // Reset the dragging cell after a few milliseconds
+      setTimeout(() => this.setState({ draggingCell: undefined }), 100);
+    }
+  };
 
   public onColumnWidthChanged = (index: number, width: number) => {
     const columnWidths = Array.from(this.state.columnWidths);

--- a/src/ui/realm-browser/RealmBrowser.scss
+++ b/src/ui/realm-browser/RealmBrowser.scss
@@ -7,6 +7,7 @@ $realm-browser-header-icon-space: 24px;
 .RealmBrowser {
   display: flex;
   height: 100%;
+  overflow: hidden;
 
   &__Sidebar {
     background: $window-background;

--- a/src/ui/realm-browser/RealmBrowser.tsx
+++ b/src/ui/realm-browser/RealmBrowser.tsx
@@ -30,6 +30,8 @@ export const RealmBrowser = ({
   selectedSchemaName,
   selectObject,
   updateObjectReference,
+  onCellChangeOrder,
+  setRowToHighlight,
 }: {
   closeSelectObject: () => void;
   columnToHighlight?: number;
@@ -63,6 +65,8 @@ export const RealmBrowser = ({
   selectedSchemaName?: string;
   selectObject?: any;
   updateObjectReference: (object: any) => void;
+  onCellChangeOrder: (currentIndex: number, newIndex: number) => void;
+  setRowToHighlight: (row: number, column?: number) => void;
 }) => {
   const values = getSelectedData();
   return (
@@ -80,11 +84,15 @@ export const RealmBrowser = ({
           columnToHighlight={columnToHighlight}
           data={values}
           onCellChange={onCellChange}
+          onCellChangeOrder={
+            selectedSchemaName === 'list' ? onCellChangeOrder : undefined
+          }
           onCellClick={onCellClick}
           onContextMenu={onContextMenu}
           progress={progress}
           rowToHighlight={rowToHighlight}
           schema={getSelectedSchema()}
+          setRowToHighlight={setRowToHighlight}
         />
       </div>
       {contextMenu && (

--- a/src/ui/realm-browser/SelectObject.tsx
+++ b/src/ui/realm-browser/SelectObject.tsx
@@ -41,6 +41,8 @@ export class SelectObject extends React.Component<IProps, IState> {
 
   public setNewValue = () => this.props.updateReference(this.state.objectToAdd);
 
+  public setToNull = () => this.props.updateReference(null);
+
   public render() {
     const { status, schema, data, close, schemaName, optional } = this.props;
     const { rowToHighlight, objectToAdd, columnToHighlight } = this.state;
@@ -60,9 +62,14 @@ export class SelectObject extends React.Component<IProps, IState> {
             )}
         </ModalBody>
         <ModalFooter>
-          {optional && (
+          {objectToAdd && (
             <Button color="primary" onClick={this.setNewValue}>
-              Set {!objectToAdd && 'to null'}
+              Set
+            </Button>
+          )}
+          {optional && (
+            <Button color="warning" onClick={this.setToNull}>
+              Set to null
             </Button>
           )}
           <Button color="secondary" onClick={close}>


### PR DESCRIPTION
I squashed and rebased the branch from https://github.com/realm/realm-studio/pull/203 onto the new master:

- feat(realm-browser): add SelectObject
- feat(realm-browser-content): add onRowClick handler
- feat(realm-browser): allow object references to be edited
- Adding spaces and sorting properties
- feat(realm-browser): enable select rows on single click and edit on double click, improve 'SelectObject' and 'StringCell'
- feat(realm-browser): add missing 'columnToHighlight' prop
- feat(realm-browser): improve typings and context-menu order
- feat(realm-browser): split 'Set' into two buttons
- feat(realm-browser): add delete/add list reference (wip)
- feat(realm-browser): add onCellChangeOrder (WIP)
- feat(realm-browser): improve draggable cells
- feat (realm-browser): Fix problem updating reference object to null
- feat(realm-browser): add 'setRowToHighlight' and 'onDragStart'
- feat(realm-browser): do not allow to edit object references when a list is active
- feat (): Using spread operator for propagating props
- refactor (RealmBrowserContainer): Rename deletedObjects to movedObjects
- refactor (Content): Simplify draggable cell