### PR TITLE
The Logs Screen now submits a request with a Refresh Token

### DIFF
--- a/src/ui/server-administration/logs/LogContainer.tsx
+++ b/src/ui/server-administration/logs/LogContainer.tsx
@@ -79,7 +79,7 @@ export class LogContainer extends React.Component<
 
     const url = this.generateLogUrl();
     const userRefreshToken = this.props.user.token;
-    this.socket = new WebSocket(url, [`refresh_token=${userRefreshToken}}`]);
+    this.socket = new WebSocket(url);
     this.socket.addEventListener('message', this.onLogMessage);
   }
 
@@ -91,8 +91,15 @@ export class LogContainer extends React.Component<
   }
 
   private generateLogUrl() {
-    const serverUrl = this.props.user.server.replace('http', 'ws');
-    return `${serverUrl}/log/${this.state.level}`;
+    const url = new URL(this.props.user.server);
+    // Add in the users identity and token
+    url.username = this.props.user.identity;
+    url.password = this.props.user.token;
+    // Use ws instead of http
+    url.protocol = url.protocol.replace('http', 'ws');
+    // Replace the path
+    url.pathname = `/log/${this.state.level}`;
+    return url.toString();
   }
 
   private onLogMessage = (e: MessageEvent) => {

--- a/src/ui/server-administration/logs/LogContainer.tsx
+++ b/src/ui/server-administration/logs/LogContainer.tsx
@@ -78,7 +78,8 @@ export class LogContainer extends React.Component<
     }
 
     const url = this.generateLogUrl();
-    this.socket = new WebSocket(url);
+    const userRefreshToken = this.props.user.token;
+    this.socket = new WebSocket(url, [`refresh_token=${userRefreshToken}}`]);
     this.socket.addEventListener('message', this.onLogMessage);
   }
 


### PR DESCRIPTION
Regarding: https://github.com/realm/ros/issues/546

```typescript
this.socket = new WebSocket(url, [`refresh_token=${userRefreshToken}}`]);
```
Unfortunately, the WebSocket API does not allow you to manipulate headers directly. The only thing you _can_ do is either to put the refresh token as a query string or as a custom protocol value.