### PR TITLE
Authenticated + reversed bottom sticky logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,1 +1,17135 @@
-{"name":"realm-studio","version":"1.2.0","lockfileVersion":1,"requires":true,"dependencies":{"@types/bcrypt":{"version":"1.0.0","resolved":"https://registry.npmjs.org/@types/bcrypt/-/bcrypt-1.0.0.tgz","integrity":"sha1-LFI9oZHbfUHAbRfeI1M1yYXv/ps=","dev":true},"@types/body-parser":{"version":"1.16.6","resolved":"https://registry.npmjs.org/@types/body-parser/-/body-parser-1.16.6.tgz","integrity":"sha512-B7sY963pBsP46QG/yTX8ei2R8zIUDQUOhPZjTBWBGQXcBMLGFKHc0R8DWkAmouGmval5sDSuQA3AB2C9VmHw6A==","dev":true,"requires":{"@types/express":"4.0.37","@types/node":"8.0.47"}},"@types/classnames":{"version":"2.2.3","resolved":"https://registry.npmjs.org/@types/classnames/-/classnames-2.2.3.tgz","integrity":"sha512-x15/Io+JdzrkM9gnX6SWUs/EmqQzd65TD9tcZIAQ1VIdb93XErNuYmB7Yho8JUCE189ipUSESsWvGvYXRRIvYA==","dev":true},"@types/colors":{"version":"1.1.3","resolved":"https://registry.npmjs.org/@types/colors/-/colors-1.1.3.tgz","integrity":"sha1-VBOwp6GxbdGL4OP9V9L+7Mgcx3Y=","dev":true},"@types/commander":{"version":"2.11.0","resolved":"https://registry.npmjs.org/@types/commander/-/commander-2.11.0.tgz","integrity":"sha512-G4+ewSX5/TPqpUjltkuyJ4QhX8oTy94WEyJMvC+R8cg/qKGjq+/n+b/TRVe/+/278jV9Iot5dS186r7NCcUrtg==","dev":true,"requires":{"@types/node":"8.0.47"}},"@types/del":{"version":"3.0.0","resolved":"https://registry.npmjs.org/@types/del/-/del-3.0.0.tgz","integrity":"sha512-18mSs54BvzV8+TTQxt0ancig6tsuPZySnhp3cQkWFFDmDMavU4pmWwR+bHHqRBWODYqpzIzVkqKLuk/fP6yypQ==","dev":true,"requires":{"@types/glob":"5.0.33"}},"@types/express":{"version":"4.0.37","resolved":"https://registry.npmjs.org/@types/express/-/express-4.0.37.tgz","integrity":"sha512-tIULTLzQpFFs5/PKnFIAFOsXQxss76glppbVKR3/jddPK26SBsD5HF5grn5G2jOGtpRWSBvYmDYoduVv+3wOXg==","dev":true,"requires":{"@types/express-serve-static-core":"4.0.54","@types/serve-static":"1.7.32"}},"@types/express-serve-static-core":{"version":"4.0.54","resolved":"https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.54.tgz","integrity":"sha512-SAwkKnz0z3VcUyT3eiZRM2pDiZ4i2xhOXHTZHdoXu6UCC1o33lnzJMftXCYTRmLvFOUxryov8c9E0JLlY2ylNw==","dev":true,"requires":{"@types/node":"8.0.47"}},"@types/faker":{"version":"4.1.1","resolved":"https://registry.npmjs.org/@types/faker/-/faker-4.1.1.tgz","integrity":"sha512-nMUlSvB+lg0DZ+J5kov54+ZogzZO+IeNqvbxQBlTvvSo34D/p0ezIb/rus1SEQY8dgzudsP/KLmjB2adz10/GA==","dev":true},"@types/fs-extra":{"version":"4.0.3","resolved":"https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.3.tgz","integrity":"sha512-cUE7dc4RJsRPCk8mbrgMAaglugcJbf1Oxp7DYi/aOj4+ggCxzddDQFZwCKWnqrLv4LJ89apyNJ7Y3pN79tAPVg==","dev":true,"requires":{"@types/node":"8.0.47"}},"@types/glob":{"version":"5.0.33","resolved":"https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz","integrity":"sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==","dev":true,"requires":{"@types/minimatch":"3.0.1","@types/node":"8.0.47"}},"@types/http-proxy":{"version":"1.12.2","resolved":"https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.12.2.tgz","integrity":"sha512-CRr4ha0rE8wHIYweCovPB9zAeVDoZkiTFTyuvksveNPf5mF3ANZiWEuDSCdEedSNvKrVHZrCJKZ1kM1bSn5mbA==","dev":true,"requires":{"@types/node":"8.0.47"}},"@types/jquery":{"version":"3.2.15","resolved":"https://registry.npmjs.org/@types/jquery/-/jquery-3.2.15.tgz","integrity":"sha512-SmiwGv/ISoltkDMngZ8sb9ijj6mYx3084XkHul/U4r03N2C14j6F+Lx+RfZ/f5zGOVOKEUIrRLVCNFKEaVDABQ==","dev":true},"@types/jsdom":{"version":"11.0.2","resolved":"https://registry.npmjs.org/@types/jsdom/-/jsdom-11.0.2.tgz","integrity":"sha512-jteTb2GhpeBc284FcpDbngQ4IQizu0Z/AQT9zyk2beSiqSvC0mxtX+SnQZj7gULgWcjLswUdlW/LfMqx0GhyNg==","dev":true,"requires":{"@types/node":"8.0.47","@types/tough-cookie":"2.3.2","parse5":"3.0.2"}},"@types/jsonwebtoken":{"version":"7.2.3","resolved":"https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.3.tgz","integrity":"sha512-cVhxZfVCyTZd1P+2a+xXSR9to7hZTulNRLLCQMVfAevUqx2Ee+EgsiD/7pX8qvdXWP3nWgSoTjKRLMrIpdPVjQ==","dev":true,"requires":{"@types/node":"8.0.47"}},"@types/lodash":{"version":"4.14.79","resolved":"https://registry.npmjs.org/@types/lodash/-/lodash-4.14.79.tgz","integrity":"sha512-EE1cINVUc0T6Wdy6qdx/P+NHCSzZAUIijlc/h4KXC+fy1Q2s/CruftBHaJSCJ7g5VRBIuO53IUaSWupDivfhJw==","dev":true},"@types/mime":{"version":"2.0.0","resolved":"https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz","integrity":"sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==","dev":true},"@types/minimatch":{"version":"3.0.1","resolved":"https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz","integrity":"sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==","dev":true},"@types/mixpanel":{"version":"2.13.0","resolved":"https://registry.npmjs.org/@types/mixpanel/-/mixpanel-2.13.0.tgz","integrity":"sha512-3Oz29yXvzJlOG7PqJMHEzwoIDWZNfC+wrYOOWyP7N5qNLBhEgY2SBoWWs/bDVS2QTGb1fSYRHsVSlWdIn0xDQQ==","dev":true},"@types/mocha":{"version":"2.2.43","resolved":"https://registry.npmjs.org/@types/mocha/-/mocha-2.2.43.tgz","integrity":"sha512-xNlAmH+lRJdUMXClMTI9Y0pRqIojdxfm7DHsIxoB2iTzu3fnPmSMEN8SsSx0cdwV36d02PWCWaDUoZPDSln+xw==","dev":true},"@types/morgan":{"version":"1.7.34","resolved":"https://registry.npmjs.org/@types/morgan/-/morgan-1.7.34.tgz","integrity":"sha512-CIwxrnVFH4y2WDfo54SNCd5Zy9zofmkoqgTy1xgvolTx65b/bP4IF9rJVd/CmNc43UdtAJnHOJg3W0fLMGW5+g==","dev":true,"requires":{"@types/express":"4.0.37"}},"@types/node":{"version":"8.0.47","resolved":"https://registry.npmjs.org/@types/node/-/node-8.0.47.tgz","integrity":"sha512-kOwL746WVvt/9Phf6/JgX/bsGQvbrK5iUgzyfwZNcKVFcjAUVSpF9HxevLTld2SG9aywYHOILj38arDdY1r/iQ==","dev":true},"@types/promptly":{"version":"1.1.28","resolved":"https://registry.npmjs.org/@types/promptly/-/promptly-1.1.28.tgz","integrity":"sha1-kBTi8SrN6kHiEAmvTjn+exH+yNE=","dev":true,"requires":{"@types/node":"8.0.47"}},"@types/prop-types":{"version":"15.5.2","resolved":"https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.2.tgz","integrity":"sha512-pQRkAVoxiuUrLq8+CDwiQX4pTCep/PmmNgBbjIwnnsd/HoYjGpR81+FFPE030lvNXgR0haaAU6eoRtztWDE4Xw==","dev":true},"@types/proxyquire":{"version":"1.3.28","resolved":"https://registry.npmjs.org/@types/proxyquire/-/proxyquire-1.3.28.tgz","integrity":"sha512-SQaNzWQ2YZSr7FqAyPPiA3FYpux2Lqh3HWMZQk47x3xbMCqgC/w0dY3dw9rGqlweDDkrySQBcaScXWeR+Yb11Q==","dev":true},"@types/react":{"version":"15.6.5","resolved":"https://registry.npmjs.org/@types/react/-/react-15.6.5.tgz","integrity":"sha512-42p/IwYtCU0CMBKZ2MRdBfRbt3f6MO9aqIhxZ6EzHOiG6fMVY+g/pM7uHTsDmoRc0blYMZdki8XPMcOG4ob2Ng==","dev":true},"@types/react-dom":{"version":"15.5.6","resolved":"https://registry.npmjs.org/@types/react-dom/-/react-dom-15.5.6.tgz","integrity":"sha512-dP4vEDEH4rL+uUl6f//c6mjepTVdJ6Ldx3z0dZbw047T5Z+o2PZDW/Qd+I4PkTmIgk7YNAZC/TFnm3IHT5UAhw==","dev":true,"requires":{"@types/react":"15.6.5"}},"@types/react-sortable-hoc":{"version":"0.6.0","resolved":"https://registry.npmjs.org/@types/react-sortable-hoc/-/react-sortable-hoc-0.6.0.tgz","integrity":"sha512-qOWavACyVKEASlqAy0qAvszIOz5GIDW5cdAcMaTl9rge30JHIvynTnOQJFzl+HmxPiEmTuz4gipiNoBjbnP3kQ==","dev":true,"requires":{"@types/react":"15.6.5"}},"@types/react-virtualized":{"version":"9.7.6","resolved":"https://registry.npmjs.org/@types/react-virtualized/-/react-virtualized-9.7.6.tgz","integrity":"sha512-6GCKDWHzFHTRExQ+4zIS1bCxOcFfmwBhoBeAl8ENqstOf1/mnx8tmx9PiqL5qnGEhq3AvsZz2gFzFVX5yqp2ig==","dev":true,"requires":{"@types/prop-types":"15.5.2","@types/react":"15.6.5"}},"@types/reactstrap":{"version":"4.6.4","resolved":"https://registry.npmjs.org/@types/reactstrap/-/reactstrap-4.6.4.tgz","integrity":"sha512-0EV4Mb+j/z5XdlzVAz2rB0KuDwj6sNv3d/JtELtxmLkMyUwZXH2XMal2Ic7f5y0+SBc5qf650WdXT/zFlsCFTw==","dev":true,"requires":{"@types/tether":"1.4.3"}},"@types/serve-static":{"version":"1.7.32","resolved":"https://registry.npmjs.org/@types/serve-static/-/serve-static-1.7.32.tgz","integrity":"sha512-WpI0g7M1FiOmJ/a97Qrjafq2I938tjAZ3hZr9O7sXyA6oUhH3bqUNZIt7r1KZg8TQAKxcvxt6JjQ5XuLfIBFvg==","dev":true,"requires":{"@types/express-serve-static-core":"4.0.54","@types/mime":"2.0.0"}},"@types/source-map":{"version":"0.5.1","resolved":"https://registry.npmjs.org/@types/source-map/-/source-map-0.5.1.tgz","integrity":"sha512-/GVAjL1Y8puvZab63n8tsuBiYwZt1bApMdx58/msQ9ID5T05ov+wm/ZV1DvYC/DKKEygpTJViqQvkh5Rhrl4CA==","dev":true},"@types/source-map-support":{"version":"0.4.0","resolved":"https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.4.0.tgz","integrity":"sha512-9oVAi1Jlr274pbMGPEe0S3IPImV9knVNafa6E4MookD/fjOZAE6EmLkFX5ZjtZ9OXNPi2FCIZzUSMvwAUUKeSg==","dev":true,"requires":{"@types/node":"8.0.47"}},"@types/superagent":{"version":"3.5.6","resolved":"https://registry.npmjs.org/@types/superagent/-/superagent-3.5.6.tgz","integrity":"sha512-yGiVkRbB1qtIkRCpEJIxlHazBoILmu33xbbu4IiwxTJjwDi/EudiPYAD7QwWe035jkE40yQgTVXZsAePFtleww==","dev":true,"requires":{"@types/node":"8.0.47"}},"@types/tapable":{"version":"0.2.4","resolved":"https://registry.npmjs.org/@types/tapable/-/tapable-0.2.4.tgz","integrity":"sha512-pclMAvhPnXJcJu1ZZ8bQthuUcdDWzDuxDdbSf6l1U6s4fP6EBiZpPsOZYqFOrbqDV97sXGFSsb6AUpiLfv4xIA==","dev":true},"@types/tether":{"version":"1.4.3","resolved":"https://registry.npmjs.org/@types/tether/-/tether-1.4.3.tgz","integrity":"sha512-q92yZeRwHuLL6s+HF5PAmrR0K0pFTQ3hT1ppM0ZRyj9XLziKR/qyhQcOitVO0UliClC02uQsAm4zBj08b6Pu/Q==","dev":true},"@types/tmp":{"version":"0.0.33","resolved":"https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz","integrity":"sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=","dev":true},"@types/tough-cookie":{"version":"2.3.2","resolved":"https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.2.tgz","integrity":"sha512-vOVmaruQG5EatOU/jM6yU2uCp3Lz6mK1P5Ztu4iJjfM4SVHU9XYktPUQtKlIXuahqXHdEyUarMrBEwg5Cwu+bA==","dev":true},"@types/uglify-js":{"version":"2.6.29","resolved":"https://registry.npmjs.org/@types/uglify-js/-/uglify-js-2.6.29.tgz","integrity":"sha512-BdFLCZW0GTl31AbqXSak8ss/MqEZ3DN2MH9rkAyGoTuzK7ifGUlX+u0nfbWeTsa7IPcZhtn8BlpYBXSV+vqGhQ==","dev":true,"requires":{"@types/source-map":"0.5.1"}},"@types/urijs":{"version":"1.15.34","resolved":"https://registry.npmjs.org/@types/urijs/-/urijs-1.15.34.tgz","integrity":"sha512-hhYTPl+5vDeyrMM0WXwS5GVYq/OoKPhXfIoZskSP48aiYjjWQTGJOgoaJczXKlawp70xZYpLU/8B31YqQRLG9g==","dev":true,"requires":{"@types/jquery":"3.2.15"}},"@types/uuid":{"version":"3.4.3","resolved":"https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz","integrity":"sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==","dev":true,"requires":{"@types/node":"8.0.47"}},"@types/uws":{"version":"0.13.0","resolved":"https://registry.npmjs.org/@types/uws/-/uws-0.13.0.tgz","integrity":"sha1-ZX7+Z6405BfZA86BOobsCc1oy+4=","dev":true,"requires":{"@types/node":"8.0.47"}},"@types/webdriverio":{"version":"4.8.6","resolved":"https://registry.npmjs.org/@types/webdriverio/-/webdriverio-4.8.6.tgz","integrity":"sha512-y8zENitnHZQzRnEkAm82wrKbRT0WD3/65IREeGhfjVkvOqYji6DNwy9OvbcSPhfklij8x8TUUshr8nn6/RiZ+g==","dev":true,"requires":{"@types/node":"8.0.47"}},"@types/webpack":{"version":"3.0.13","resolved":"https://registry.npmjs.org/@types/webpack/-/webpack-3.0.13.tgz","integrity":"sha512-gWVIAVaGapOPHOrjUQalUqdJWdUIn8w5gpKzz2L14megpB1euvq4HxvGusp9nhtkYGjD/sIg20Zse42b7+7BDw==","dev":true,"requires":{"@types/node":"8.0.47","@types/tapable":"0.2.4","@types/uglify-js":"2.6.29"}},"@types/webpack-env":{"version":"1.13.2","resolved":"https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.2.tgz","integrity":"sha512-pjbzi3A1Y4iLpNdNZNG4loIZKtYOnpCQY82bnsHi9lQXl4f3ul0TDsd1fUd10jbgCXR5bwaP4Ffy1BDLuEZpaQ==","dev":true},"7zip-bin":{"version":"2.2.7","resolved":"https://registry.npmjs.org/7zip-bin/-/7zip-bin-2.2.7.tgz","integrity":"sha512-+rr4OgeTNrLuJAf09o3USdttEYiXvZshWMkhD6wR9v1ieXH0JM1Q2yT41/cJuJcqiPpSXlM/g3aR+Y5MWQdr0Q==","dev":true,"requires":{"7zip-bin-mac":"1.0.1"}},"7zip-bin-mac":{"version":"1.0.1","resolved":"https://registry.npmjs.org/7zip-bin-mac/-/7zip-bin-mac-1.0.1.tgz","integrity":"sha1-Pmh3i78JJq3GgVlCcHRQXUdVXAI=","dev":true,"optional":true},"abab":{"version":"1.0.4","resolved":"https://registry.npmjs.org/abab/-/abab-1.0.4.tgz","integrity":"sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=","dev":true},"abbrev":{"version":"1.1.1","resolved":"https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz","integrity":"sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="},"accepts":{"version":"1.3.4","resolved":"https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz","integrity":"sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=","dev":true,"requires":{"mime-types":"2.1.17","negotiator":"0.6.1"}},"accessibility-developer-tools":{"version":"2.12.0","resolved":"https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz","integrity":"sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=","dev":true},"acorn":{"version":"5.1.2","resolved":"https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz","integrity":"sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==","dev":true},"acorn-dynamic-import":{"version":"2.0.2","resolved":"https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz","integrity":"sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=","dev":true,"requires":{"acorn":"4.0.13"},"dependencies":{"acorn":{"version":"4.0.13","resolved":"https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz","integrity":"sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=","dev":true}}},"acorn-globals":{"version":"4.1.0","resolved":"https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz","integrity":"sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==","dev":true,"requires":{"acorn":"5.1.2"}},"acorn-jsx":{"version":"3.0.1","resolved":"https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz","integrity":"sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=","dev":true,"requires":{"acorn":"3.3.0"},"dependencies":{"acorn":{"version":"3.3.0","resolved":"https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz","integrity":"sha1-ReN/s56No/JbruP/U2niu18iAXo=","dev":true}}},"adjust-sourcemap-loader":{"version":"1.1.0","resolved":"https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-1.1.0.tgz","integrity":"sha1-QS2SQE62HkETY1ASy6U6M9AI4OI=","dev":true,"requires":{"assert":"1.4.1","camelcase":"1.2.1","loader-utils":"1.1.0","lodash.assign":"4.2.0","lodash.defaults":"3.1.2","object-path":"0.9.2","regex-parser":"2.2.8"},"dependencies":{"camelcase":{"version":"1.2.1","resolved":"https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz","integrity":"sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=","dev":true},"lodash.defaults":{"version":"3.1.2","resolved":"https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz","integrity":"sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=","dev":true,"requires":{"lodash.assign":"3.2.0","lodash.restparam":"3.6.1"},"dependencies":{"lodash.assign":{"version":"3.2.0","resolved":"https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz","integrity":"sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=","dev":true,"requires":{"lodash._baseassign":"3.2.0","lodash._createassigner":"3.1.1","lodash.keys":"3.1.2"}}}}}},"agent-base":{"version":"2.1.1","resolved":"https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz","integrity":"sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=","dev":true,"requires":{"extend":"3.0.1","semver":"5.0.3"},"dependencies":{"semver":{"version":"5.0.3","resolved":"https://registry.npmjs.org/semver/-/semver-5.0.3.tgz","integrity":"sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=","dev":true}}},"ajv":{"version":"4.11.8","resolved":"https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz","integrity":"sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=","requires":{"co":"4.6.0","json-stable-stringify":"1.0.1"}},"ajv-keywords":{"version":"2.1.0","resolved":"https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz","integrity":"sha1-opbhf3v658HOT34N5T0pyzIWLfA=","dev":true},"align-text":{"version":"0.1.4","resolved":"https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz","integrity":"sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=","dev":true,"requires":{"kind-of":"3.2.2","longest":"1.0.1","repeat-string":"1.6.1"},"dependencies":{"kind-of":{"version":"3.2.2","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz","integrity":"sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=","dev":true,"requires":{"is-buffer":"1.1.5"}}}},"alphanum-sort":{"version":"1.0.2","resolved":"https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz","integrity":"sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=","dev":true},"amdefine":{"version":"1.0.1","resolved":"https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz","integrity":"sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=","dev":true},"ansi-align":{"version":"2.0.0","resolved":"https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz","integrity":"sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=","dev":true,"requires":{"string-width":"2.1.1"},"dependencies":{"ansi-regex":{"version":"3.0.0","resolved":"https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz","integrity":"sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=","dev":true},"is-fullwidth-code-point":{"version":"2.0.0","resolved":"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz","integrity":"sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=","dev":true},"string-width":{"version":"2.1.1","resolved":"https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz","integrity":"sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==","dev":true,"requires":{"is-fullwidth-code-point":"2.0.0","strip-ansi":"4.0.0"}},"strip-ansi":{"version":"4.0.0","resolved":"https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz","integrity":"sha1-qEeQIusaw2iocTibY1JixQXuNo8=","dev":true,"requires":{"ansi-regex":"3.0.0"}}}},"ansi-escapes":{"version":"1.4.0","resolved":"https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz","integrity":"sha1-06ioOzGapneTZisT52HHkRQiMG4=","dev":true},"ansi-html":{"version":"0.0.7","resolved":"https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz","integrity":"sha1-gTWEAhliqenm/QOflA0S9WynhZ4=","dev":true},"ansi-regex":{"version":"2.1.1","resolved":"https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz","integrity":"sha1-w7M6te42DYbg5ijwRorn7yfWVN8="},"ansi-styles":{"version":"1.1.0","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz","integrity":"sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=","dev":true},"anymatch":{"version":"1.3.2","resolved":"https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz","integrity":"sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==","dev":true,"requires":{"micromatch":"2.3.11","normalize-path":"2.1.1"},"dependencies":{"arr-diff":{"version":"2.0.0","resolved":"https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz","integrity":"sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=","dev":true,"requires":{"arr-flatten":"1.1.0"}},"array-unique":{"version":"0.2.1","resolved":"https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz","integrity":"sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=","dev":true},"braces":{"version":"1.8.5","resolved":"https://registry.npmjs.org/braces/-/braces-1.8.5.tgz","integrity":"sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=","dev":true,"requires":{"expand-range":"1.8.2","preserve":"0.2.0","repeat-element":"1.1.2"}},"expand-brackets":{"version":"0.1.5","resolved":"https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz","integrity":"sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=","dev":true,"requires":{"is-posix-bracket":"0.1.1"}},"extglob":{"version":"0.3.2","resolved":"https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz","integrity":"sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=","dev":true,"requires":{"is-extglob":"1.0.0"}},"is-extglob":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz","integrity":"sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=","dev":true},"is-glob":{"version":"2.0.1","resolved":"https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz","integrity":"sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=","dev":true,"requires":{"is-extglob":"1.0.0"}},"kind-of":{"version":"3.2.2","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz","integrity":"sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=","dev":true,"requires":{"is-buffer":"1.1.5"}},"micromatch":{"version":"2.3.11","resolved":"https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz","integrity":"sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=","dev":true,"requires":{"arr-diff":"2.0.0","array-unique":"0.2.1","braces":"1.8.5","expand-brackets":"0.1.5","extglob":"0.3.2","filename-regex":"2.0.1","is-extglob":"1.0.0","is-glob":"2.0.1","kind-of":"3.2.2","normalize-path":"2.1.1","object.omit":"2.0.1","parse-glob":"3.0.4","regex-cache":"0.4.4"}},"normalize-path":{"version":"2.1.1","resolved":"https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz","integrity":"sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=","dev":true,"requires":{"remove-trailing-separator":"1.1.0"}}}},"app-package-builder":{"version":"1.3.1","resolved":"https://registry.npmjs.org/app-package-builder/-/app-package-builder-1.3.1.tgz","integrity":"sha512-TnKHgkO0zW1x9b1bDAJSPNx9FljH21GaG8gF7uAn134GvR4hVO98h+zQ9lDYKV4uyW+F6eKrWKAUhUupD2sNuQ==","dev":true,"requires":{"bluebird-lst":"1.0.5","builder-util":"3.1.0","builder-util-runtime":"2.4.0","fs-extra-p":"4.4.4","int64-buffer":"0.1.9","js-yaml":"3.10.0","rabin-bindings":"1.7.3"}},"app-root-path":{"version":"2.0.1","resolved":"https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz","integrity":"sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=","dev":true},"aproba":{"version":"1.2.0","resolved":"https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz","integrity":"sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="},"archiver":{"version":"1.3.0","resolved":"https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz","integrity":"sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=","dev":true,"requires":{"archiver-utils":"1.3.0","async":"2.5.0","buffer-crc32":"0.2.13","glob":"7.1.2","lodash":"4.17.4","readable-stream":"2.3.3","tar-stream":"1.5.4","walkdir":"0.0.11","zip-stream":"1.2.0"},"dependencies":{"async":{"version":"2.5.0","resolved":"https://registry.npmjs.org/async/-/async-2.5.0.tgz","integrity":"sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==","dev":true,"requires":{"lodash":"4.17.4"}}}},"archiver-utils":{"version":"1.3.0","resolved":"https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz","integrity":"sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=","dev":true,"requires":{"glob":"7.1.2","graceful-fs":"4.1.11","lazystream":"1.0.0","lodash":"4.17.4","normalize-path":"2.1.1","readable-stream":"2.3.3"},"dependencies":{"normalize-path":{"version":"2.1.1","resolved":"https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz","integrity":"sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=","dev":true,"requires":{"remove-trailing-separator":"1.1.0"}}}},"are-we-there-yet":{"version":"1.1.4","resolved":"https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz","integrity":"sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=","requires":{"delegates":"1.0.0","readable-stream":"2.3.3"}},"argparse":{"version":"1.0.9","resolved":"https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz","integrity":"sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=","requires":{"sprintf-js":"1.0.3"}},"arr-diff":{"version":"4.0.0","resolved":"https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz","integrity":"sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=","dev":true},"arr-flatten":{"version":"1.1.0","resolved":"https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz","integrity":"sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==","dev":true},"arr-union":{"version":"3.1.0","resolved":"https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz","integrity":"sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=","dev":true},"array-back":{"version":"2.0.0","resolved":"https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz","integrity":"sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==","requires":{"typical":"2.6.1"}},"array-equal":{"version":"1.0.0","resolved":"https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz","integrity":"sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=","dev":true},"array-find-index":{"version":"1.0.2","resolved":"https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz","integrity":"sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=","dev":true},"array-flatten":{"version":"1.1.1","resolved":"https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz","integrity":"sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=","dev":true},"array-includes":{"version":"3.0.3","resolved":"https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz","integrity":"sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=","dev":true,"requires":{"define-properties":"1.1.2","es-abstract":"1.9.0"}},"array-union":{"version":"1.0.2","resolved":"https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz","integrity":"sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=","dev":true,"requires":{"array-uniq":"1.0.3"}},"array-uniq":{"version":"1.0.3","resolved":"https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz","integrity":"sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=","dev":true},"array-unique":{"version":"0.3.2","resolved":"https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz","integrity":"sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=","dev":true},"arrify":{"version":"1.0.1","resolved":"https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz","integrity":"sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=","dev":true},"asap":{"version":"2.0.6","resolved":"https://registry.npmjs.org/asap/-/asap-2.0.6.tgz","integrity":"sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="},"asar-integrity":{"version":"0.2.3","resolved":"https://registry.npmjs.org/asar-integrity/-/asar-integrity-0.2.3.tgz","integrity":"sha512-c+oMuxlpKRDv9Kv6WdjbnkySfSYATAmW+cvy8NIdMg9twY9RMvSdvOoPssroWlTpSra1qX9vLew2ROpV4jQm7w==","dev":true,"requires":{"bluebird-lst":"1.0.5","fs-extra-p":"4.4.4"}},"asn1":{"version":"0.2.3","resolved":"https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz","integrity":"sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="},"asn1.js":{"version":"4.9.1","resolved":"https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz","integrity":"sha1-SLokC0WpKA6UdImQull9IWYX/UA=","dev":true,"requires":{"bn.js":"4.11.8","inherits":"2.0.3","minimalistic-assert":"1.0.0"}},"assert":{"version":"1.4.1","resolved":"https://registry.npmjs.org/assert/-/assert-1.4.1.tgz","integrity":"sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=","dev":true,"requires":{"util":"0.10.3"}},"assert-plus":{"version":"0.2.0","resolved":"https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz","integrity":"sha1-104bh+ev/A24qttwIfP+SBAasjQ="},"ast-types":{"version":"0.9.6","resolved":"https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz","integrity":"sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=","dev":true},"async":{"version":"1.0.0","resolved":"https://registry.npmjs.org/async/-/async-1.0.0.tgz","integrity":"sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=","dev":true},"async-each":{"version":"1.0.1","resolved":"https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz","integrity":"sha1-GdOGodntxufByF04iu28xW0zYC0=","dev":true},"async-exit-hook":{"version":"2.0.1","resolved":"https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz","integrity":"sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==","dev":true},"async-foreach":{"version":"0.1.3","resolved":"https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz","integrity":"sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=","dev":true},"asynckit":{"version":"0.4.0","resolved":"https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz","integrity":"sha1-x57Zf380y48robyXkLzDZkdLS3k="},"atob":{"version":"2.0.3","resolved":"https://registry.npmjs.org/atob/-/atob-2.0.3.tgz","integrity":"sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=","dev":true},"autoprefixer":{"version":"6.7.7","resolved":"https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz","integrity":"sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=","dev":true,"requires":{"browserslist":"1.7.7","caniuse-db":"1.0.30000750","normalize-range":"0.1.2","num2fraction":"1.2.2","postcss":"5.2.18","postcss-value-parser":"3.3.0"}},"awesome-typescript-loader":{"version":"3.2.3","resolved":"https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-3.2.3.tgz","integrity":"sha512-zGGD6j6jYYtIOBtfhtnrbNB3dlDThVdgF9CQhkPqBwPUUsyJOHNxj9d2LOmVJY1PlBoNPABoDeyRfphIDeYGxA==","dev":true,"requires":{"colors":"1.1.2","enhanced-resolve":"3.3.0","loader-utils":"1.1.0","lodash":"4.17.4","micromatch":"3.1.3","mkdirp":"0.5.1","object-assign":"4.1.1","source-map-support":"0.4.18"},"dependencies":{"source-map":{"version":"0.5.7","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz","integrity":"sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=","dev":true},"source-map-support":{"version":"0.4.18","resolved":"https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz","integrity":"sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==","dev":true,"requires":{"source-map":"0.5.7"}}}},"aws-sdk":{"version":"2.140.0","resolved":"https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.140.0.tgz","integrity":"sha1-wV/Fw9t6GAXFn4V2frEGeuNPmuQ=","dev":true,"requires":{"buffer":"4.9.1","crypto-browserify":"1.0.9","events":"1.1.1","jmespath":"0.15.0","querystring":"0.2.0","sax":"1.2.1","url":"0.10.3","uuid":"3.1.0","xml2js":"0.4.17","xmlbuilder":"4.2.1"},"dependencies":{"base64-js":{"version":"1.2.1","resolved":"https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz","integrity":"sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==","dev":true},"buffer":{"version":"4.9.1","resolved":"https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz","integrity":"sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=","dev":true,"requires":{"base64-js":"1.2.1","ieee754":"1.1.8","isarray":"1.0.0"}},"sax":{"version":"1.2.1","resolved":"https://registry.npmjs.org/sax/-/sax-1.2.1.tgz","integrity":"sha1-e45lYZCyKOgaZq6nSEgNgozS03o=","dev":true},"xmlbuilder":{"version":"4.2.1","resolved":"https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz","integrity":"sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=","dev":true,"requires":{"lodash":"4.17.4"}}}},"aws-sign2":{"version":"0.6.0","resolved":"https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz","integrity":"sha1-FDQt0428yU0OW4fXY81jYSwOeU8="},"aws4":{"version":"1.6.0","resolved":"https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz","integrity":"sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="},"babel-code-frame":{"version":"6.26.0","resolved":"https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz","integrity":"sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=","dev":true,"requires":{"chalk":"1.1.3","esutils":"2.0.2","js-tokens":"3.0.2"},"dependencies":{"ansi-styles":{"version":"2.2.1","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz","integrity":"sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=","dev":true},"chalk":{"version":"1.1.3","resolved":"https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz","integrity":"sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=","dev":true,"requires":{"ansi-styles":"2.2.1","escape-string-regexp":"1.0.5","has-ansi":"2.0.0","strip-ansi":"3.0.1","supports-color":"2.0.0"}},"has-ansi":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz","integrity":"sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=","dev":true,"requires":{"ansi-regex":"2.1.1"}},"supports-color":{"version":"2.0.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz","integrity":"sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=","dev":true}}},"babel-runtime":{"version":"6.26.0","resolved":"https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz","integrity":"sha1-llxwWGaOgrVde/4E/yM3vItWR/4=","requires":{"core-js":"2.5.1","regenerator-runtime":"0.11.0"},"dependencies":{"core-js":{"version":"2.5.1","resolved":"https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz","integrity":"sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="}}},"balanced-match":{"version":"1.0.0","resolved":"https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz","integrity":"sha1-ibTRmasr7kneFk6gK4nORi1xt2c="},"base":{"version":"0.11.2","resolved":"https://registry.npmjs.org/base/-/base-0.11.2.tgz","integrity":"sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==","dev":true,"requires":{"cache-base":"1.0.1","class-utils":"0.3.5","component-emitter":"1.2.1","define-property":"1.0.0","isobject":"3.0.1","mixin-deep":"1.2.0","pascalcase":"0.1.1"}},"base62":{"version":"1.2.0","resolved":"https://registry.npmjs.org/base62/-/base62-1.2.0.tgz","integrity":"sha1-MeflYNyEbJ9EwaUx32UU2jVHQVc=","dev":true},"base64-js":{"version":"0.0.8","resolved":"https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz","integrity":"sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="},"base64url":{"version":"2.0.0","resolved":"https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz","integrity":"sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs=","dev":true},"basic-auth":{"version":"2.0.0","resolved":"https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz","integrity":"sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=","dev":true,"requires":{"safe-buffer":"5.1.1"}},"batch":{"version":"0.6.1","resolved":"https://registry.npmjs.org/batch/-/batch-0.6.1.tgz","integrity":"sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=","dev":true},"bcrypt":{"version":"1.0.3","resolved":"https://registry.npmjs.org/bcrypt/-/bcrypt-1.0.3.tgz","integrity":"sha512-pRyDdo73C8Nim3jwFJ7DWe3TZCgwDfWZ6nHS5LSdU77kWbj1frruvdndP02AOavtD4y8v6Fp2dolbHgp4SDrfg==","dev":true,"requires":{"nan":"2.6.2","node-pre-gyp":"0.6.36"},"dependencies":{"nan":{"version":"2.6.2","resolved":"https://registry.npmjs.org/nan/-/nan-2.6.2.tgz","integrity":"sha1-5P805slf37WuzAjeZZb0NgWn20U=","dev":true},"node-pre-gyp":{"version":"0.6.36","resolved":"https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz","integrity":"sha1-22BBEst04NR3VU6bUFsXq936t4Y=","dev":true,"requires":{"mkdirp":"0.5.1","nopt":"4.0.1","npmlog":"4.1.2","rc":"1.2.2","request":"2.83.0","rimraf":"2.6.2","semver":"5.4.1","tar":"2.2.1","tar-pack":"3.4.1"}}}},"bcrypt-pbkdf":{"version":"1.0.1","resolved":"https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz","integrity":"sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=","optional":true,"requires":{"tweetnacl":"0.14.5"}},"big.js":{"version":"3.2.0","resolved":"https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz","integrity":"sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==","dev":true},"binary-extensions":{"version":"1.10.0","resolved":"https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz","integrity":"sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=","dev":true},"bindings":{"version":"1.3.0","resolved":"https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz","integrity":"sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==","dev":true},"bl":{"version":"1.2.1","resolved":"https://registry.npmjs.org/bl/-/bl-1.2.1.tgz","integrity":"sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=","requires":{"readable-stream":"2.3.3"}},"block-stream":{"version":"0.0.9","resolved":"https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz","integrity":"sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=","requires":{"inherits":"2.0.3"}},"bluebird":{"version":"3.5.1","resolved":"https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz","integrity":"sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="},"bluebird-lst":{"version":"1.0.5","resolved":"https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.5.tgz","integrity":"sha512-Ey0bDNys5qpYPhZ/oQ9vOEvD0TYQDTILMXWP2iGfvMg7rSDde+oV4aQQgqRH+CvBFNz2BSDQnPGMUl6LKBUUQA==","requires":{"bluebird":"3.5.1"}},"bn.js":{"version":"4.11.8","resolved":"https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz","integrity":"sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==","dev":true},"body-parser":{"version":"1.18.2","resolved":"https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz","integrity":"sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=","dev":true,"requires":{"bytes":"3.0.0","content-type":"1.0.4","debug":"2.6.9","depd":"1.1.1","http-errors":"1.6.2","iconv-lite":"0.4.19","on-finished":"2.3.0","qs":"6.5.1","raw-body":"2.3.2","type-is":"1.6.15"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}},"qs":{"version":"6.5.1","resolved":"https://registry.npmjs.org/qs/-/qs-6.5.1.tgz","integrity":"sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==","dev":true}}},"bonjour":{"version":"3.5.0","resolved":"https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz","integrity":"sha1-jokKGD2O6aI5OzhExpGkK897yfU=","dev":true,"requires":{"array-flatten":"2.1.1","deep-equal":"1.0.1","dns-equal":"1.0.0","dns-txt":"2.0.2","multicast-dns":"6.1.1","multicast-dns-service-types":"1.1.0"},"dependencies":{"array-flatten":{"version":"2.1.1","resolved":"https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz","integrity":"sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=","dev":true}}},"boom":{"version":"2.10.1","resolved":"https://registry.npmjs.org/boom/-/boom-2.10.1.tgz","integrity":"sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=","requires":{"hoek":"2.16.3"}},"bootstrap":{"version":"4.0.0-alpha.6","resolved":"https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0-alpha.6.tgz","integrity":"sha1-T1TdM6wN6sOyhAe8LffsYIhpycg=","dev":true,"requires":{"jquery":"3.2.1","tether":"1.4.0"}},"boxen":{"version":"1.2.2","resolved":"https://registry.npmjs.org/boxen/-/boxen-1.2.2.tgz","integrity":"sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=","dev":true,"requires":{"ansi-align":"2.0.0","camelcase":"4.1.0","chalk":"2.3.0","cli-boxes":"1.0.0","string-width":"2.1.1","term-size":"1.2.0","widest-line":"1.0.0"},"dependencies":{"ansi-regex":{"version":"3.0.0","resolved":"https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz","integrity":"sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=","dev":true},"ansi-styles":{"version":"3.2.0","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz","integrity":"sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==","dev":true,"requires":{"color-convert":"1.9.0"}},"camelcase":{"version":"4.1.0","resolved":"https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz","integrity":"sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=","dev":true},"chalk":{"version":"2.3.0","resolved":"https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz","integrity":"sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==","dev":true,"requires":{"ansi-styles":"3.2.0","escape-string-regexp":"1.0.5","supports-color":"4.5.0"}},"has-flag":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz","integrity":"sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=","dev":true},"is-fullwidth-code-point":{"version":"2.0.0","resolved":"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz","integrity":"sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=","dev":true},"string-width":{"version":"2.1.1","resolved":"https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz","integrity":"sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==","dev":true,"requires":{"is-fullwidth-code-point":"2.0.0","strip-ansi":"4.0.0"}},"strip-ansi":{"version":"4.0.0","resolved":"https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz","integrity":"sha1-qEeQIusaw2iocTibY1JixQXuNo8=","dev":true,"requires":{"ansi-regex":"3.0.0"}},"supports-color":{"version":"4.5.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz","integrity":"sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=","dev":true,"requires":{"has-flag":"2.0.0"}}}},"brace-expansion":{"version":"1.1.8","resolved":"https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz","integrity":"sha1-wHshHHyVLsH479Uad+8NHTmQopI=","requires":{"balanced-match":"1.0.0","concat-map":"0.0.1"}},"braces":{"version":"2.3.0","resolved":"https://registry.npmjs.org/braces/-/braces-2.3.0.tgz","integrity":"sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==","dev":true,"requires":{"arr-flatten":"1.1.0","array-unique":"0.3.2","define-property":"1.0.0","extend-shallow":"2.0.1","fill-range":"4.0.0","isobject":"3.0.1","repeat-element":"1.1.2","snapdragon":"0.8.1","snapdragon-node":"2.1.1","split-string":"3.0.2","to-regex":"3.0.1"}},"brorand":{"version":"1.1.0","resolved":"https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz","integrity":"sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=","dev":true},"browser-stdout":{"version":"1.3.0","resolved":"https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz","integrity":"sha1-81HTKWnTL6XXpVZxVCY9korjvR8=","dev":true},"browserify-aes":{"version":"1.1.1","resolved":"https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz","integrity":"sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==","dev":true,"requires":{"buffer-xor":"1.0.3","cipher-base":"1.0.4","create-hash":"1.1.3","evp_bytestokey":"1.0.3","inherits":"2.0.3","safe-buffer":"5.1.1"}},"browserify-cipher":{"version":"1.0.0","resolved":"https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz","integrity":"sha1-mYgkSHS/XtTijalWZtzWasj8Njo=","dev":true,"requires":{"browserify-aes":"1.1.1","browserify-des":"1.0.0","evp_bytestokey":"1.0.3"}},"browserify-des":{"version":"1.0.0","resolved":"https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz","integrity":"sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=","dev":true,"requires":{"cipher-base":"1.0.4","des.js":"1.0.0","inherits":"2.0.3"}},"browserify-rsa":{"version":"4.0.1","resolved":"https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz","integrity":"sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=","dev":true,"requires":{"bn.js":"4.11.8","randombytes":"2.0.5"}},"browserify-sign":{"version":"4.0.4","resolved":"https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz","integrity":"sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=","dev":true,"requires":{"bn.js":"4.11.8","browserify-rsa":"4.0.1","create-hash":"1.1.3","create-hmac":"1.1.6","elliptic":"6.4.0","inherits":"2.0.3","parse-asn1":"5.1.0"}},"browserify-zlib":{"version":"0.1.4","resolved":"https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz","integrity":"sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=","dev":true,"requires":{"pako":"0.2.9"}},"browserslist":{"version":"1.7.7","resolved":"https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz","integrity":"sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=","dev":true,"requires":{"caniuse-db":"1.0.30000750","electron-to-chromium":"1.3.27"}},"buffer":{"version":"3.6.0","resolved":"https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz","integrity":"sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=","requires":{"base64-js":"0.0.8","ieee754":"1.1.8","isarray":"1.0.0"}},"buffer-crc32":{"version":"0.2.13","resolved":"https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz","integrity":"sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="},"buffer-equal-constant-time":{"version":"1.0.1","resolved":"https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz","integrity":"sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=","dev":true},"buffer-indexof":{"version":"1.1.1","resolved":"https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz","integrity":"sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==","dev":true},"buffer-xor":{"version":"1.0.3","resolved":"https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz","integrity":"sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=","dev":true},"builder-util":{"version":"3.1.0","resolved":"https://registry.npmjs.org/builder-util/-/builder-util-3.1.0.tgz","integrity":"sha512-DVf9/tZqh0CGUyOGf6dHCmT34j3sd6a30tgfu89+ZcdBfYMN9Iu2piFm0BsClzhOxZE/UsJie4d9LuD1Dxm9XA==","dev":true,"requires":{"7zip-bin":"2.2.7","bluebird-lst":"1.0.5","builder-util-runtime":"2.4.0","chalk":"2.3.0","debug":"3.1.0","fs-extra-p":"4.4.4","ini":"1.3.4","is-ci":"1.0.10","js-yaml":"3.10.0","lazy-val":"1.0.2","node-emoji":"1.8.1","semver":"5.4.1","source-map-support":"0.5.0","stat-mode":"0.2.2","temp-file":"2.0.3","tunnel-agent":"0.6.0"},"dependencies":{"ansi-styles":{"version":"3.2.0","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz","integrity":"sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==","dev":true,"requires":{"color-convert":"1.9.0"}},"chalk":{"version":"2.3.0","resolved":"https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz","integrity":"sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==","dev":true,"requires":{"ansi-styles":"3.2.0","escape-string-regexp":"1.0.5","supports-color":"4.5.0"}},"has-flag":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz","integrity":"sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=","dev":true},"supports-color":{"version":"4.5.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz","integrity":"sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=","dev":true,"requires":{"has-flag":"2.0.0"}}}},"builder-util-runtime":{"version":"2.4.0","resolved":"https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-2.4.0.tgz","integrity":"sha512-35PskRowZnDnqJ6zbGSZ+ijndHPan2l56tF9n+FHMNmZnSQ69aw5eXWQDxyMlKKVwt/lF6dFGWhyRtsBmtDL7g==","requires":{"bluebird-lst":"1.0.5","debug":"3.1.0","fs-extra-p":"4.4.4","sax":"1.2.4"}},"builtin-modules":{"version":"1.1.1","resolved":"https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz","integrity":"sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=","dev":true},"builtin-status-codes":{"version":"3.0.0","resolved":"https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz","integrity":"sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=","dev":true},"bytes":{"version":"3.0.0","resolved":"https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz","integrity":"sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=","dev":true},"cache-base":{"version":"1.0.1","resolved":"https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz","integrity":"sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==","dev":true,"requires":{"collection-visit":"1.0.0","component-emitter":"1.2.1","get-value":"2.0.6","has-value":"1.0.0","isobject":"3.0.1","set-value":"2.0.0","to-object-path":"0.3.0","union-value":"1.0.0","unset-value":"1.0.0"}},"caller-path":{"version":"0.1.0","resolved":"https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz","integrity":"sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=","dev":true,"requires":{"callsites":"0.2.0"}},"callsites":{"version":"0.2.0","resolved":"https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz","integrity":"sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=","dev":true},"camelcase":{"version":"2.1.1","resolved":"https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz","integrity":"sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=","dev":true},"camelcase-keys":{"version":"2.1.0","resolved":"https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz","integrity":"sha1-MIvur/3ygRkFHvodkyITyRuPkuc=","dev":true,"requires":{"camelcase":"2.1.1","map-obj":"1.0.1"}},"caniuse-api":{"version":"1.6.1","resolved":"https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz","integrity":"sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=","dev":true,"requires":{"browserslist":"1.7.7","caniuse-db":"1.0.30000750","lodash.memoize":"4.1.2","lodash.uniq":"4.5.0"}},"caniuse-db":{"version":"1.0.30000750","resolved":"https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000750.tgz","integrity":"sha1-Px+FySyRNO3ac1aV42nX4XZ1K3U=","dev":true},"capture-stack-trace":{"version":"1.0.0","resolved":"https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz","integrity":"sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=","dev":true},"caseless":{"version":"0.12.0","resolved":"https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz","integrity":"sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="},"center-align":{"version":"0.1.3","resolved":"https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz","integrity":"sha1-qg0yYptu6XIgBBHL1EYckHvCt60=","dev":true,"requires":{"align-text":"0.1.4","lazy-cache":"1.0.4"},"dependencies":{"lazy-cache":{"version":"1.0.4","resolved":"https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz","integrity":"sha1-odePw6UEdMuAhF07O24dpJpEbo4=","dev":true}}},"chain-function":{"version":"1.0.0","resolved":"https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz","integrity":"sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="},"chalk":{"version":"0.5.1","resolved":"https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz","integrity":"sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=","dev":true,"requires":{"ansi-styles":"1.1.0","escape-string-regexp":"1.0.5","has-ansi":"0.1.0","strip-ansi":"0.3.0","supports-color":"0.2.0"},"dependencies":{"ansi-regex":{"version":"0.2.1","resolved":"https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz","integrity":"sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=","dev":true},"strip-ansi":{"version":"0.3.0","resolved":"https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz","integrity":"sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=","dev":true,"requires":{"ansi-regex":"0.2.1"}},"supports-color":{"version":"0.2.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz","integrity":"sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=","dev":true}}},"charenc":{"version":"0.0.2","resolved":"https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz","integrity":"sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=","dev":true},"chokidar":{"version":"1.7.0","resolved":"https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz","integrity":"sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=","dev":true,"requires":{"anymatch":"1.3.2","async-each":"1.0.1","fsevents":"1.1.2","glob-parent":"2.0.0","inherits":"2.0.3","is-binary-path":"1.0.1","is-glob":"2.0.1","path-is-absolute":"1.0.1","readdirp":"2.1.0"},"dependencies":{"is-extglob":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz","integrity":"sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=","dev":true},"is-glob":{"version":"2.0.1","resolved":"https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz","integrity":"sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=","dev":true,"requires":{"is-extglob":"1.0.0"}}}},"chownr":{"version":"1.0.1","resolved":"https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz","integrity":"sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=","dev":true},"chromium-pickle-js":{"version":"0.2.0","resolved":"https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz","integrity":"sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=","dev":true},"ci-info":{"version":"1.1.1","resolved":"https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz","integrity":"sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==","dev":true},"cipher-base":{"version":"1.0.4","resolved":"https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz","integrity":"sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==","dev":true,"requires":{"inherits":"2.0.3","safe-buffer":"5.1.1"}},"circular-buffer":{"version":"1.0.2","resolved":"https://registry.npmjs.org/circular-buffer/-/circular-buffer-1.0.2.tgz","integrity":"sha1-+g4VLtYp92/iTd+J5y69AHhsWm4=","dev":true},"circular-json":{"version":"0.3.3","resolved":"https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz","integrity":"sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==","dev":true},"clap":{"version":"1.2.3","resolved":"https://registry.npmjs.org/clap/-/clap-1.2.3.tgz","integrity":"sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==","dev":true,"requires":{"chalk":"1.1.3"},"dependencies":{"ansi-styles":{"version":"2.2.1","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz","integrity":"sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=","dev":true},"chalk":{"version":"1.1.3","resolved":"https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz","integrity":"sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=","dev":true,"requires":{"ansi-styles":"2.2.1","escape-string-regexp":"1.0.5","has-ansi":"2.0.0","strip-ansi":"3.0.1","supports-color":"2.0.0"}},"has-ansi":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz","integrity":"sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=","dev":true,"requires":{"ansi-regex":"2.1.1"}},"supports-color":{"version":"2.0.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz","integrity":"sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=","dev":true}}},"class-utils":{"version":"0.3.5","resolved":"https://registry.npmjs.org/class-utils/-/class-utils-0.3.5.tgz","integrity":"sha1-F+eTEDdQ+WJ7IXbqNM/RtWWQPIA=","dev":true,"requires":{"arr-union":"3.1.0","define-property":"0.2.5","isobject":"3.0.1","lazy-cache":"2.0.2","static-extend":"0.1.2"},"dependencies":{"define-property":{"version":"0.2.5","resolved":"https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz","integrity":"sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=","dev":true,"requires":{"is-descriptor":"0.1.6"}},"is-descriptor":{"version":"0.1.6","resolved":"https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz","integrity":"sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==","dev":true,"requires":{"is-accessor-descriptor":"0.1.6","is-data-descriptor":"0.1.4","kind-of":"5.1.0"}},"kind-of":{"version":"5.1.0","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz","integrity":"sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==","dev":true}}},"classnames":{"version":"2.2.5","resolved":"https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz","integrity":"sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="},"cli-boxes":{"version":"1.0.0","resolved":"https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz","integrity":"sha1-T6kXw+WclKAEzWH47lCdplFocUM=","dev":true},"cli-cursor":{"version":"1.0.2","resolved":"https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz","integrity":"sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=","dev":true,"requires":{"restore-cursor":"1.0.1"}},"cli-spinners":{"version":"0.1.2","resolved":"https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz","integrity":"sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=","dev":true},"cli-truncate":{"version":"0.2.1","resolved":"https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz","integrity":"sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=","dev":true,"requires":{"slice-ansi":"0.0.4","string-width":"1.0.2"}},"cli-width":{"version":"2.2.0","resolved":"https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz","integrity":"sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=","dev":true},"cliui":{"version":"3.2.0","resolved":"https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz","integrity":"sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=","dev":true,"requires":{"string-width":"1.0.2","strip-ansi":"3.0.1","wrap-ansi":"2.1.0"}},"clone":{"version":"1.0.2","resolved":"https://registry.npmjs.org/clone/-/clone-1.0.2.tgz","integrity":"sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=","dev":true},"clone-deep":{"version":"0.3.0","resolved":"https://registry.npmjs.org/clone-deep/-/clone-deep-0.3.0.tgz","integrity":"sha1-NIxhrpzb4O3+BT2R/0zFIdeQ7eg=","dev":true,"requires":{"for-own":"1.0.0","is-plain-object":"2.0.4","kind-of":"3.2.2","shallow-clone":"0.1.2"},"dependencies":{"for-own":{"version":"1.0.0","resolved":"https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz","integrity":"sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=","dev":true,"requires":{"for-in":"1.0.2"}},"kind-of":{"version":"3.2.2","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz","integrity":"sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=","dev":true,"requires":{"is-buffer":"1.1.5"}}}},"co":{"version":"4.6.0","resolved":"https://registry.npmjs.org/co/-/co-4.6.0.tgz","integrity":"sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="},"coa":{"version":"1.0.4","resolved":"https://registry.npmjs.org/coa/-/coa-1.0.4.tgz","integrity":"sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=","dev":true,"requires":{"q":"1.5.1"}},"code-point-at":{"version":"1.1.0","resolved":"https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz","integrity":"sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="},"collection-visit":{"version":"1.0.0","resolved":"https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz","integrity":"sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=","dev":true,"requires":{"map-visit":"1.0.0","object-visit":"1.0.1"}},"color":{"version":"0.11.4","resolved":"https://registry.npmjs.org/color/-/color-0.11.4.tgz","integrity":"sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=","dev":true,"requires":{"clone":"1.0.2","color-convert":"1.9.0","color-string":"0.3.0"}},"color-convert":{"version":"1.9.0","resolved":"https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz","integrity":"sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=","dev":true,"requires":{"color-name":"1.1.3"}},"color-name":{"version":"1.1.3","resolved":"https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz","integrity":"sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=","dev":true},"color-string":{"version":"0.3.0","resolved":"https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz","integrity":"sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=","dev":true,"requires":{"color-name":"1.1.3"}},"colormin":{"version":"1.1.2","resolved":"https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz","integrity":"sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=","dev":true,"requires":{"color":"0.11.4","css-color-names":"0.0.4","has":"1.0.1"}},"colors":{"version":"1.1.2","resolved":"https://registry.npmjs.org/colors/-/colors-1.1.2.tgz","integrity":"sha1-FopHAXVran9RoSzgyXv6KMCE7WM=","dev":true},"combined-stream":{"version":"1.0.5","resolved":"https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz","integrity":"sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=","requires":{"delayed-stream":"1.0.0"}},"command-line-args":{"version":"4.0.7","resolved":"https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz","integrity":"sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==","requires":{"array-back":"2.0.0","find-replace":"1.0.3","typical":"2.6.1"}},"commander":{"version":"2.8.1","resolved":"https://registry.npmjs.org/commander/-/commander-2.8.1.tgz","integrity":"sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=","requires":{"graceful-readlink":"1.0.1"}},"commoner":{"version":"0.10.8","resolved":"https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz","integrity":"sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=","dev":true,"requires":{"commander":"2.8.1","detective":"4.5.0","glob":"5.0.15","graceful-fs":"4.1.11","iconv-lite":"0.4.19","mkdirp":"0.5.1","private":"0.1.8","q":"1.5.1","recast":"0.11.23"},"dependencies":{"glob":{"version":"5.0.15","resolved":"https://registry.npmjs.org/glob/-/glob-5.0.15.tgz","integrity":"sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=","dev":true,"requires":{"inflight":"1.0.6","inherits":"2.0.3","minimatch":"3.0.4","once":"1.4.0","path-is-absolute":"1.0.1"}}}},"compare-version":{"version":"0.1.2","resolved":"https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz","integrity":"sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA=","dev":true},"component-emitter":{"version":"1.2.1","resolved":"https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz","integrity":"sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=","dev":true},"compress-commons":{"version":"1.2.2","resolved":"https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz","integrity":"sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=","dev":true,"requires":{"buffer-crc32":"0.2.13","crc32-stream":"2.0.0","normalize-path":"2.1.1","readable-stream":"2.3.3"},"dependencies":{"normalize-path":{"version":"2.1.1","resolved":"https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz","integrity":"sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=","dev":true,"requires":{"remove-trailing-separator":"1.1.0"}}}},"compressible":{"version":"2.0.12","resolved":"https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz","integrity":"sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=","dev":true,"requires":{"mime-db":"1.30.0"}},"compression":{"version":"1.7.1","resolved":"https://registry.npmjs.org/compression/-/compression-1.7.1.tgz","integrity":"sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=","dev":true,"requires":{"accepts":"1.3.4","bytes":"3.0.0","compressible":"2.0.12","debug":"2.6.9","on-headers":"1.0.1","safe-buffer":"5.1.1","vary":"1.1.2"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}}}},"concat-map":{"version":"0.0.1","resolved":"https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz","integrity":"sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="},"concat-stream":{"version":"1.6.0","resolved":"https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz","integrity":"sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=","requires":{"inherits":"2.0.3","readable-stream":"2.3.3","typedarray":"0.0.6"}},"concurrently":{"version":"3.5.0","resolved":"https://registry.npmjs.org/concurrently/-/concurrently-3.5.0.tgz","integrity":"sha1-jPG3cHppFqeKT/W3e7BN7FSzebI=","dev":true,"requires":{"chalk":"0.5.1","commander":"2.6.0","date-fns":"1.29.0","lodash":"4.17.4","rx":"2.3.24","spawn-command":"0.0.2-1","supports-color":"3.2.3","tree-kill":"1.2.0"},"dependencies":{"commander":{"version":"2.6.0","resolved":"https://registry.npmjs.org/commander/-/commander-2.6.0.tgz","integrity":"sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=","dev":true}}},"configstore":{"version":"3.1.1","resolved":"https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz","integrity":"sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==","dev":true,"requires":{"dot-prop":"4.2.0","graceful-fs":"4.1.11","make-dir":"1.1.0","unique-string":"1.0.0","write-file-atomic":"2.3.0","xdg-basedir":"3.0.0"}},"connect-history-api-fallback":{"version":"1.4.0","resolved":"https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.4.0.tgz","integrity":"sha1-PbJPlz9LkjsOgvYZzg3wJBHKYj0=","dev":true},"console-browserify":{"version":"1.1.0","resolved":"https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz","integrity":"sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=","dev":true,"requires":{"date-now":"0.1.4"}},"console-control-strings":{"version":"1.1.0","resolved":"https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz","integrity":"sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="},"constants-browserify":{"version":"1.0.0","resolved":"https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz","integrity":"sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=","dev":true},"content-disposition":{"version":"0.5.2","resolved":"https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz","integrity":"sha1-DPaLud318r55YcOoUXjLhdunjLQ=","dev":true},"content-type":{"version":"1.0.4","resolved":"https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz","integrity":"sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==","dev":true},"content-type-parser":{"version":"1.0.2","resolved":"https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz","integrity":"sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==","dev":true},"convert-source-map":{"version":"1.5.0","resolved":"https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz","integrity":"sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=","dev":true},"cookie":{"version":"0.3.1","resolved":"https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz","integrity":"sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=","dev":true},"cookie-signature":{"version":"1.0.6","resolved":"https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz","integrity":"sha1-4wOogrNCzD7oylE6eZmXNNqzriw=","dev":true},"cookiejar":{"version":"2.1.1","resolved":"https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz","integrity":"sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=","dev":true},"copy-descriptor":{"version":"0.1.1","resolved":"https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz","integrity":"sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=","dev":true},"core-js":{"version":"1.2.7","resolved":"https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz","integrity":"sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="},"core-util-is":{"version":"1.0.2","resolved":"https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz","integrity":"sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="},"cosmiconfig":{"version":"1.1.0","resolved":"https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz","integrity":"sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=","dev":true,"requires":{"graceful-fs":"4.1.11","js-yaml":"3.10.0","minimist":"1.2.0","object-assign":"4.1.1","os-homedir":"1.0.2","parse-json":"2.2.0","pinkie-promise":"2.0.1","require-from-string":"1.2.1"},"dependencies":{"minimist":{"version":"1.2.0","resolved":"https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz","integrity":"sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=","dev":true}}},"crc":{"version":"3.5.0","resolved":"https://registry.npmjs.org/crc/-/crc-3.5.0.tgz","integrity":"sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ=","dev":true},"crc32-stream":{"version":"2.0.0","resolved":"https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz","integrity":"sha1-483TtN8xaN10494/u8t7KX/pCPQ=","dev":true,"requires":{"crc":"3.5.0","readable-stream":"2.3.3"}},"create-ecdh":{"version":"4.0.0","resolved":"https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz","integrity":"sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=","dev":true,"requires":{"bn.js":"4.11.8","elliptic":"6.4.0"}},"create-error-class":{"version":"3.0.2","resolved":"https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz","integrity":"sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=","dev":true,"requires":{"capture-stack-trace":"1.0.0"}},"create-hash":{"version":"1.1.3","resolved":"https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz","integrity":"sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=","dev":true,"requires":{"cipher-base":"1.0.4","inherits":"2.0.3","ripemd160":"2.0.1","sha.js":"2.4.9"}},"create-hmac":{"version":"1.1.6","resolved":"https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz","integrity":"sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=","dev":true,"requires":{"cipher-base":"1.0.4","create-hash":"1.1.3","inherits":"2.0.3","ripemd160":"2.0.1","safe-buffer":"5.1.1","sha.js":"2.4.9"}},"create-react-class":{"version":"15.6.2","resolved":"https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz","integrity":"sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=","requires":{"fbjs":"0.8.16","loose-envify":"1.3.1","object-assign":"4.1.1"}},"cross-spawn":{"version":"5.1.0","resolved":"https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz","integrity":"sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=","dev":true,"requires":{"lru-cache":"4.1.1","shebang-command":"1.2.0","which":"1.3.0"}},"crypt":{"version":"0.0.2","resolved":"https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz","integrity":"sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=","dev":true},"cryptiles":{"version":"2.0.5","resolved":"https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz","integrity":"sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=","requires":{"boom":"2.10.1"}},"crypto-browserify":{"version":"1.0.9","resolved":"https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz","integrity":"sha1-zFRJaF37hesRyYKKzHy4erW7/MA=","dev":true},"crypto-random-string":{"version":"1.0.0","resolved":"https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz","integrity":"sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=","dev":true},"css":{"version":"2.2.1","resolved":"https://registry.npmjs.org/css/-/css-2.2.1.tgz","integrity":"sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=","dev":true,"requires":{"inherits":"2.0.3","source-map":"0.1.43","source-map-resolve":"0.3.1","urix":"0.1.0"},"dependencies":{"atob":{"version":"1.1.3","resolved":"https://registry.npmjs.org/atob/-/atob-1.1.3.tgz","integrity":"sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M=","dev":true},"source-map":{"version":"0.1.43","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz","integrity":"sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=","dev":true,"requires":{"amdefine":"1.0.1"}},"source-map-resolve":{"version":"0.3.1","resolved":"https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz","integrity":"sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=","dev":true,"requires":{"atob":"1.1.3","resolve-url":"0.2.1","source-map-url":"0.3.0","urix":"0.1.0"}},"source-map-url":{"version":"0.3.0","resolved":"https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz","integrity":"sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=","dev":true}}},"css-color-names":{"version":"0.0.4","resolved":"https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz","integrity":"sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=","dev":true},"css-loader":{"version":"0.28.7","resolved":"https://registry.npmjs.org/css-loader/-/css-loader-0.28.7.tgz","integrity":"sha512-GxMpax8a/VgcfRrVy0gXD6yLd5ePYbXX/5zGgTVYp4wXtJklS8Z2VaUArJgc//f6/Dzil7BaJObdSv8eKKCPgg==","dev":true,"requires":{"babel-code-frame":"6.26.0","css-selector-tokenizer":"0.7.0","cssnano":"3.10.0","icss-utils":"2.1.0","loader-utils":"1.1.0","lodash.camelcase":"4.3.0","object-assign":"4.1.1","postcss":"5.2.18","postcss-modules-extract-imports":"1.1.0","postcss-modules-local-by-default":"1.2.0","postcss-modules-scope":"1.1.0","postcss-modules-values":"1.3.0","postcss-value-parser":"3.3.0","source-list-map":"2.0.0"}},"css-parse":{"version":"2.0.0","resolved":"https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz","integrity":"sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=","dev":true,"requires":{"css":"2.2.1"}},"css-selector-tokenizer":{"version":"0.7.0","resolved":"https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz","integrity":"sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=","dev":true,"requires":{"cssesc":"0.1.0","fastparse":"1.1.1","regexpu-core":"1.0.0"}},"css-value":{"version":"0.0.1","resolved":"https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz","integrity":"sha1-Xv1sLupeof1rasV+wEJ7GEUkJOo=","dev":true},"cssesc":{"version":"0.1.0","resolved":"https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz","integrity":"sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=","dev":true},"cssnano":{"version":"3.10.0","resolved":"https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz","integrity":"sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=","dev":true,"requires":{"autoprefixer":"6.7.7","decamelize":"1.2.0","defined":"1.0.0","has":"1.0.1","object-assign":"4.1.1","postcss":"5.2.18","postcss-calc":"5.3.1","postcss-colormin":"2.2.2","postcss-convert-values":"2.6.1","postcss-discard-comments":"2.0.4","postcss-discard-duplicates":"2.1.0","postcss-discard-empty":"2.1.0","postcss-discard-overridden":"0.1.1","postcss-discard-unused":"2.2.3","postcss-filter-plugins":"2.0.2","postcss-merge-idents":"2.1.7","postcss-merge-longhand":"2.0.2","postcss-merge-rules":"2.1.2","postcss-minify-font-values":"1.0.5","postcss-minify-gradients":"1.0.5","postcss-minify-params":"1.2.2","postcss-minify-selectors":"2.1.1","postcss-normalize-charset":"1.1.1","postcss-normalize-url":"3.0.8","postcss-ordered-values":"2.2.3","postcss-reduce-idents":"2.4.0","postcss-reduce-initial":"1.0.1","postcss-reduce-transforms":"1.0.4","postcss-svgo":"2.1.6","postcss-unique-selectors":"2.0.2","postcss-value-parser":"3.3.0","postcss-zindex":"2.2.0"}},"csso":{"version":"2.3.2","resolved":"https://registry.npmjs.org/csso/-/csso-2.3.2.tgz","integrity":"sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=","dev":true,"requires":{"clap":"1.2.3","source-map":"0.5.7"},"dependencies":{"source-map":{"version":"0.5.7","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz","integrity":"sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=","dev":true}}},"cssom":{"version":"0.3.2","resolved":"https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz","integrity":"sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=","dev":true},"cssstyle":{"version":"0.2.37","resolved":"https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz","integrity":"sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=","dev":true,"requires":{"cssom":"0.3.2"}},"cuint":{"version":"0.2.2","resolved":"https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz","integrity":"sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=","dev":true},"currently-unhandled":{"version":"0.4.1","resolved":"https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz","integrity":"sha1-mI3zP+qxke95mmE2nddsF635V+o=","dev":true,"requires":{"array-find-index":"1.0.2"}},"cycle":{"version":"1.0.3","resolved":"https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz","integrity":"sha1-IegLK+hYD5i0aPN5QwZisEbDStI=","dev":true},"d":{"version":"1.0.0","resolved":"https://registry.npmjs.org/d/-/d-1.0.0.tgz","integrity":"sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=","dev":true,"requires":{"es5-ext":"0.10.35"}},"d3":{"version":"3.5.17","resolved":"https://registry.npmjs.org/d3/-/d3-3.5.17.tgz","integrity":"sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g=","dev":true},"dashdash":{"version":"1.14.1","resolved":"https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz","integrity":"sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=","requires":{"assert-plus":"1.0.0"},"dependencies":{"assert-plus":{"version":"1.0.0","resolved":"https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz","integrity":"sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="}}},"date-fns":{"version":"1.29.0","resolved":"https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz","integrity":"sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==","dev":true},"date-now":{"version":"0.1.4","resolved":"https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz","integrity":"sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=","dev":true},"debug":{"version":"3.1.0","resolved":"https://registry.npmjs.org/debug/-/debug-3.1.0.tgz","integrity":"sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==","requires":{"ms":"2.0.0"}},"decamelize":{"version":"1.2.0","resolved":"https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz","integrity":"sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=","dev":true},"decode-uri-component":{"version":"0.2.0","resolved":"https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz","integrity":"sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=","dev":true},"decompress":{"version":"4.2.0","resolved":"https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz","integrity":"sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=","requires":{"decompress-tar":"4.1.1","decompress-tarbz2":"4.1.1","decompress-targz":"4.1.1","decompress-unzip":"4.0.1","graceful-fs":"4.1.11","make-dir":"1.1.0","pify":"2.3.0","strip-dirs":"2.1.0"}},"decompress-tar":{"version":"4.1.1","resolved":"https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz","integrity":"sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==","requires":{"file-type":"5.2.0","is-stream":"1.1.0","tar-stream":"1.5.4"}},"decompress-tarbz2":{"version":"4.1.1","resolved":"https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz","integrity":"sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==","requires":{"decompress-tar":"4.1.1","file-type":"6.2.0","is-stream":"1.1.0","seek-bzip":"1.0.5","unbzip2-stream":"1.2.5"},"dependencies":{"file-type":{"version":"6.2.0","resolved":"https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz","integrity":"sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="}}},"decompress-targz":{"version":"4.1.1","resolved":"https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz","integrity":"sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==","requires":{"decompress-tar":"4.1.1","file-type":"5.2.0","is-stream":"1.1.0"}},"decompress-tarxz":{"version":"2.1.1","resolved":"https://registry.npmjs.org/decompress-tarxz/-/decompress-tarxz-2.1.1.tgz","integrity":"sha512-U7LniyhLTpCc07lAmNXMX4NBW60ONkpGTwo6KxIDk9zk22GYh5NKjEI09F8I1oYkGr9WGOA6OH7scqLo7Xu5lA==","requires":{"decompress-tar":"4.1.1","file-type":"3.9.0","is-stream":"1.1.0","lzma-native":"3.0.1"},"dependencies":{"file-type":{"version":"3.9.0","resolved":"https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz","integrity":"sha1-JXoHg4TR24CHvESdEH1SpSZyuek="}}},"decompress-unzip":{"version":"4.0.1","resolved":"https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz","integrity":"sha1-3qrM39FK6vhVePczroIQ+bSEj2k=","requires":{"file-type":"3.9.0","get-stream":"2.3.1","pify":"2.3.0","yauzl":"2.8.0"},"dependencies":{"file-type":{"version":"3.9.0","resolved":"https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz","integrity":"sha1-JXoHg4TR24CHvESdEH1SpSZyuek="}}},"deep-equal":{"version":"1.0.1","resolved":"https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz","integrity":"sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=","dev":true},"deep-extend":{"version":"0.4.2","resolved":"https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz","integrity":"sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="},"deep-is":{"version":"0.1.3","resolved":"https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz","integrity":"sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=","dev":true},"deepmerge":{"version":"1.3.2","resolved":"https://registry.npmjs.org/deepmerge/-/deepmerge-1.3.2.tgz","integrity":"sha1-FmNpFinU2/42T6EqKk8KqGqjoFA=","dev":true},"define-properties":{"version":"1.1.2","resolved":"https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz","integrity":"sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=","dev":true,"requires":{"foreach":"2.0.5","object-keys":"1.0.11"},"dependencies":{"object-keys":{"version":"1.0.11","resolved":"https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz","integrity":"sha1-xUYBd4rVYPEULODgG8yotW0TQm0=","dev":true}}},"define-property":{"version":"1.0.0","resolved":"https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz","integrity":"sha1-dp66rz9KY6rTr56NMEybvnm/sOY=","dev":true,"requires":{"is-descriptor":"1.0.1"}},"defined":{"version":"1.0.0","resolved":"https://registry.npmjs.org/defined/-/defined-1.0.0.tgz","integrity":"sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=","dev":true},"del":{"version":"2.2.2","resolved":"https://registry.npmjs.org/del/-/del-2.2.2.tgz","integrity":"sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=","dev":true,"requires":{"globby":"5.0.0","is-path-cwd":"1.0.0","is-path-in-cwd":"1.0.0","object-assign":"4.1.1","pify":"2.3.0","pinkie-promise":"2.0.1","rimraf":"2.6.2"},"dependencies":{"globby":{"version":"5.0.0","resolved":"https://registry.npmjs.org/globby/-/globby-5.0.0.tgz","integrity":"sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=","dev":true,"requires":{"array-union":"1.0.2","arrify":"1.0.1","glob":"7.1.2","object-assign":"4.1.1","pify":"2.3.0","pinkie-promise":"2.0.1"}}}},"delayed-stream":{"version":"1.0.0","resolved":"https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz","integrity":"sha1-3zrhmayt+31ECqrgsp4icrJOxhk="},"delegates":{"version":"1.0.0","resolved":"https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz","integrity":"sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="},"depd":{"version":"1.1.1","resolved":"https://registry.npmjs.org/depd/-/depd-1.1.1.tgz","integrity":"sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=","dev":true},"des.js":{"version":"1.0.0","resolved":"https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz","integrity":"sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=","dev":true,"requires":{"inherits":"2.0.3","minimalistic-assert":"1.0.0"}},"destroy":{"version":"1.0.4","resolved":"https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz","integrity":"sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=","dev":true},"detect-node":{"version":"2.0.3","resolved":"https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz","integrity":"sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=","dev":true},"detective":{"version":"4.5.0","resolved":"https://registry.npmjs.org/detective/-/detective-4.5.0.tgz","integrity":"sha1-blqMaybmx6JUsca210kNmOyR7dE=","dev":true,"requires":{"acorn":"4.0.13","defined":"1.0.0"},"dependencies":{"acorn":{"version":"4.0.13","resolved":"https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz","integrity":"sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=","dev":true}}},"dev-null":{"version":"0.1.1","resolved":"https://registry.npmjs.org/dev-null/-/dev-null-0.1.1.tgz","integrity":"sha1-WiBc48Ky73e2I41roXnrdMag6Bg=","dev":true},"devtron":{"version":"1.4.0","resolved":"https://registry.npmjs.org/devtron/-/devtron-1.4.0.tgz","integrity":"sha1-tedIvW6Vu+cL/MaKrm/mlhGUQeE=","dev":true,"requires":{"accessibility-developer-tools":"2.12.0","highlight.js":"9.12.0","humanize-plus":"1.8.2"}},"diff":{"version":"3.2.0","resolved":"https://registry.npmjs.org/diff/-/diff-3.2.0.tgz","integrity":"sha1-yc45Okt8vQsFinJck98pkCeGj/k=","dev":true},"diffie-hellman":{"version":"5.0.2","resolved":"https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz","integrity":"sha1-tYNXOScM/ias9jIJn97SoH8gnl4=","dev":true,"requires":{"bn.js":"4.11.8","miller-rabin":"4.0.1","randombytes":"2.0.5"}},"dmg-builder":{"version":"2.1.3","resolved":"https://registry.npmjs.org/dmg-builder/-/dmg-builder-2.1.3.tgz","integrity":"sha512-3H0BNx62NzhTX/UuEf6GHRAl6moZvECufemxqgeByKs3o4ys6SNU+HynzppPTKZ5nNwx4EqcJXtAbhfPuMwHUQ==","dev":true,"requires":{"bluebird-lst":"1.0.5","builder-util":"3.1.0","debug":"3.1.0","fs-extra-p":"4.4.4","iconv-lite":"0.4.19","js-yaml":"3.10.0","parse-color":"1.0.0"}},"dns-equal":{"version":"1.0.0","resolved":"https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz","integrity":"sha1-s55/HabrCnW6nBcySzR1PEfgZU0=","dev":true},"dns-packet":{"version":"1.2.2","resolved":"https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.2.tgz","integrity":"sha512-kN+DjfGF7dJGUL7nWRktL9Z18t1rWP3aQlyZdY8XlpvU3Nc6GeFTQApftcjtWKxAZfiggZSGrCEoszNgvnpwDg==","dev":true,"requires":{"ip":"1.1.5","safe-buffer":"5.1.1"}},"dns-txt":{"version":"2.0.2","resolved":"https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz","integrity":"sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=","dev":true,"requires":{"buffer-indexof":"1.1.1"}},"doctrine":{"version":"1.5.0","resolved":"https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz","integrity":"sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=","dev":true,"requires":{"esutils":"2.0.2","isarray":"1.0.0"}},"dom-helpers":{"version":"3.2.1","resolved":"https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz","integrity":"sha1-MgPgf+0he9H0JLAZc1WC/Deyglo="},"dom-serializer":{"version":"0.1.0","resolved":"https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz","integrity":"sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=","dev":true,"requires":{"domelementtype":"1.1.3","entities":"1.1.1"},"dependencies":{"domelementtype":{"version":"1.1.3","resolved":"https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz","integrity":"sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=","dev":true}}},"dom-walk":{"version":"0.1.1","resolved":"https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz","integrity":"sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=","dev":true},"domain-browser":{"version":"1.1.7","resolved":"https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz","integrity":"sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=","dev":true},"domelementtype":{"version":"1.3.0","resolved":"https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz","integrity":"sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=","dev":true},"domexception":{"version":"1.0.0","resolved":"https://registry.npmjs.org/domexception/-/domexception-1.0.0.tgz","integrity":"sha512-WpwuBlZ2lQRFa4H/4w49deb9rJLot9KmqrKKjMc9qBl7CID+DdC2swoa34ccRl+anL2B6bLp6TjFdIdnzekMBQ==","dev":true},"domhandler":{"version":"2.4.1","resolved":"https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz","integrity":"sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=","dev":true,"requires":{"domelementtype":"1.3.0"}},"domready":{"version":"1.0.8","resolved":"https://registry.npmjs.org/domready/-/domready-1.0.8.tgz","integrity":"sha1-kfJS5Ze2Wvd+dFriTdAYXV4m1Yw=","dev":true},"domutils":{"version":"1.6.2","resolved":"https://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz","integrity":"sha1-GVjMC0yUJuntNn+xyOhUiRsPo/8=","dev":true,"requires":{"dom-serializer":"0.1.0","domelementtype":"1.3.0"}},"dot-prop":{"version":"4.2.0","resolved":"https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz","integrity":"sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==","dev":true,"requires":{"is-obj":"1.0.1"}},"dotenv":{"version":"4.0.0","resolved":"https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz","integrity":"sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=","dev":true},"dotenv-expand":{"version":"4.0.1","resolved":"https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.0.1.tgz","integrity":"sha1-aP3cFWGBTgoQlkERBX/xOM7X16g=","dev":true},"duplexer3":{"version":"0.1.4","resolved":"https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz","integrity":"sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=","dev":true},"ecc-jsbn":{"version":"0.1.1","resolved":"https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz","integrity":"sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=","optional":true,"requires":{"jsbn":"0.1.1"}},"ecdsa-sig-formatter":{"version":"1.0.9","resolved":"https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz","integrity":"sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=","dev":true,"requires":{"base64url":"2.0.0","safe-buffer":"5.1.1"}},"ee-first":{"version":"1.1.1","resolved":"https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz","integrity":"sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=","dev":true},"ejs":{"version":"2.5.7","resolved":"https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz","integrity":"sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=","dev":true},"electron":{"version":"1.8.1","resolved":"https://registry.npmjs.org/electron/-/electron-1.8.1.tgz","integrity":"sha1-GbbznyAT4gSpGmC8MIbcekoH7Yg=","dev":true,"requires":{"@types/node":"8.0.47","electron-download":"3.3.0","extract-zip":"1.6.5"}},"electron-builder":{"version":"19.41.0","resolved":"https://registry.npmjs.org/electron-builder/-/electron-builder-19.41.0.tgz","integrity":"sha512-ncvGpEJEZjvJLVi9dqi6pWR4pqaw2e99dKRiXlFmsFPQXpmlEQMEmP/S9yoJkb3RgOEzVRKFMHmtwvZ73LGD+g==","dev":true,"requires":{"7zip-bin":"2.2.7","app-package-builder":"1.3.1","asar-integrity":"0.2.3","async-exit-hook":"2.0.1","bluebird-lst":"1.0.5","builder-util":"3.1.0","builder-util-runtime":"2.4.0","chalk":"2.3.0","chromium-pickle-js":"0.2.0","cuint":"0.2.2","debug":"3.1.0","dmg-builder":"2.1.3","ejs":"2.5.7","electron-download-tf":"4.3.4","electron-osx-sign":"0.4.7","electron-publish":"19.40.0","fs-extra-p":"4.4.4","hosted-git-info":"2.5.0","is-ci":"1.0.10","isbinaryfile":"3.0.2","js-yaml":"3.10.0","lazy-val":"1.0.2","minimatch":"3.0.4","normalize-package-data":"2.4.0","plist":"2.1.0","read-config-file":"1.2.0","sanitize-filename":"1.6.1","semver":"5.4.1","temp-file":"2.0.3","update-notifier":"2.3.0","yargs":"10.0.3"},"dependencies":{"ansi-styles":{"version":"3.2.0","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz","integrity":"sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==","dev":true,"requires":{"color-convert":"1.9.0"}},"chalk":{"version":"2.3.0","resolved":"https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz","integrity":"sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==","dev":true,"requires":{"ansi-styles":"3.2.0","escape-string-regexp":"1.0.5","supports-color":"4.5.0"}},"electron-download-tf":{"version":"4.3.4","resolved":"https://registry.npmjs.org/electron-download-tf/-/electron-download-tf-4.3.4.tgz","integrity":"sha512-SQYDGMLpTgty1bx3NycuDb7dNPzktVSdK2sqPZjyRocauq/uN/V4S2lcpFVLupaHhKlD8zozm9fTpm5UdohvTg==","dev":true,"requires":{"debug":"3.1.0","env-paths":"1.0.0","fs-extra":"4.0.2","minimist":"1.2.0","nugget":"2.0.1","path-exists":"3.0.0","rc":"1.2.2","semver":"5.4.1","sumchecker":"2.0.2"}},"has-flag":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz","integrity":"sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=","dev":true},"minimist":{"version":"1.2.0","resolved":"https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz","integrity":"sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=","dev":true},"path-exists":{"version":"3.0.0","resolved":"https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz","integrity":"sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=","dev":true},"sumchecker":{"version":"2.0.2","resolved":"https://registry.npmjs.org/sumchecker/-/sumchecker-2.0.2.tgz","integrity":"sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=","dev":true,"requires":{"debug":"2.6.9"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}}}},"supports-color":{"version":"4.5.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz","integrity":"sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=","dev":true,"requires":{"has-flag":"2.0.0"}}}},"electron-chromedriver":{"version":"1.7.1","resolved":"https://registry.npmjs.org/electron-chromedriver/-/electron-chromedriver-1.7.1.tgz","integrity":"sha1-AIyXl2AHqk6xhJHuCV6U0X7kdhA=","dev":true,"requires":{"electron-download":"4.1.0","extract-zip":"1.6.5"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}},"electron-download":{"version":"4.1.0","resolved":"https://registry.npmjs.org/electron-download/-/electron-download-4.1.0.tgz","integrity":"sha1-v5MsdG8vh//MCdHdRy8v9rkYeEU=","dev":true,"requires":{"debug":"2.6.9","env-paths":"1.0.0","fs-extra":"2.1.2","minimist":"1.2.0","nugget":"2.0.1","path-exists":"3.0.0","rc":"1.2.2","semver":"5.4.1","sumchecker":"2.0.2"}},"fs-extra":{"version":"2.1.2","resolved":"https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz","integrity":"sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=","dev":true,"requires":{"graceful-fs":"4.1.11","jsonfile":"2.4.0"}},"jsonfile":{"version":"2.4.0","resolved":"https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz","integrity":"sha1-NzaitCi4e72gzIO1P6PWM6NcKug=","dev":true,"requires":{"graceful-fs":"4.1.11"}},"minimist":{"version":"1.2.0","resolved":"https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz","integrity":"sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=","dev":true},"path-exists":{"version":"3.0.0","resolved":"https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz","integrity":"sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=","dev":true},"sumchecker":{"version":"2.0.2","resolved":"https://registry.npmjs.org/sumchecker/-/sumchecker-2.0.2.tgz","integrity":"sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=","dev":true,"requires":{"debug":"2.6.9"}}}},"electron-download":{"version":"3.3.0","resolved":"https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz","integrity":"sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=","dev":true,"requires":{"debug":"2.6.9","fs-extra":"0.30.0","home-path":"1.0.5","minimist":"1.2.0","nugget":"2.0.1","path-exists":"2.1.0","rc":"1.2.2","semver":"5.4.1","sumchecker":"1.3.1"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}},"fs-extra":{"version":"0.30.0","resolved":"https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz","integrity":"sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=","dev":true,"requires":{"graceful-fs":"4.1.11","jsonfile":"2.4.0","klaw":"1.3.1","path-is-absolute":"1.0.1","rimraf":"2.6.2"}},"jsonfile":{"version":"2.4.0","resolved":"https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz","integrity":"sha1-NzaitCi4e72gzIO1P6PWM6NcKug=","dev":true,"requires":{"graceful-fs":"4.1.11"}},"minimist":{"version":"1.2.0","resolved":"https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz","integrity":"sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=","dev":true}}},"electron-is-dev":{"version":"0.3.0","resolved":"https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-0.3.0.tgz","integrity":"sha1-FOb9pcaOnk7L7/nM8DfL18BcWv4="},"electron-osx-sign":{"version":"0.4.7","resolved":"https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.7.tgz","integrity":"sha1-HXVkeoJ0jqzUi+pwYW7IP/rePuU=","dev":true,"requires":{"bluebird":"3.5.1","compare-version":"0.1.2","debug":"2.6.9","isbinaryfile":"3.0.2","minimist":"1.2.0","plist":"2.1.0"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}},"minimist":{"version":"1.2.0","resolved":"https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz","integrity":"sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=","dev":true}}},"electron-publish":{"version":"19.40.0","resolved":"https://registry.npmjs.org/electron-publish/-/electron-publish-19.40.0.tgz","integrity":"sha512-8SZOp+V3o65IYfKjOgkqis16uL3S6gQLK08MYs9ceGelQ5IEvC69lJslk0hCTAxwfczH6eL7QlGS3A/zAyWsbQ==","dev":true,"requires":{"bluebird-lst":"1.0.5","builder-util":"3.1.0","builder-util-runtime":"2.4.0","chalk":"2.1.0","fs-extra-p":"4.4.4","mime":"2.0.3"},"dependencies":{"ansi-styles":{"version":"3.2.0","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz","integrity":"sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==","dev":true,"requires":{"color-convert":"1.9.0"}},"chalk":{"version":"2.1.0","resolved":"https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz","integrity":"sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==","dev":true,"requires":{"ansi-styles":"3.2.0","escape-string-regexp":"1.0.5","supports-color":"4.5.0"}},"has-flag":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz","integrity":"sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=","dev":true},"supports-color":{"version":"4.5.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz","integrity":"sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=","dev":true,"requires":{"has-flag":"2.0.0"}}}},"electron-publisher-s3":{"version":"19.40.0","resolved":"https://registry.npmjs.org/electron-publisher-s3/-/electron-publisher-s3-19.40.0.tgz","integrity":"sha512-I4KBEcPAkAchat0uoB/7eP1FNok900XMkGZvRLag+B1io7AVJLGvvNPTkA0oKI1ZC/eYlUSGrDdDF27uFmejKQ==","dev":true,"requires":{"aws-sdk":"2.140.0","bluebird-lst":"1.0.5","builder-util":"3.1.0","electron-publish":"19.40.0","fs-extra-p":"4.4.4","mime":"2.0.3"}},"electron-to-chromium":{"version":"1.3.27","resolved":"https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz","integrity":"sha1-eOy4o5kGYYe7N07t412ccFZagD0=","dev":true},"electron-updater":{"version":"2.15.0","resolved":"https://registry.npmjs.org/electron-updater/-/electron-updater-2.15.0.tgz","integrity":"sha512-xHGUPJav7EOKrEs/Tdlv6HFhtzkDfemLKew+S4iIjXyGPuV8hg7bFnbrHdOXid1iQF6ZE2QiNa1iT1Or2gnZsQ==","requires":{"bluebird-lst":"1.0.5","builder-util-runtime":"2.4.0","electron-is-dev":"0.3.0","fs-extra-p":"4.4.4","js-yaml":"3.10.0","lazy-val":"1.0.2","lodash.isequal":"4.5.0","semver":"5.4.1","source-map-support":"0.5.0"}},"elegant-spinner":{"version":"1.0.1","resolved":"https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz","integrity":"sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=","dev":true},"elliptic":{"version":"6.4.0","resolved":"https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz","integrity":"sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=","dev":true,"requires":{"bn.js":"4.11.8","brorand":"1.1.0","hash.js":"1.1.3","hmac-drbg":"1.0.1","inherits":"2.0.3","minimalistic-assert":"1.0.0","minimalistic-crypto-utils":"1.0.1"}},"emojis-list":{"version":"2.1.0","resolved":"https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz","integrity":"sha1-TapNnbAPmBmIDHn6RXrlsJof04k=","dev":true},"encodeurl":{"version":"1.0.1","resolved":"https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz","integrity":"sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=","dev":true},"encoding":{"version":"0.1.12","resolved":"https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz","integrity":"sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=","requires":{"iconv-lite":"0.4.19"}},"end-of-stream":{"version":"1.4.0","resolved":"https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz","integrity":"sha1-epDYM+/abPpurA9JSduw+tOmMgY=","requires":{"once":"1.4.0"}},"enhanced-resolve":{"version":"3.3.0","resolved":"https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz","integrity":"sha512-2qbxE7ek3YxPJ1ML6V+satHkzHpJQKWkRHmRx6mfAoW59yP8YH8BFplbegSP+u2hBd6B6KCOpvJQ3dZAP+hkpg==","dev":true,"requires":{"graceful-fs":"4.1.11","memory-fs":"0.4.1","object-assign":"4.1.1","tapable":"0.2.8"}},"entities":{"version":"1.1.1","resolved":"https://registry.npmjs.org/entities/-/entities-1.1.1.tgz","integrity":"sha1-blwtClYhtdra7O+AuQ7ftc13cvA=","dev":true},"env-paths":{"version":"1.0.0","resolved":"https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz","integrity":"sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=","dev":true},"envify":{"version":"3.4.1","resolved":"https://registry.npmjs.org/envify/-/envify-3.4.1.tgz","integrity":"sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=","dev":true,"requires":{"jstransform":"11.0.3","through":"2.3.8"}},"errno":{"version":"0.1.4","resolved":"https://registry.npmjs.org/errno/-/errno-0.1.4.tgz","integrity":"sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=","dev":true,"requires":{"prr":"0.0.0"}},"error-ex":{"version":"1.3.1","resolved":"https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz","integrity":"sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=","dev":true,"requires":{"is-arrayish":"0.2.1"}},"error-stack-parser":{"version":"1.3.6","resolved":"https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz","integrity":"sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=","dev":true,"requires":{"stackframe":"0.3.1"}},"es-abstract":{"version":"1.9.0","resolved":"https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz","integrity":"sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==","dev":true,"requires":{"es-to-primitive":"1.1.1","function-bind":"1.1.1","has":"1.0.1","is-callable":"1.1.3","is-regex":"1.0.4"}},"es-to-primitive":{"version":"1.1.1","resolved":"https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz","integrity":"sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=","dev":true,"requires":{"is-callable":"1.1.3","is-date-object":"1.0.1","is-symbol":"1.0.1"}},"es5-ext":{"version":"0.10.35","resolved":"https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz","integrity":"sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=","dev":true,"requires":{"es6-iterator":"2.0.3","es6-symbol":"3.1.1"}},"es6-iterator":{"version":"2.0.3","resolved":"https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz","integrity":"sha1-p96IkUGgWpSwhUQDstCg+/qY87c=","dev":true,"requires":{"d":"1.0.0","es5-ext":"0.10.35","es6-symbol":"3.1.1"}},"es6-map":{"version":"0.1.5","resolved":"https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz","integrity":"sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=","dev":true,"requires":{"d":"1.0.0","es5-ext":"0.10.35","es6-iterator":"2.0.3","es6-set":"0.1.5","es6-symbol":"3.1.1","event-emitter":"0.3.5"}},"es6-promise":{"version":"4.1.1","resolved":"https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz","integrity":"sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==","dev":true},"es6-set":{"version":"0.1.5","resolved":"https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz","integrity":"sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=","dev":true,"requires":{"d":"1.0.0","es5-ext":"0.10.35","es6-iterator":"2.0.3","es6-symbol":"3.1.1","event-emitter":"0.3.5"}},"es6-symbol":{"version":"3.1.1","resolved":"https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz","integrity":"sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=","dev":true,"requires":{"d":"1.0.0","es5-ext":"0.10.35"}},"es6-weak-map":{"version":"2.0.2","resolved":"https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz","integrity":"sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=","dev":true,"requires":{"d":"1.0.0","es5-ext":"0.10.35","es6-iterator":"2.0.3","es6-symbol":"3.1.1"}},"escape-html":{"version":"1.0.3","resolved":"https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz","integrity":"sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=","dev":true},"escape-string-regexp":{"version":"1.0.5","resolved":"https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz","integrity":"sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=","dev":true},"escodegen":{"version":"1.9.0","resolved":"https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz","integrity":"sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==","dev":true,"requires":{"esprima":"3.1.3","estraverse":"4.2.0","esutils":"2.0.2","optionator":"0.8.2","source-map":"0.5.7"},"dependencies":{"esprima":{"version":"3.1.3","resolved":"https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz","integrity":"sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=","dev":true},"source-map":{"version":"0.5.7","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz","integrity":"sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=","dev":true,"optional":true}}},"escope":{"version":"3.6.0","resolved":"https://registry.npmjs.org/escope/-/escope-3.6.0.tgz","integrity":"sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=","dev":true,"requires":{"es6-map":"0.1.5","es6-weak-map":"2.0.2","esrecurse":"4.2.0","estraverse":"4.2.0"}},"eslint":{"version":"2.13.1","resolved":"https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz","integrity":"sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=","dev":true,"requires":{"chalk":"1.1.3","concat-stream":"1.6.0","debug":"2.6.9","doctrine":"1.5.0","es6-map":"0.1.5","escope":"3.6.0","espree":"3.5.1","estraverse":"4.2.0","esutils":"2.0.2","file-entry-cache":"1.3.1","glob":"7.1.2","globals":"9.18.0","ignore":"3.3.6","imurmurhash":"0.1.4","inquirer":"0.12.0","is-my-json-valid":"2.16.1","is-resolvable":"1.0.0","js-yaml":"3.10.0","json-stable-stringify":"1.0.1","levn":"0.3.0","lodash":"4.17.4","mkdirp":"0.5.1","optionator":"0.8.2","path-is-absolute":"1.0.1","path-is-inside":"1.0.2","pluralize":"1.2.1","progress":"1.1.8","require-uncached":"1.0.3","shelljs":"0.6.1","strip-json-comments":"1.0.4","table":"3.8.3","text-table":"0.2.0","user-home":"2.0.0"},"dependencies":{"ansi-styles":{"version":"2.2.1","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz","integrity":"sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=","dev":true},"chalk":{"version":"1.1.3","resolved":"https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz","integrity":"sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=","dev":true,"requires":{"ansi-styles":"2.2.1","escape-string-regexp":"1.0.5","has-ansi":"2.0.0","strip-ansi":"3.0.1","supports-color":"2.0.0"}},"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}},"has-ansi":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz","integrity":"sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=","dev":true,"requires":{"ansi-regex":"2.1.1"}},"progress":{"version":"1.1.8","resolved":"https://registry.npmjs.org/progress/-/progress-1.1.8.tgz","integrity":"sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=","dev":true},"strip-json-comments":{"version":"1.0.4","resolved":"https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz","integrity":"sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=","dev":true},"supports-color":{"version":"2.0.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz","integrity":"sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=","dev":true}}},"eslint-plugin-prettier":{"version":"2.3.1","resolved":"https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.3.1.tgz","integrity":"sha512-AV8shBlGN9tRZffj5v/f4uiQWlP3qiQ+lh+BhTqRLuKSyczx+HRWVkVZaf7dOmguxghAH1wftnou/JUEEChhGg==","dev":true,"requires":{"fast-diff":"1.1.2","jest-docblock":"21.2.0"}},"espree":{"version":"3.5.1","resolved":"https://registry.npmjs.org/espree/-/espree-3.5.1.tgz","integrity":"sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=","dev":true,"requires":{"acorn":"5.1.2","acorn-jsx":"3.0.1"}},"esprima":{"version":"4.0.0","resolved":"https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz","integrity":"sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="},"esrecurse":{"version":"4.2.0","resolved":"https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz","integrity":"sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=","dev":true,"requires":{"estraverse":"4.2.0","object-assign":"4.1.1"}},"estraverse":{"version":"4.2.0","resolved":"https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz","integrity":"sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=","dev":true},"esutils":{"version":"2.0.2","resolved":"https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz","integrity":"sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=","dev":true},"etag":{"version":"1.8.1","resolved":"https://registry.npmjs.org/etag/-/etag-1.8.1.tgz","integrity":"sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=","dev":true},"event-emitter":{"version":"0.3.5","resolved":"https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz","integrity":"sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=","dev":true,"requires":{"d":"1.0.0","es5-ext":"0.10.35"}},"eventemitter3":{"version":"1.2.0","resolved":"https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz","integrity":"sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=","dev":true},"events":{"version":"1.1.1","resolved":"https://registry.npmjs.org/events/-/events-1.1.1.tgz","integrity":"sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=","dev":true},"eventsource":{"version":"0.1.6","resolved":"https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz","integrity":"sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=","dev":true,"requires":{"original":"1.0.0"}},"evp_bytestokey":{"version":"1.0.3","resolved":"https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz","integrity":"sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==","dev":true,"requires":{"md5.js":"1.3.4","safe-buffer":"5.1.1"}},"execa":{"version":"0.7.0","resolved":"https://registry.npmjs.org/execa/-/execa-0.7.0.tgz","integrity":"sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=","dev":true,"requires":{"cross-spawn":"5.1.0","get-stream":"3.0.0","is-stream":"1.1.0","npm-run-path":"2.0.2","p-finally":"1.0.0","signal-exit":"3.0.2","strip-eof":"1.0.0"},"dependencies":{"get-stream":{"version":"3.0.0","resolved":"https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz","integrity":"sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=","dev":true}}},"exit-hook":{"version":"1.1.1","resolved":"https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz","integrity":"sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=","dev":true},"expand-brackets":{"version":"2.1.4","resolved":"https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz","integrity":"sha1-t3c14xXOMPa27/D4OwQVGiJEliI=","dev":true,"requires":{"debug":"2.6.9","define-property":"0.2.5","extend-shallow":"2.0.1","posix-character-classes":"0.1.1","regex-not":"1.0.0","snapdragon":"0.8.1","to-regex":"3.0.1"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}},"define-property":{"version":"0.2.5","resolved":"https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz","integrity":"sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=","dev":true,"requires":{"is-descriptor":"0.1.6"}},"is-descriptor":{"version":"0.1.6","resolved":"https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz","integrity":"sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==","dev":true,"requires":{"is-accessor-descriptor":"0.1.6","is-data-descriptor":"0.1.4","kind-of":"5.1.0"}},"kind-of":{"version":"5.1.0","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz","integrity":"sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==","dev":true}}},"expand-range":{"version":"1.8.2","resolved":"https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz","integrity":"sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=","dev":true,"requires":{"fill-range":"2.2.3"},"dependencies":{"fill-range":{"version":"2.2.3","resolved":"https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz","integrity":"sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=","dev":true,"requires":{"is-number":"2.1.0","isobject":"2.1.0","randomatic":"1.1.7","repeat-element":"1.1.2","repeat-string":"1.6.1"}},"is-number":{"version":"2.1.0","resolved":"https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz","integrity":"sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=","dev":true,"requires":{"kind-of":"3.2.2"}},"isobject":{"version":"2.1.0","resolved":"https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz","integrity":"sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=","dev":true,"requires":{"isarray":"1.0.0"}},"kind-of":{"version":"3.2.2","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz","integrity":"sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=","dev":true,"requires":{"is-buffer":"1.1.5"}}}},"expand-template":{"version":"1.1.0","resolved":"https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz","integrity":"sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ==","dev":true},"express":{"version":"4.16.2","resolved":"https://registry.npmjs.org/express/-/express-4.16.2.tgz","integrity":"sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=","dev":true,"requires":{"accepts":"1.3.4","array-flatten":"1.1.1","body-parser":"1.18.2","content-disposition":"0.5.2","content-type":"1.0.4","cookie":"0.3.1","cookie-signature":"1.0.6","debug":"2.6.9","depd":"1.1.1","encodeurl":"1.0.1","escape-html":"1.0.3","etag":"1.8.1","finalhandler":"1.1.0","fresh":"0.5.2","merge-descriptors":"1.0.1","methods":"1.1.2","on-finished":"2.3.0","parseurl":"1.3.2","path-to-regexp":"0.1.7","proxy-addr":"2.0.2","qs":"6.5.1","range-parser":"1.2.0","safe-buffer":"5.1.1","send":"0.16.1","serve-static":"1.13.1","setprototypeof":"1.1.0","statuses":"1.3.1","type-is":"1.6.15","utils-merge":"1.0.1","vary":"1.1.2"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}},"path-to-regexp":{"version":"0.1.7","resolved":"https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz","integrity":"sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=","dev":true},"qs":{"version":"6.5.1","resolved":"https://registry.npmjs.org/qs/-/qs-6.5.1.tgz","integrity":"sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==","dev":true},"setprototypeof":{"version":"1.1.0","resolved":"https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz","integrity":"sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==","dev":true},"statuses":{"version":"1.3.1","resolved":"https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz","integrity":"sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=","dev":true}}},"extend":{"version":"3.0.1","resolved":"https://registry.npmjs.org/extend/-/extend-3.0.1.tgz","integrity":"sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="},"extend-shallow":{"version":"2.0.1","resolved":"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz","integrity":"sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=","dev":true,"requires":{"is-extendable":"0.1.1"}},"external-editor":{"version":"2.0.5","resolved":"https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz","integrity":"sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==","dev":true,"requires":{"iconv-lite":"0.4.19","jschardet":"1.5.1","tmp":"0.0.33"}},"extglob":{"version":"2.0.2","resolved":"https://registry.npmjs.org/extglob/-/extglob-2.0.2.tgz","integrity":"sha512-I0+eZBH+jFGL8F5BnIz2ON2nKCjTS3AS3H/5PeSmCp7UVC70Ym8IhdRiQly2juKYQ//f7z1aj1BRpQniFJoU1w==","dev":true,"requires":{"array-unique":"0.3.2","define-property":"1.0.0","expand-brackets":"2.1.4","extend-shallow":"2.0.1","fragment-cache":"0.2.1","regex-not":"1.0.0","snapdragon":"0.8.1","to-regex":"3.0.1"}},"extract-zip":{"version":"1.6.5","resolved":"https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz","integrity":"sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=","dev":true,"requires":{"concat-stream":"1.6.0","debug":"2.2.0","mkdirp":"0.5.0","yauzl":"2.4.1"},"dependencies":{"debug":{"version":"2.2.0","resolved":"https://registry.npmjs.org/debug/-/debug-2.2.0.tgz","integrity":"sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=","dev":true,"requires":{"ms":"0.7.1"}},"mkdirp":{"version":"0.5.0","resolved":"https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz","integrity":"sha1-HXMHam35hs2TROFecfzAWkyavxI=","dev":true,"requires":{"minimist":"0.0.8"}},"ms":{"version":"0.7.1","resolved":"https://registry.npmjs.org/ms/-/ms-0.7.1.tgz","integrity":"sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=","dev":true},"yauzl":{"version":"2.4.1","resolved":"https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz","integrity":"sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=","dev":true,"requires":{"fd-slicer":"1.0.1"}}}},"extsprintf":{"version":"1.3.0","resolved":"https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz","integrity":"sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="},"eyes":{"version":"0.1.8","resolved":"https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz","integrity":"sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=","dev":true},"faker":{"version":"4.1.0","resolved":"https://registry.npmjs.org/faker/-/faker-4.1.0.tgz","integrity":"sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="},"fast-deep-equal":{"version":"1.0.0","resolved":"https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz","integrity":"sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="},"fast-diff":{"version":"1.1.2","resolved":"https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz","integrity":"sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==","dev":true},"fast-json-stable-stringify":{"version":"2.0.0","resolved":"https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz","integrity":"sha1-1RQsDK7msRifh9OnYREGT4bIu/I="},"fast-levenshtein":{"version":"2.0.6","resolved":"https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz","integrity":"sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=","dev":true},"fastparse":{"version":"1.1.1","resolved":"https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz","integrity":"sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=","dev":true},"faye-websocket":{"version":"0.10.0","resolved":"https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz","integrity":"sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=","dev":true,"requires":{"websocket-driver":"0.7.0"}},"fbjs":{"version":"0.8.16","resolved":"https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz","integrity":"sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=","requires":{"core-js":"1.2.7","isomorphic-fetch":"2.2.1","loose-envify":"1.3.1","object-assign":"4.1.1","promise":"7.3.1","setimmediate":"1.0.5","ua-parser-js":"0.7.17"}},"fd-slicer":{"version":"1.0.1","resolved":"https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz","integrity":"sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=","requires":{"pend":"1.2.0"}},"figures":{"version":"1.7.0","resolved":"https://registry.npmjs.org/figures/-/figures-1.7.0.tgz","integrity":"sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=","dev":true,"requires":{"escape-string-regexp":"1.0.5","object-assign":"4.1.1"}},"file-entry-cache":{"version":"1.3.1","resolved":"https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz","integrity":"sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=","dev":true,"requires":{"flat-cache":"1.3.0","object-assign":"4.1.1"}},"file-loader":{"version":"1.1.5","resolved":"https://registry.npmjs.org/file-loader/-/file-loader-1.1.5.tgz","integrity":"sha512-RzGHDatcVNpGISTvCpfUfOGpYuSR7HSsSg87ki+wF6rw1Hm0RALPTiAdsxAq1UwLf0RRhbe22/eHK6nhXspiOQ==","dev":true,"requires":{"loader-utils":"1.1.0","schema-utils":"0.3.0"}},"file-type":{"version":"5.2.0","resolved":"https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz","integrity":"sha1-LdvqfHP/42No365J3DOMBYwritY="},"filename-regex":{"version":"2.0.1","resolved":"https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz","integrity":"sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=","dev":true},"fill-range":{"version":"4.0.0","resolved":"https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz","integrity":"sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=","dev":true,"requires":{"extend-shallow":"2.0.1","is-number":"3.0.0","repeat-string":"1.6.1","to-regex-range":"2.1.1"}},"finalhandler":{"version":"1.1.0","resolved":"https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz","integrity":"sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=","dev":true,"requires":{"debug":"2.6.9","encodeurl":"1.0.1","escape-html":"1.0.3","on-finished":"2.3.0","parseurl":"1.3.2","statuses":"1.3.1","unpipe":"1.0.0"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}},"statuses":{"version":"1.3.1","resolved":"https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz","integrity":"sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=","dev":true}}},"find-replace":{"version":"1.0.3","resolved":"https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz","integrity":"sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=","requires":{"array-back":"1.0.4","test-value":"2.1.0"},"dependencies":{"array-back":{"version":"1.0.4","resolved":"https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz","integrity":"sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=","requires":{"typical":"2.6.1"}}}},"find-up":{"version":"1.1.2","resolved":"https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz","integrity":"sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=","dev":true,"requires":{"path-exists":"2.1.0","pinkie-promise":"2.0.1"}},"flat-cache":{"version":"1.3.0","resolved":"https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz","integrity":"sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=","dev":true,"requires":{"circular-json":"0.3.3","del":"2.2.2","graceful-fs":"4.1.11","write":"0.2.1"}},"flatten":{"version":"1.0.2","resolved":"https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz","integrity":"sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=","dev":true},"font-awesome":{"version":"4.7.0","resolved":"https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz","integrity":"sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="},"for-in":{"version":"1.0.2","resolved":"https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz","integrity":"sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=","dev":true},"for-own":{"version":"0.1.5","resolved":"https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz","integrity":"sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=","dev":true,"requires":{"for-in":"1.0.2"}},"foreach":{"version":"2.0.5","resolved":"https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz","integrity":"sha1-C+4AUBiusmDQo6865ljdATbsG5k=","dev":true},"forever-agent":{"version":"0.6.1","resolved":"https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz","integrity":"sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="},"form-data":{"version":"2.1.4","resolved":"https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz","integrity":"sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=","requires":{"asynckit":"0.4.0","combined-stream":"1.0.5","mime-types":"2.1.17"}},"formidable":{"version":"1.1.1","resolved":"https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz","integrity":"sha1-lriIb3w8NQi5Mta9cMTTqI818ak=","dev":true},"forwarded":{"version":"0.1.2","resolved":"https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz","integrity":"sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=","dev":true},"fragment-cache":{"version":"0.2.1","resolved":"https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz","integrity":"sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=","dev":true,"requires":{"map-cache":"0.2.2"}},"fresh":{"version":"0.5.2","resolved":"https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz","integrity":"sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=","dev":true},"front-matter":{"version":"2.1.2","resolved":"https://registry.npmjs.org/front-matter/-/front-matter-2.1.2.tgz","integrity":"sha1-91mDufL0E75ljJPf172M5AePXNs=","dev":true,"requires":{"js-yaml":"3.10.0"}},"fs-extra":{"version":"4.0.2","resolved":"https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz","integrity":"sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=","requires":{"graceful-fs":"4.1.11","jsonfile":"4.0.0","universalify":"0.1.1"}},"fs-extra-p":{"version":"4.4.4","resolved":"https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.4.4.tgz","integrity":"sha512-zHsMNJWhXD184QfHKEIFSQSgAFNV7v9J+Nt2XpaLZp2nTz6WxZNV+R4G2uYeGeLTMaKvUZiqGKrH/4iFCupcUA==","requires":{"bluebird-lst":"1.0.5","fs-extra":"4.0.2"}},"fs.realpath":{"version":"1.0.0","resolved":"https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz","integrity":"sha1-FQStJSMVjKpA20onh8sBQRmU6k8="},"fsevents":{"version":"1.1.2","resolved":"https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz","integrity":"sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==","dev":true,"optional":true,"requires":{"nan":"2.7.0","node-pre-gyp":"0.6.36"},"dependencies":{"abbrev":{"version":"1.1.0","bundled":true,"dev":true,"optional":true},"ajv":{"version":"4.11.8","bundled":true,"dev":true,"optional":true,"requires":{"co":"4.6.0","json-stable-stringify":"1.0.1"}},"ansi-regex":{"version":"2.1.1","bundled":true,"dev":true},"aproba":{"version":"1.1.1","bundled":true,"dev":true,"optional":true},"are-we-there-yet":{"version":"1.1.4","bundled":true,"dev":true,"optional":true,"requires":{"delegates":"1.0.0","readable-stream":"2.2.9"}},"asn1":{"version":"0.2.3","bundled":true,"dev":true,"optional":true},"assert-plus":{"version":"0.2.0","bundled":true,"dev":true,"optional":true},"asynckit":{"version":"0.4.0","bundled":true,"dev":true,"optional":true},"aws-sign2":{"version":"0.6.0","bundled":true,"dev":true,"optional":true},"aws4":{"version":"1.6.0","bundled":true,"dev":true,"optional":true},"balanced-match":{"version":"0.4.2","bundled":true,"dev":true},"bcrypt-pbkdf":{"version":"1.0.1","bundled":true,"dev":true,"optional":true,"requires":{"tweetnacl":"0.14.5"}},"block-stream":{"version":"0.0.9","bundled":true,"dev":true,"requires":{"inherits":"2.0.3"}},"boom":{"version":"2.10.1","bundled":true,"dev":true,"requires":{"hoek":"2.16.3"}},"brace-expansion":{"version":"1.1.7","bundled":true,"dev":true,"requires":{"balanced-match":"0.4.2","concat-map":"0.0.1"}},"buffer-shims":{"version":"1.0.0","bundled":true,"dev":true},"caseless":{"version":"0.12.0","bundled":true,"dev":true,"optional":true},"co":{"version":"4.6.0","bundled":true,"dev":true,"optional":true},"code-point-at":{"version":"1.1.0","bundled":true,"dev":true},"combined-stream":{"version":"1.0.5","bundled":true,"dev":true,"requires":{"delayed-stream":"1.0.0"}},"concat-map":{"version":"0.0.1","bundled":true,"dev":true},"console-control-strings":{"version":"1.1.0","bundled":true,"dev":true},"core-util-is":{"version":"1.0.2","bundled":true,"dev":true},"cryptiles":{"version":"2.0.5","bundled":true,"dev":true,"optional":true,"requires":{"boom":"2.10.1"}},"dashdash":{"version":"1.14.1","bundled":true,"dev":true,"optional":true,"requires":{"assert-plus":"1.0.0"},"dependencies":{"assert-plus":{"version":"1.0.0","bundled":true,"dev":true,"optional":true}}},"debug":{"version":"2.6.8","bundled":true,"dev":true,"optional":true,"requires":{"ms":"2.0.0"}},"deep-extend":{"version":"0.4.2","bundled":true,"dev":true,"optional":true},"delayed-stream":{"version":"1.0.0","bundled":true,"dev":true},"delegates":{"version":"1.0.0","bundled":true,"dev":true,"optional":true},"ecc-jsbn":{"version":"0.1.1","bundled":true,"dev":true,"optional":true,"requires":{"jsbn":"0.1.1"}},"extend":{"version":"3.0.1","bundled":true,"dev":true,"optional":true},"extsprintf":{"version":"1.0.2","bundled":true,"dev":true},"forever-agent":{"version":"0.6.1","bundled":true,"dev":true,"optional":true},"form-data":{"version":"2.1.4","bundled":true,"dev":true,"optional":true,"requires":{"asynckit":"0.4.0","combined-stream":"1.0.5","mime-types":"2.1.15"}},"fs.realpath":{"version":"1.0.0","bundled":true,"dev":true},"fstream":{"version":"1.0.11","bundled":true,"dev":true,"requires":{"graceful-fs":"4.1.11","inherits":"2.0.3","mkdirp":"0.5.1","rimraf":"2.6.1"}},"fstream-ignore":{"version":"1.0.5","bundled":true,"dev":true,"optional":true,"requires":{"fstream":"1.0.11","inherits":"2.0.3","minimatch":"3.0.4"}},"gauge":{"version":"2.7.4","bundled":true,"dev":true,"optional":true,"requires":{"aproba":"1.1.1","console-control-strings":"1.1.0","has-unicode":"2.0.1","object-assign":"4.1.1","signal-exit":"3.0.2","string-width":"1.0.2","strip-ansi":"3.0.1","wide-align":"1.1.2"}},"getpass":{"version":"0.1.7","bundled":true,"dev":true,"optional":true,"requires":{"assert-plus":"1.0.0"},"dependencies":{"assert-plus":{"version":"1.0.0","bundled":true,"dev":true,"optional":true}}},"glob":{"version":"7.1.2","bundled":true,"dev":true,"requires":{"fs.realpath":"1.0.0","inflight":"1.0.6","inherits":"2.0.3","minimatch":"3.0.4","once":"1.4.0","path-is-absolute":"1.0.1"}},"graceful-fs":{"version":"4.1.11","bundled":true,"dev":true},"har-schema":{"version":"1.0.5","bundled":true,"dev":true,"optional":true},"har-validator":{"version":"4.2.1","bundled":true,"dev":true,"optional":true,"requires":{"ajv":"4.11.8","har-schema":"1.0.5"}},"has-unicode":{"version":"2.0.1","bundled":true,"dev":true,"optional":true},"hawk":{"version":"3.1.3","bundled":true,"dev":true,"optional":true,"requires":{"boom":"2.10.1","cryptiles":"2.0.5","hoek":"2.16.3","sntp":"1.0.9"}},"hoek":{"version":"2.16.3","bundled":true,"dev":true},"http-signature":{"version":"1.1.1","bundled":true,"dev":true,"optional":true,"requires":{"assert-plus":"0.2.0","jsprim":"1.4.0","sshpk":"1.13.0"}},"inflight":{"version":"1.0.6","bundled":true,"dev":true,"requires":{"once":"1.4.0","wrappy":"1.0.2"}},"inherits":{"version":"2.0.3","bundled":true,"dev":true},"ini":{"version":"1.3.4","bundled":true,"dev":true,"optional":true},"is-fullwidth-code-point":{"version":"1.0.0","bundled":true,"dev":true,"requires":{"number-is-nan":"1.0.1"}},"is-typedarray":{"version":"1.0.0","bundled":true,"dev":true,"optional":true},"isarray":{"version":"1.0.0","bundled":true,"dev":true},"isstream":{"version":"0.1.2","bundled":true,"dev":true,"optional":true},"jodid25519":{"version":"1.0.2","bundled":true,"dev":true,"optional":true,"requires":{"jsbn":"0.1.1"}},"jsbn":{"version":"0.1.1","bundled":true,"dev":true,"optional":true},"json-schema":{"version":"0.2.3","bundled":true,"dev":true,"optional":true},"json-stable-stringify":{"version":"1.0.1","bundled":true,"dev":true,"optional":true,"requires":{"jsonify":"0.0.0"}},"json-stringify-safe":{"version":"5.0.1","bundled":true,"dev":true,"optional":true},"jsonify":{"version":"0.0.0","bundled":true,"dev":true,"optional":true},"jsprim":{"version":"1.4.0","bundled":true,"dev":true,"optional":true,"requires":{"assert-plus":"1.0.0","extsprintf":"1.0.2","json-schema":"0.2.3","verror":"1.3.6"},"dependencies":{"assert-plus":{"version":"1.0.0","bundled":true,"dev":true,"optional":true}}},"mime-db":{"version":"1.27.0","bundled":true,"dev":true},"mime-types":{"version":"2.1.15","bundled":true,"dev":true,"requires":{"mime-db":"1.27.0"}},"minimatch":{"version":"3.0.4","bundled":true,"dev":true,"requires":{"brace-expansion":"1.1.7"}},"minimist":{"version":"0.0.8","bundled":true,"dev":true},"mkdirp":{"version":"0.5.1","bundled":true,"dev":true,"requires":{"minimist":"0.0.8"}},"ms":{"version":"2.0.0","bundled":true,"dev":true,"optional":true},"node-pre-gyp":{"version":"0.6.36","bundled":true,"dev":true,"optional":true,"requires":{"mkdirp":"0.5.1","nopt":"4.0.1","npmlog":"4.1.0","rc":"1.2.1","request":"2.81.0","rimraf":"2.6.1","semver":"5.3.0","tar":"2.2.1","tar-pack":"3.4.0"}},"nopt":{"version":"4.0.1","bundled":true,"dev":true,"optional":true,"requires":{"abbrev":"1.1.0","osenv":"0.1.4"}},"npmlog":{"version":"4.1.0","bundled":true,"dev":true,"optional":true,"requires":{"are-we-there-yet":"1.1.4","console-control-strings":"1.1.0","gauge":"2.7.4","set-blocking":"2.0.0"}},"number-is-nan":{"version":"1.0.1","bundled":true,"dev":true},"oauth-sign":{"version":"0.8.2","bundled":true,"dev":true,"optional":true},"object-assign":{"version":"4.1.1","bundled":true,"dev":true,"optional":true},"once":{"version":"1.4.0","bundled":true,"dev":true,"requires":{"wrappy":"1.0.2"}},"os-homedir":{"version":"1.0.2","bundled":true,"dev":true,"optional":true},"os-tmpdir":{"version":"1.0.2","bundled":true,"dev":true,"optional":true},"osenv":{"version":"0.1.4","bundled":true,"dev":true,"optional":true,"requires":{"os-homedir":"1.0.2","os-tmpdir":"1.0.2"}},"path-is-absolute":{"version":"1.0.1","bundled":true,"dev":true},"performance-now":{"version":"0.2.0","bundled":true,"dev":true,"optional":true},"process-nextick-args":{"version":"1.0.7","bundled":true,"dev":true},"punycode":{"version":"1.4.1","bundled":true,"dev":true,"optional":true},"qs":{"version":"6.4.0","bundled":true,"dev":true,"optional":true},"rc":{"version":"1.2.1","bundled":true,"dev":true,"optional":true,"requires":{"deep-extend":"0.4.2","ini":"1.3.4","minimist":"1.2.0","strip-json-comments":"2.0.1"},"dependencies":{"minimist":{"version":"1.2.0","bundled":true,"dev":true,"optional":true}}},"readable-stream":{"version":"2.2.9","bundled":true,"dev":true,"requires":{"buffer-shims":"1.0.0","core-util-is":"1.0.2","inherits":"2.0.3","isarray":"1.0.0","process-nextick-args":"1.0.7","string_decoder":"1.0.1","util-deprecate":"1.0.2"}},"request":{"version":"2.81.0","bundled":true,"dev":true,"optional":true,"requires":{"aws-sign2":"0.6.0","aws4":"1.6.0","caseless":"0.12.0","combined-stream":"1.0.5","extend":"3.0.1","forever-agent":"0.6.1","form-data":"2.1.4","har-validator":"4.2.1","hawk":"3.1.3","http-signature":"1.1.1","is-typedarray":"1.0.0","isstream":"0.1.2","json-stringify-safe":"5.0.1","mime-types":"2.1.15","oauth-sign":"0.8.2","performance-now":"0.2.0","qs":"6.4.0","safe-buffer":"5.0.1","stringstream":"0.0.5","tough-cookie":"2.3.2","tunnel-agent":"0.6.0","uuid":"3.0.1"}},"rimraf":{"version":"2.6.1","bundled":true,"dev":true,"requires":{"glob":"7.1.2"}},"safe-buffer":{"version":"5.0.1","bundled":true,"dev":true},"semver":{"version":"5.3.0","bundled":true,"dev":true,"optional":true},"set-blocking":{"version":"2.0.0","bundled":true,"dev":true,"optional":true},"signal-exit":{"version":"3.0.2","bundled":true,"dev":true,"optional":true},"sntp":{"version":"1.0.9","bundled":true,"dev":true,"optional":true,"requires":{"hoek":"2.16.3"}},"sshpk":{"version":"1.13.0","bundled":true,"dev":true,"optional":true,"requires":{"asn1":"0.2.3","assert-plus":"1.0.0","bcrypt-pbkdf":"1.0.1","dashdash":"1.14.1","ecc-jsbn":"0.1.1","getpass":"0.1.7","jodid25519":"1.0.2","jsbn":"0.1.1","tweetnacl":"0.14.5"},"dependencies":{"assert-plus":{"version":"1.0.0","bundled":true,"dev":true,"optional":true}}},"string_decoder":{"version":"1.0.1","bundled":true,"dev":true,"requires":{"safe-buffer":"5.0.1"}},"string-width":{"version":"1.0.2","bundled":true,"dev":true,"requires":{"code-point-at":"1.1.0","is-fullwidth-code-point":"1.0.0","strip-ansi":"3.0.1"}},"stringstream":{"version":"0.0.5","bundled":true,"dev":true,"optional":true},"strip-ansi":{"version":"3.0.1","bundled":true,"dev":true,"requires":{"ansi-regex":"2.1.1"}},"strip-json-comments":{"version":"2.0.1","bundled":true,"dev":true,"optional":true},"tar":{"version":"2.2.1","bundled":true,"dev":true,"requires":{"block-stream":"0.0.9","fstream":"1.0.11","inherits":"2.0.3"}},"tar-pack":{"version":"3.4.0","bundled":true,"dev":true,"optional":true,"requires":{"debug":"2.6.8","fstream":"1.0.11","fstream-ignore":"1.0.5","once":"1.4.0","readable-stream":"2.2.9","rimraf":"2.6.1","tar":"2.2.1","uid-number":"0.0.6"}},"tough-cookie":{"version":"2.3.2","bundled":true,"dev":true,"optional":true,"requires":{"punycode":"1.4.1"}},"tunnel-agent":{"version":"0.6.0","bundled":true,"dev":true,"optional":true,"requires":{"safe-buffer":"5.0.1"}},"tweetnacl":{"version":"0.14.5","bundled":true,"dev":true,"optional":true},"uid-number":{"version":"0.0.6","bundled":true,"dev":true,"optional":true},"util-deprecate":{"version":"1.0.2","bundled":true,"dev":true},"uuid":{"version":"3.0.1","bundled":true,"dev":true,"optional":true},"verror":{"version":"1.3.6","bundled":true,"dev":true,"optional":true,"requires":{"extsprintf":"1.0.2"}},"wide-align":{"version":"1.1.2","bundled":true,"dev":true,"optional":true,"requires":{"string-width":"1.0.2"}},"wrappy":{"version":"1.0.2","bundled":true,"dev":true}}},"fstream":{"version":"1.0.11","resolved":"https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz","integrity":"sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=","requires":{"graceful-fs":"4.1.11","inherits":"2.0.3","mkdirp":"0.5.1","rimraf":"2.6.2"}},"fstream-ignore":{"version":"1.0.5","resolved":"https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz","integrity":"sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=","requires":{"fstream":"1.0.11","inherits":"2.0.3","minimatch":"3.0.4"}},"function-bind":{"version":"1.1.1","resolved":"https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz","integrity":"sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==","dev":true},"gauge":{"version":"2.7.4","resolved":"https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz","integrity":"sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=","requires":{"aproba":"1.2.0","console-control-strings":"1.1.0","has-unicode":"2.0.1","object-assign":"4.1.1","signal-exit":"3.0.2","string-width":"1.0.2","strip-ansi":"3.0.1","wide-align":"1.1.2"}},"gaze":{"version":"1.1.2","resolved":"https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz","integrity":"sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=","dev":true,"requires":{"globule":"1.2.0"}},"generate-function":{"version":"2.0.0","resolved":"https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz","integrity":"sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=","dev":true},"generate-object-property":{"version":"1.2.0","resolved":"https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz","integrity":"sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=","dev":true,"requires":{"is-property":"1.0.2"}},"get-caller-file":{"version":"1.0.2","resolved":"https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz","integrity":"sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=","dev":true},"get-own-enumerable-property-symbols":{"version":"2.0.1","resolved":"https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz","integrity":"sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==","dev":true},"get-stdin":{"version":"4.0.1","resolved":"https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz","integrity":"sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=","dev":true},"get-stream":{"version":"2.3.1","resolved":"https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz","integrity":"sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=","requires":{"object-assign":"4.1.1","pinkie-promise":"2.0.1"}},"get-value":{"version":"2.0.6","resolved":"https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz","integrity":"sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=","dev":true},"getpass":{"version":"0.1.7","resolved":"https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz","integrity":"sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=","requires":{"assert-plus":"1.0.0"},"dependencies":{"assert-plus":{"version":"1.0.0","resolved":"https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz","integrity":"sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="}}},"github-from-package":{"version":"0.0.0","resolved":"https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz","integrity":"sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=","dev":true},"glob":{"version":"7.1.2","resolved":"https://registry.npmjs.org/glob/-/glob-7.1.2.tgz","integrity":"sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==","requires":{"fs.realpath":"1.0.0","inflight":"1.0.6","inherits":"2.0.3","minimatch":"3.0.4","once":"1.4.0","path-is-absolute":"1.0.1"}},"glob-base":{"version":"0.3.0","resolved":"https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz","integrity":"sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=","dev":true,"requires":{"glob-parent":"2.0.0","is-glob":"2.0.1"},"dependencies":{"is-extglob":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz","integrity":"sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=","dev":true},"is-glob":{"version":"2.0.1","resolved":"https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz","integrity":"sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=","dev":true,"requires":{"is-extglob":"1.0.0"}}}},"glob-parent":{"version":"2.0.0","resolved":"https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz","integrity":"sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=","dev":true,"requires":{"is-glob":"2.0.1"},"dependencies":{"is-extglob":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz","integrity":"sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=","dev":true},"is-glob":{"version":"2.0.1","resolved":"https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz","integrity":"sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=","dev":true,"requires":{"is-extglob":"1.0.0"}}}},"global":{"version":"4.3.2","resolved":"https://registry.npmjs.org/global/-/global-4.3.2.tgz","integrity":"sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=","dev":true,"requires":{"min-document":"2.19.0","process":"0.5.2"}},"global-dirs":{"version":"0.1.0","resolved":"https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.0.tgz","integrity":"sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=","dev":true,"requires":{"ini":"1.3.4"}},"globals":{"version":"9.18.0","resolved":"https://registry.npmjs.org/globals/-/globals-9.18.0.tgz","integrity":"sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==","dev":true},"globby":{"version":"6.1.0","resolved":"https://registry.npmjs.org/globby/-/globby-6.1.0.tgz","integrity":"sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=","dev":true,"requires":{"array-union":"1.0.2","glob":"7.1.2","object-assign":"4.1.1","pify":"2.3.0","pinkie-promise":"2.0.1"}},"globule":{"version":"1.2.0","resolved":"https://registry.npmjs.org/globule/-/globule-1.2.0.tgz","integrity":"sha1-HcScaCLdnoovoAuiopUAboZkvQk=","dev":true,"requires":{"glob":"7.1.2","lodash":"4.17.4","minimatch":"3.0.4"}},"gonzales-pe-sl":{"version":"4.2.3","resolved":"https://registry.npmjs.org/gonzales-pe-sl/-/gonzales-pe-sl-4.2.3.tgz","integrity":"sha1-aoaLw4BkXxQf7rBCxvl/zHG1n+Y=","dev":true,"requires":{"minimist":"1.1.3"},"dependencies":{"minimist":{"version":"1.1.3","resolved":"https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz","integrity":"sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=","dev":true}}},"got":{"version":"6.7.1","resolved":"https://registry.npmjs.org/got/-/got-6.7.1.tgz","integrity":"sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=","dev":true,"requires":{"create-error-class":"3.0.2","duplexer3":"0.1.4","get-stream":"3.0.0","is-redirect":"1.0.0","is-retry-allowed":"1.1.0","is-stream":"1.1.0","lowercase-keys":"1.0.0","safe-buffer":"5.1.1","timed-out":"4.0.1","unzip-response":"2.0.1","url-parse-lax":"1.0.0"},"dependencies":{"get-stream":{"version":"3.0.0","resolved":"https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz","integrity":"sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=","dev":true},"unzip-response":{"version":"2.0.1","resolved":"https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz","integrity":"sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=","dev":true}}},"graceful-fs":{"version":"4.1.11","resolved":"https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz","integrity":"sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="},"graceful-readlink":{"version":"1.0.1","resolved":"https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz","integrity":"sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="},"growl":{"version":"1.9.2","resolved":"https://registry.npmjs.org/growl/-/growl-1.9.2.tgz","integrity":"sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=","dev":true},"handle-thing":{"version":"1.2.5","resolved":"https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz","integrity":"sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=","dev":true},"har-schema":{"version":"1.0.5","resolved":"https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz","integrity":"sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="},"har-validator":{"version":"4.2.1","resolved":"https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz","integrity":"sha1-M0gdDxu/9gDdID11gSpqX7oALio=","requires":{"ajv":"4.11.8","har-schema":"1.0.5"}},"has":{"version":"1.0.1","resolved":"https://registry.npmjs.org/has/-/has-1.0.1.tgz","integrity":"sha1-hGFzP1OLCDfJNh45qauelwTcLyg=","dev":true,"requires":{"function-bind":"1.1.1"}},"has-ansi":{"version":"0.1.0","resolved":"https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz","integrity":"sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=","dev":true,"requires":{"ansi-regex":"0.2.1"},"dependencies":{"ansi-regex":{"version":"0.2.1","resolved":"https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz","integrity":"sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=","dev":true}}},"has-flag":{"version":"1.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz","integrity":"sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=","dev":true},"has-unicode":{"version":"2.0.1","resolved":"https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz","integrity":"sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="},"has-value":{"version":"1.0.0","resolved":"https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz","integrity":"sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=","dev":true,"requires":{"get-value":"2.0.6","has-values":"1.0.0","isobject":"3.0.1"}},"has-values":{"version":"1.0.0","resolved":"https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz","integrity":"sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=","dev":true,"requires":{"is-number":"3.0.0","kind-of":"4.0.0"},"dependencies":{"kind-of":{"version":"4.0.0","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz","integrity":"sha1-IIE989cSkosgc3hpGkUGb65y3Vc=","dev":true,"requires":{"is-buffer":"1.1.5"}}}},"hash-base":{"version":"2.0.2","resolved":"https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz","integrity":"sha1-ZuodhW206KVHDK32/OI65SRO8uE=","dev":true,"requires":{"inherits":"2.0.3"}},"hash.js":{"version":"1.1.3","resolved":"https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz","integrity":"sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==","dev":true,"requires":{"inherits":"2.0.3","minimalistic-assert":"1.0.0"}},"hawk":{"version":"3.1.3","resolved":"https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz","integrity":"sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=","requires":{"boom":"2.10.1","cryptiles":"2.0.5","hoek":"2.16.3","sntp":"1.0.9"}},"he":{"version":"1.1.1","resolved":"https://registry.npmjs.org/he/-/he-1.1.1.tgz","integrity":"sha1-k0EP0hsAlzUVH4howvJx80J+I/0=","dev":true},"highlight.js":{"version":"9.12.0","resolved":"https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz","integrity":"sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=","dev":true},"hmac-drbg":{"version":"1.0.1","resolved":"https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz","integrity":"sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=","dev":true,"requires":{"hash.js":"1.1.3","minimalistic-assert":"1.0.0","minimalistic-crypto-utils":"1.0.1"}},"hoek":{"version":"2.16.3","resolved":"https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz","integrity":"sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="},"home-path":{"version":"1.0.5","resolved":"https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz","integrity":"sha1-eIspgVsS1Tus9XVkhHbm+QQdEz8=","dev":true},"hosted-git-info":{"version":"2.5.0","resolved":"https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz","integrity":"sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==","dev":true},"hpack.js":{"version":"2.1.6","resolved":"https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz","integrity":"sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=","dev":true,"requires":{"inherits":"2.0.3","obuf":"1.1.1","readable-stream":"2.3.3","wbuf":"1.7.2"}},"html-comment-regex":{"version":"1.1.1","resolved":"https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz","integrity":"sha1-ZouTd26q5V696POtRkswekljYl4=","dev":true},"html-encoding-sniffer":{"version":"1.0.2","resolved":"https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz","integrity":"sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==","dev":true,"requires":{"whatwg-encoding":"1.0.2"}},"html-entities":{"version":"1.2.1","resolved":"https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz","integrity":"sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=","dev":true},"htmlparser2":{"version":"3.9.2","resolved":"https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz","integrity":"sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=","dev":true,"requires":{"domelementtype":"1.3.0","domhandler":"2.4.1","domutils":"1.6.2","entities":"1.1.1","inherits":"2.0.3","readable-stream":"2.3.3"}},"http-basic":{"version":"2.5.1","resolved":"https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz","integrity":"sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=","requires":{"caseless":"0.11.0","concat-stream":"1.6.0","http-response-object":"1.1.0"},"dependencies":{"caseless":{"version":"0.11.0","resolved":"https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz","integrity":"sha1-cVuW6phBWTzDMGeSP17GDr2k99c="}}},"http-deceiver":{"version":"1.2.7","resolved":"https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz","integrity":"sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=","dev":true},"http-errors":{"version":"1.6.2","resolved":"https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz","integrity":"sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=","dev":true,"requires":{"depd":"1.1.1","inherits":"2.0.3","setprototypeof":"1.0.3","statuses":"1.4.0"}},"http-parser-js":{"version":"0.4.9","resolved":"https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz","integrity":"sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE=","dev":true},"http-proxy":{"version":"1.16.2","resolved":"https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz","integrity":"sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=","dev":true,"requires":{"eventemitter3":"1.2.0","requires-port":"1.0.0"}},"http-proxy-middleware":{"version":"0.17.4","resolved":"https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz","integrity":"sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=","dev":true,"requires":{"http-proxy":"1.16.2","is-glob":"3.1.0","lodash":"4.17.4","micromatch":"2.3.11"},"dependencies":{"arr-diff":{"version":"2.0.0","resolved":"https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz","integrity":"sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=","dev":true,"requires":{"arr-flatten":"1.1.0"}},"array-unique":{"version":"0.2.1","resolved":"https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz","integrity":"sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=","dev":true},"braces":{"version":"1.8.5","resolved":"https://registry.npmjs.org/braces/-/braces-1.8.5.tgz","integrity":"sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=","dev":true,"requires":{"expand-range":"1.8.2","preserve":"0.2.0","repeat-element":"1.1.2"}},"expand-brackets":{"version":"0.1.5","resolved":"https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz","integrity":"sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=","dev":true,"requires":{"is-posix-bracket":"0.1.1"}},"extglob":{"version":"0.3.2","resolved":"https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz","integrity":"sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=","dev":true,"requires":{"is-extglob":"1.0.0"},"dependencies":{"is-extglob":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz","integrity":"sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=","dev":true}}},"is-glob":{"version":"3.1.0","resolved":"https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz","integrity":"sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=","dev":true,"requires":{"is-extglob":"2.1.1"}},"kind-of":{"version":"3.2.2","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz","integrity":"sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=","dev":true,"requires":{"is-buffer":"1.1.5"}},"micromatch":{"version":"2.3.11","resolved":"https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz","integrity":"sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=","dev":true,"requires":{"arr-diff":"2.0.0","array-unique":"0.2.1","braces":"1.8.5","expand-brackets":"0.1.5","extglob":"0.3.2","filename-regex":"2.0.1","is-extglob":"1.0.0","is-glob":"2.0.1","kind-of":"3.2.2","normalize-path":"2.1.1","object.omit":"2.0.1","parse-glob":"3.0.4","regex-cache":"0.4.4"},"dependencies":{"is-extglob":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz","integrity":"sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=","dev":true},"is-glob":{"version":"2.0.1","resolved":"https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz","integrity":"sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=","dev":true,"requires":{"is-extglob":"1.0.0"}}}},"normalize-path":{"version":"2.1.1","resolved":"https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz","integrity":"sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=","dev":true,"requires":{"remove-trailing-separator":"1.1.0"}}}},"http-response-object":{"version":"1.1.0","resolved":"https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz","integrity":"sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM="},"http-signature":{"version":"1.1.1","resolved":"https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz","integrity":"sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=","requires":{"assert-plus":"0.2.0","jsprim":"1.4.1","sshpk":"1.13.1"}},"https-browserify":{"version":"0.0.1","resolved":"https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz","integrity":"sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=","dev":true},"https-proxy-agent":{"version":"1.0.0","resolved":"https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz","integrity":"sha1-NffabEjOTdv6JkiRrFk+5f+GceY=","dev":true,"requires":{"agent-base":"2.1.1","debug":"2.6.9","extend":"3.0.1"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}}}},"humanize-plus":{"version":"1.8.2","resolved":"https://registry.npmjs.org/humanize-plus/-/humanize-plus-1.8.2.tgz","integrity":"sha1-pls0RZrWNnrbs3B6gqPJ+RYWcDA=","dev":true},"husky":{"version":"0.14.3","resolved":"https://registry.npmjs.org/husky/-/husky-0.14.3.tgz","integrity":"sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==","dev":true,"requires":{"is-ci":"1.0.10","normalize-path":"1.0.0","strip-indent":"2.0.0"},"dependencies":{"strip-indent":{"version":"2.0.0","resolved":"https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz","integrity":"sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=","dev":true}}},"iconv-lite":{"version":"0.4.19","resolved":"https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz","integrity":"sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="},"icss-replace-symbols":{"version":"1.1.0","resolved":"https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz","integrity":"sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=","dev":true},"icss-utils":{"version":"2.1.0","resolved":"https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz","integrity":"sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=","dev":true,"requires":{"postcss":"6.0.13"},"dependencies":{"ansi-styles":{"version":"3.2.0","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz","integrity":"sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==","dev":true,"requires":{"color-convert":"1.9.0"}},"chalk":{"version":"2.3.0","resolved":"https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz","integrity":"sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==","dev":true,"requires":{"ansi-styles":"3.2.0","escape-string-regexp":"1.0.5","supports-color":"4.5.0"}},"has-flag":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz","integrity":"sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=","dev":true},"postcss":{"version":"6.0.13","resolved":"https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz","integrity":"sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==","dev":true,"requires":{"chalk":"2.3.0","source-map":"0.6.1","supports-color":"4.5.0"}},"supports-color":{"version":"4.5.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz","integrity":"sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=","dev":true,"requires":{"has-flag":"2.0.0"}}}},"ieee754":{"version":"1.1.8","resolved":"https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz","integrity":"sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="},"ignore":{"version":"3.3.6","resolved":"https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz","integrity":"sha512-HrxmNxKTGZ9a3uAl/FNG66Sdt0G9L4TtMbbUQjP1WhGmSj0FOyHvSgx7623aGJvXfPOur8MwmarlHT+37jmzlw==","dev":true},"image-size":{"version":"0.5.5","resolved":"https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz","integrity":"sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=","dev":true},"import-lazy":{"version":"2.1.0","resolved":"https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz","integrity":"sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=","dev":true},"import-local":{"version":"0.1.1","resolved":"https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz","integrity":"sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=","dev":true,"requires":{"pkg-dir":"2.0.0","resolve-cwd":"2.0.0"}},"imurmurhash":{"version":"0.1.4","resolved":"https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz","integrity":"sha1-khi5srkoojixPcT7a21XbyMUU+o=","dev":true},"in-publish":{"version":"2.0.0","resolved":"https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz","integrity":"sha1-4g/146KvwmkDILbcVSaCqcf631E=","dev":true},"indent-string":{"version":"2.1.0","resolved":"https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz","integrity":"sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=","dev":true,"requires":{"repeating":"2.0.1"}},"indexes-of":{"version":"1.0.1","resolved":"https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz","integrity":"sha1-8w9xbI4r00bHtn0985FVZqfAVgc=","dev":true},"indexof":{"version":"0.0.1","resolved":"https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz","integrity":"sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=","dev":true},"inflight":{"version":"1.0.6","resolved":"https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz","integrity":"sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=","requires":{"once":"1.4.0","wrappy":"1.0.2"}},"inherits":{"version":"2.0.3","resolved":"https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz","integrity":"sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="},"ini":{"version":"1.3.4","resolved":"https://registry.npmjs.org/ini/-/ini-1.3.4.tgz","integrity":"sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="},"inquirer":{"version":"0.12.0","resolved":"https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz","integrity":"sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=","dev":true,"requires":{"ansi-escapes":"1.4.0","ansi-regex":"2.1.1","chalk":"1.1.3","cli-cursor":"1.0.2","cli-width":"2.2.0","figures":"1.7.0","lodash":"4.17.4","readline2":"1.0.1","run-async":"0.1.0","rx-lite":"3.1.2","string-width":"1.0.2","strip-ansi":"3.0.1","through":"2.3.8"},"dependencies":{"ansi-styles":{"version":"2.2.1","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz","integrity":"sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=","dev":true},"chalk":{"version":"1.1.3","resolved":"https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz","integrity":"sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=","dev":true,"requires":{"ansi-styles":"2.2.1","escape-string-regexp":"1.0.5","has-ansi":"2.0.0","strip-ansi":"3.0.1","supports-color":"2.0.0"}},"has-ansi":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz","integrity":"sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=","dev":true,"requires":{"ansi-regex":"2.1.1"}},"supports-color":{"version":"2.0.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz","integrity":"sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=","dev":true}}},"int64-buffer":{"version":"0.1.9","resolved":"https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.9.tgz","integrity":"sha1-ngOdoEOyT3ixlrKD4EZT716ZD2E=","dev":true},"internal-ip":{"version":"1.2.0","resolved":"https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz","integrity":"sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=","dev":true,"requires":{"meow":"3.7.0"}},"interpret":{"version":"1.0.4","resolved":"https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz","integrity":"sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=","dev":true},"invariant":{"version":"2.2.2","resolved":"https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz","integrity":"sha1-nh9WrArNtr8wMwbzOL47IErmA2A=","requires":{"loose-envify":"1.3.1"}},"invert-kv":{"version":"1.0.0","resolved":"https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz","integrity":"sha1-EEqOSqym09jNFXqO+L+rLXo//bY=","dev":true},"ip":{"version":"1.1.5","resolved":"https://registry.npmjs.org/ip/-/ip-1.1.5.tgz","integrity":"sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=","dev":true},"ipaddr.js":{"version":"1.5.2","resolved":"https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz","integrity":"sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=","dev":true},"is-absolute-url":{"version":"2.1.0","resolved":"https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz","integrity":"sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=","dev":true},"is-accessor-descriptor":{"version":"0.1.6","resolved":"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz","integrity":"sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=","dev":true,"requires":{"kind-of":"3.2.2"},"dependencies":{"kind-of":{"version":"3.2.2","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz","integrity":"sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=","dev":true,"requires":{"is-buffer":"1.1.5"}}}},"is-arrayish":{"version":"0.2.1","resolved":"https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz","integrity":"sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=","dev":true},"is-binary-path":{"version":"1.0.1","resolved":"https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz","integrity":"sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=","dev":true,"requires":{"binary-extensions":"1.10.0"}},"is-buffer":{"version":"1.1.5","resolved":"https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz","integrity":"sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=","dev":true},"is-builtin-module":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz","integrity":"sha1-VAVy0096wxGfj3bDDLwbHgN6/74=","dev":true,"requires":{"builtin-modules":"1.1.1"}},"is-callable":{"version":"1.1.3","resolved":"https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz","integrity":"sha1-hut1OSgF3cM69xySoO7fdO52BLI=","dev":true},"is-ci":{"version":"1.0.10","resolved":"https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz","integrity":"sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=","dev":true,"requires":{"ci-info":"1.1.1"}},"is-data-descriptor":{"version":"0.1.4","resolved":"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz","integrity":"sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=","dev":true,"requires":{"kind-of":"3.2.2"},"dependencies":{"kind-of":{"version":"3.2.2","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz","integrity":"sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=","dev":true,"requires":{"is-buffer":"1.1.5"}}}},"is-date-object":{"version":"1.0.1","resolved":"https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz","integrity":"sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=","dev":true},"is-descriptor":{"version":"1.0.1","resolved":"https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz","integrity":"sha512-G3fFVFTqfaqu7r4YuSBHKBAuOaLz8Sy7ekklUpFEliaLMP1Y2ZjoN9jS62YWCAPQrQpMUQSitRlrzibbuCZjdA==","dev":true,"requires":{"is-accessor-descriptor":"0.1.6","is-data-descriptor":"0.1.4","kind-of":"5.1.0"},"dependencies":{"kind-of":{"version":"5.1.0","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz","integrity":"sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==","dev":true}}},"is-dotfile":{"version":"1.0.3","resolved":"https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz","integrity":"sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=","dev":true},"is-equal-shallow":{"version":"0.1.3","resolved":"https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz","integrity":"sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=","dev":true,"requires":{"is-primitive":"2.0.0"}},"is-extendable":{"version":"0.1.1","resolved":"https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz","integrity":"sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=","dev":true},"is-extglob":{"version":"2.1.1","resolved":"https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz","integrity":"sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=","dev":true},"is-finite":{"version":"1.0.2","resolved":"https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz","integrity":"sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=","dev":true,"requires":{"number-is-nan":"1.0.1"}},"is-fullwidth-code-point":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz","integrity":"sha1-754xOG8DGn8NZDr4L95QxFfvAMs=","requires":{"number-is-nan":"1.0.1"}},"is-glob":{"version":"4.0.0","resolved":"https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz","integrity":"sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=","dev":true,"requires":{"is-extglob":"2.1.1"}},"is-installed-globally":{"version":"0.1.0","resolved":"https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz","integrity":"sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=","dev":true,"requires":{"global-dirs":"0.1.0","is-path-inside":"1.0.0"}},"is-my-json-valid":{"version":"2.16.1","resolved":"https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz","integrity":"sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==","dev":true,"requires":{"generate-function":"2.0.0","generate-object-property":"1.2.0","jsonpointer":"4.0.1","xtend":"4.0.1"}},"is-natural-number":{"version":"4.0.1","resolved":"https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz","integrity":"sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="},"is-npm":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz","integrity":"sha1-8vtjpl5JBbQGyGBydloaTceTufQ=","dev":true},"is-number":{"version":"3.0.0","resolved":"https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz","integrity":"sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=","dev":true,"requires":{"kind-of":"3.2.2"},"dependencies":{"kind-of":{"version":"3.2.2","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz","integrity":"sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=","dev":true,"requires":{"is-buffer":"1.1.5"}}}},"is-obj":{"version":"1.0.1","resolved":"https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz","integrity":"sha1-PkcprB9f3gJc19g6iW2rn09n2w8=","dev":true},"is-odd":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz","integrity":"sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=","dev":true,"requires":{"is-number":"3.0.0"}},"is-path-cwd":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz","integrity":"sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=","dev":true},"is-path-in-cwd":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz","integrity":"sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=","dev":true,"requires":{"is-path-inside":"1.0.0"}},"is-path-inside":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz","integrity":"sha1-/AbloWg/vaE95mev9xe7wQpI838=","dev":true,"requires":{"path-is-inside":"1.0.2"}},"is-plain-obj":{"version":"1.1.0","resolved":"https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz","integrity":"sha1-caUMhCnfync8kqOQpKA7OfzVHT4=","dev":true},"is-plain-object":{"version":"2.0.4","resolved":"https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz","integrity":"sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==","dev":true,"requires":{"isobject":"3.0.1"}},"is-posix-bracket":{"version":"0.1.1","resolved":"https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz","integrity":"sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=","dev":true},"is-primitive":{"version":"2.0.0","resolved":"https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz","integrity":"sha1-IHurkWOEmcB7Kt8kCkGochADRXU=","dev":true},"is-promise":{"version":"2.1.0","resolved":"https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz","integrity":"sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=","dev":true},"is-property":{"version":"1.0.2","resolved":"https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz","integrity":"sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=","dev":true},"is-redirect":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz","integrity":"sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=","dev":true},"is-regex":{"version":"1.0.4","resolved":"https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz","integrity":"sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=","dev":true,"requires":{"has":"1.0.1"}},"is-regexp":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz","integrity":"sha1-/S2INUXEa6xaYz57mgnof6LLUGk=","dev":true},"is-resolvable":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz","integrity":"sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=","dev":true,"requires":{"tryit":"1.0.3"}},"is-retry-allowed":{"version":"1.1.0","resolved":"https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz","integrity":"sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=","dev":true},"is-stream":{"version":"1.1.0","resolved":"https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz","integrity":"sha1-EtSj3U5o4Lec6428hBc66A2RykQ="},"is-svg":{"version":"2.1.0","resolved":"https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz","integrity":"sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=","dev":true,"requires":{"html-comment-regex":"1.1.1"}},"is-symbol":{"version":"1.0.1","resolved":"https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz","integrity":"sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=","dev":true},"is-typedarray":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz","integrity":"sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="},"is-utf8":{"version":"0.2.1","resolved":"https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz","integrity":"sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=","dev":true},"is-wsl":{"version":"1.1.0","resolved":"https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz","integrity":"sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=","dev":true},"isarray":{"version":"1.0.0","resolved":"https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz","integrity":"sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="},"isbinaryfile":{"version":"3.0.2","resolved":"https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz","integrity":"sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE=","dev":true},"isemail":{"version":"1.2.0","resolved":"https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz","integrity":"sha1-vgPfjMPineTSxd9lASY/H6RZXpo=","dev":true},"isexe":{"version":"2.0.0","resolved":"https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz","integrity":"sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=","dev":true},"isobject":{"version":"3.0.1","resolved":"https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz","integrity":"sha1-TkMekrEalzFjaqH5yNHMvP2reN8=","dev":true},"isomorphic-fetch":{"version":"2.2.1","resolved":"https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz","integrity":"sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=","requires":{"node-fetch":"1.7.3","whatwg-fetch":"2.0.3"}},"isstream":{"version":"0.1.2","resolved":"https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz","integrity":"sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="},"jest-docblock":{"version":"21.2.0","resolved":"https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz","integrity":"sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==","dev":true},"jest-get-type":{"version":"21.2.0","resolved":"https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz","integrity":"sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==","dev":true},"jest-validate":{"version":"21.2.1","resolved":"https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz","integrity":"sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==","dev":true,"requires":{"chalk":"2.3.0","jest-get-type":"21.2.0","leven":"2.1.0","pretty-format":"21.2.1"},"dependencies":{"ansi-styles":{"version":"3.2.0","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz","integrity":"sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==","dev":true,"requires":{"color-convert":"1.9.0"}},"chalk":{"version":"2.3.0","resolved":"https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz","integrity":"sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==","dev":true,"requires":{"ansi-styles":"3.2.0","escape-string-regexp":"1.0.5","supports-color":"4.5.0"}},"has-flag":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz","integrity":"sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=","dev":true},"supports-color":{"version":"4.5.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz","integrity":"sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=","dev":true,"requires":{"has-flag":"2.0.0"}}}},"jmespath":{"version":"0.15.0","resolved":"https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz","integrity":"sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=","dev":true},"joi":{"version":"6.10.1","resolved":"https://registry.npmjs.org/joi/-/joi-6.10.1.tgz","integrity":"sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=","dev":true,"requires":{"hoek":"2.16.3","isemail":"1.2.0","moment":"2.19.1","topo":"1.1.0"}},"jquery":{"version":"3.2.1","resolved":"https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz","integrity":"sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c=","dev":true},"js-base64":{"version":"2.3.2","resolved":"https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz","integrity":"sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw==","dev":true},"js-tokens":{"version":"3.0.2","resolved":"https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz","integrity":"sha1-mGbfOVECEw449/mWvOtlRDIJwls="},"js-yaml":{"version":"3.10.0","resolved":"https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz","integrity":"sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==","requires":{"argparse":"1.0.9","esprima":"4.0.0"}},"jsbn":{"version":"0.1.1","resolved":"https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz","integrity":"sha1-peZUwuWi3rXyAdls77yoDA7y9RM=","optional":true},"jschardet":{"version":"1.5.1","resolved":"https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz","integrity":"sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==","dev":true},"jsdom":{"version":"11.3.0","resolved":"https://registry.npmjs.org/jsdom/-/jsdom-11.3.0.tgz","integrity":"sha512-aPZTDl4MplzQhx5bLztk6nzjbEslmO3Q3+z0WpCMutL1XJDhZIRzir6R1Y8S84LgeT/7jhQvgtUMkY6oPwvlUw==","dev":true,"requires":{"abab":"1.0.4","acorn":"5.1.2","acorn-globals":"4.1.0","array-equal":"1.0.0","content-type-parser":"1.0.2","cssom":"0.3.2","cssstyle":"0.2.37","domexception":"1.0.0","escodegen":"1.9.0","html-encoding-sniffer":"1.0.2","nwmatcher":"1.4.3","parse5":"3.0.2","pn":"1.0.0","request":"2.83.0","request-promise-native":"1.0.5","sax":"1.2.4","symbol-tree":"3.2.2","tough-cookie":"2.3.3","webidl-conversions":"4.0.2","whatwg-encoding":"1.0.2","whatwg-url":"6.3.0","xml-name-validator":"2.0.1"}},"jsesc":{"version":"0.5.0","resolved":"https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz","integrity":"sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=","dev":true},"json-loader":{"version":"0.5.7","resolved":"https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz","integrity":"sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==","dev":true},"json-schema":{"version":"0.2.3","resolved":"https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz","integrity":"sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="},"json-schema-traverse":{"version":"0.3.1","resolved":"https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz","integrity":"sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="},"json-stable-stringify":{"version":"1.0.1","resolved":"https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz","integrity":"sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=","requires":{"jsonify":"0.0.0"}},"json-stringify-safe":{"version":"5.0.1","resolved":"https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz","integrity":"sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="},"json3":{"version":"3.3.2","resolved":"https://registry.npmjs.org/json3/-/json3-3.3.2.tgz","integrity":"sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=","dev":true},"json5":{"version":"0.5.1","resolved":"https://registry.npmjs.org/json5/-/json5-0.5.1.tgz","integrity":"sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=","dev":true},"jsonfile":{"version":"4.0.0","resolved":"https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz","integrity":"sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=","requires":{"graceful-fs":"4.1.11"}},"jsonify":{"version":"0.0.0","resolved":"https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz","integrity":"sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="},"jsonparse":{"version":"1.3.1","resolved":"https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz","integrity":"sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=","dev":true},"jsonpointer":{"version":"4.0.1","resolved":"https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz","integrity":"sha1-T9kss04OnbPInIYi7PUfm5eMbLk=","dev":true},"JSONStream":{"version":"1.3.1","resolved":"https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz","integrity":"sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=","dev":true,"requires":{"jsonparse":"1.3.1","through":"2.3.8"}},"jsonwebtoken":{"version":"7.4.3","resolved":"https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz","integrity":"sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=","dev":true,"requires":{"joi":"6.10.1","jws":"3.1.4","lodash.once":"4.1.1","ms":"2.0.0","xtend":"4.0.1"}},"jsprim":{"version":"1.4.1","resolved":"https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz","integrity":"sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=","requires":{"assert-plus":"1.0.0","extsprintf":"1.3.0","json-schema":"0.2.3","verror":"1.10.0"},"dependencies":{"assert-plus":{"version":"1.0.0","resolved":"https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz","integrity":"sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="}}},"jstransform":{"version":"11.0.3","resolved":"https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz","integrity":"sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=","dev":true,"requires":{"base62":"1.2.0","commoner":"0.10.8","esprima-fb":"15001.1.0-dev-harmony-fb","object-assign":"2.1.1","source-map":"0.4.4"},"dependencies":{"esprima-fb":{"version":"15001.1.0-dev-harmony-fb","resolved":"https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz","integrity":"sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE=","dev":true},"object-assign":{"version":"2.1.1","resolved":"https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz","integrity":"sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=","dev":true},"source-map":{"version":"0.4.4","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz","integrity":"sha1-66T12pwNyZneaAMti092FzZSA2s=","dev":true,"requires":{"amdefine":"1.0.1"}}}},"jwa":{"version":"1.1.5","resolved":"https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz","integrity":"sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=","dev":true,"requires":{"base64url":"2.0.0","buffer-equal-constant-time":"1.0.1","ecdsa-sig-formatter":"1.0.9","safe-buffer":"5.1.1"}},"jws":{"version":"3.1.4","resolved":"https://registry.npmjs.org/jws/-/jws-3.1.4.tgz","integrity":"sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=","dev":true,"requires":{"base64url":"2.0.0","jwa":"1.1.5","safe-buffer":"5.1.1"}},"kind-of":{"version":"6.0.0","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-6.0.0.tgz","integrity":"sha512-sUd5AnFyOPh+RW+ZIHd1FHuwM4OFvhKCPVxxhamLxWLpmv1xQ394lzRMmhLQOiMpXvnB64YRLezWaJi5xGk7Dg==","dev":true},"klaw":{"version":"1.3.1","resolved":"https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz","integrity":"sha1-QIhDO0azsbolnXh4XY6W9zugJDk=","dev":true,"requires":{"graceful-fs":"4.1.11"}},"known-css-properties":{"version":"0.3.0","resolved":"https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.3.0.tgz","integrity":"sha512-QMQcnKAiQccfQTqtBh/qwquGZ2XK/DXND1jrcN9M8gMMy99Gwla7GQjndVUsEqIaRyP6bsFRuhwRj5poafBGJQ==","dev":true},"latest-version":{"version":"3.1.0","resolved":"https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz","integrity":"sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=","dev":true,"requires":{"package-json":"4.0.1"}},"lazy-cache":{"version":"2.0.2","resolved":"https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz","integrity":"sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=","dev":true,"requires":{"set-getter":"0.1.0"}},"lazy-val":{"version":"1.0.2","resolved":"https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.2.tgz","integrity":"sha512-2BaSu6qVnicKdWQPysrffZVFAKcPcZQ/q2YyeSjAxWaJlvCvKSrkcvsSHlleeIfA//fW2goTcYDTy2cBLN7+PQ=="},"lazystream":{"version":"1.0.0","resolved":"https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz","integrity":"sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=","dev":true,"requires":{"readable-stream":"2.3.3"}},"lcid":{"version":"1.0.0","resolved":"https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz","integrity":"sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=","dev":true,"requires":{"invert-kv":"1.0.0"}},"leven":{"version":"2.1.0","resolved":"https://registry.npmjs.org/leven/-/leven-2.1.0.tgz","integrity":"sha1-wuep93IJTe6dNCAq6KzORoeHVYA=","dev":true},"levn":{"version":"0.3.0","resolved":"https://registry.npmjs.org/levn/-/levn-0.3.0.tgz","integrity":"sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=","dev":true,"requires":{"prelude-ls":"1.1.2","type-check":"0.3.2"}},"lint-staged":{"version":"4.3.0","resolved":"https://registry.npmjs.org/lint-staged/-/lint-staged-4.3.0.tgz","integrity":"sha512-C/Zxslg0VRbsxwmCu977iIs+QyrmW2cyRCPUV5NDFYOH/jtRFHH8ch7ua2fH0voI/nVC3Tpg7DykfgMZySliKw==","dev":true,"requires":{"app-root-path":"2.0.1","chalk":"2.3.0","commander":"2.11.0","cosmiconfig":"1.1.0","execa":"0.8.0","is-glob":"4.0.0","jest-validate":"21.2.1","listr":"0.12.0","lodash":"4.17.4","log-symbols":"2.1.0","minimatch":"3.0.4","npm-which":"3.0.1","p-map":"1.2.0","staged-git-files":"0.0.4","stringify-object":"3.2.1"},"dependencies":{"ansi-styles":{"version":"3.2.0","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz","integrity":"sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==","dev":true,"requires":{"color-convert":"1.9.0"}},"chalk":{"version":"2.3.0","resolved":"https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz","integrity":"sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==","dev":true,"requires":{"ansi-styles":"3.2.0","escape-string-regexp":"1.0.5","supports-color":"4.5.0"}},"commander":{"version":"2.11.0","resolved":"https://registry.npmjs.org/commander/-/commander-2.11.0.tgz","integrity":"sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==","dev":true},"execa":{"version":"0.8.0","resolved":"https://registry.npmjs.org/execa/-/execa-0.8.0.tgz","integrity":"sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=","dev":true,"requires":{"cross-spawn":"5.1.0","get-stream":"3.0.0","is-stream":"1.1.0","npm-run-path":"2.0.2","p-finally":"1.0.0","signal-exit":"3.0.2","strip-eof":"1.0.0"}},"get-stream":{"version":"3.0.0","resolved":"https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz","integrity":"sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=","dev":true},"has-flag":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz","integrity":"sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=","dev":true},"supports-color":{"version":"4.5.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz","integrity":"sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=","dev":true,"requires":{"has-flag":"2.0.0"}}}},"listr":{"version":"0.12.0","resolved":"https://registry.npmjs.org/listr/-/listr-0.12.0.tgz","integrity":"sha1-a84sD1YD+klYDqF81qAMwOX6RRo=","dev":true,"requires":{"chalk":"1.1.3","cli-truncate":"0.2.1","figures":"1.7.0","indent-string":"2.1.0","is-promise":"2.1.0","is-stream":"1.1.0","listr-silent-renderer":"1.1.1","listr-update-renderer":"0.2.0","listr-verbose-renderer":"0.4.1","log-symbols":"1.0.2","log-update":"1.0.2","ora":"0.2.3","p-map":"1.2.0","rxjs":"5.5.1","stream-to-observable":"0.1.0","strip-ansi":"3.0.1"},"dependencies":{"ansi-styles":{"version":"2.2.1","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz","integrity":"sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=","dev":true},"chalk":{"version":"1.1.3","resolved":"https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz","integrity":"sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=","dev":true,"requires":{"ansi-styles":"2.2.1","escape-string-regexp":"1.0.5","has-ansi":"2.0.0","strip-ansi":"3.0.1","supports-color":"2.0.0"}},"has-ansi":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz","integrity":"sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=","dev":true,"requires":{"ansi-regex":"2.1.1"}},"log-symbols":{"version":"1.0.2","resolved":"https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz","integrity":"sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=","dev":true,"requires":{"chalk":"1.1.3"}},"supports-color":{"version":"2.0.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz","integrity":"sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=","dev":true}}},"listr-silent-renderer":{"version":"1.1.1","resolved":"https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz","integrity":"sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=","dev":true},"listr-update-renderer":{"version":"0.2.0","resolved":"https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz","integrity":"sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=","dev":true,"requires":{"chalk":"1.1.3","cli-truncate":"0.2.1","elegant-spinner":"1.0.1","figures":"1.7.0","indent-string":"3.2.0","log-symbols":"1.0.2","log-update":"1.0.2","strip-ansi":"3.0.1"},"dependencies":{"ansi-styles":{"version":"2.2.1","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz","integrity":"sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=","dev":true},"chalk":{"version":"1.1.3","resolved":"https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz","integrity":"sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=","dev":true,"requires":{"ansi-styles":"2.2.1","escape-string-regexp":"1.0.5","has-ansi":"2.0.0","strip-ansi":"3.0.1","supports-color":"2.0.0"}},"has-ansi":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz","integrity":"sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=","dev":true,"requires":{"ansi-regex":"2.1.1"}},"indent-string":{"version":"3.2.0","resolved":"https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz","integrity":"sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=","dev":true},"log-symbols":{"version":"1.0.2","resolved":"https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz","integrity":"sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=","dev":true,"requires":{"chalk":"1.1.3"}},"supports-color":{"version":"2.0.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz","integrity":"sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=","dev":true}}},"listr-verbose-renderer":{"version":"0.4.1","resolved":"https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz","integrity":"sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=","dev":true,"requires":{"chalk":"1.1.3","cli-cursor":"1.0.2","date-fns":"1.29.0","figures":"1.7.0"},"dependencies":{"ansi-styles":{"version":"2.2.1","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz","integrity":"sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=","dev":true},"chalk":{"version":"1.1.3","resolved":"https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz","integrity":"sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=","dev":true,"requires":{"ansi-styles":"2.2.1","escape-string-regexp":"1.0.5","has-ansi":"2.0.0","strip-ansi":"3.0.1","supports-color":"2.0.0"}},"has-ansi":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz","integrity":"sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=","dev":true,"requires":{"ansi-regex":"2.1.1"}},"supports-color":{"version":"2.0.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz","integrity":"sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=","dev":true}}},"load-json-file":{"version":"1.1.0","resolved":"https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz","integrity":"sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=","dev":true,"requires":{"graceful-fs":"4.1.11","parse-json":"2.2.0","pify":"2.3.0","pinkie-promise":"2.0.1","strip-bom":"2.0.0"}},"loader-runner":{"version":"2.3.0","resolved":"https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz","integrity":"sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=","dev":true},"loader-utils":{"version":"1.1.0","resolved":"https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz","integrity":"sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=","dev":true,"requires":{"big.js":"3.2.0","emojis-list":"2.1.0","json5":"0.5.1"}},"locate-path":{"version":"2.0.0","resolved":"https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz","integrity":"sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=","dev":true,"requires":{"p-locate":"2.0.0","path-exists":"3.0.0"},"dependencies":{"path-exists":{"version":"3.0.0","resolved":"https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz","integrity":"sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=","dev":true}}},"lodash":{"version":"4.17.4","resolved":"https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz","integrity":"sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="},"lodash._baseassign":{"version":"3.2.0","resolved":"https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz","integrity":"sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=","dev":true,"requires":{"lodash._basecopy":"3.0.1","lodash.keys":"3.1.2"}},"lodash._basecopy":{"version":"3.0.1","resolved":"https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz","integrity":"sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=","dev":true},"lodash._basecreate":{"version":"3.0.3","resolved":"https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz","integrity":"sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=","dev":true},"lodash._bindcallback":{"version":"3.0.1","resolved":"https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz","integrity":"sha1-5THCdkTPi1epnhftlbNcdIeJOS4=","dev":true},"lodash._createassigner":{"version":"3.1.1","resolved":"https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz","integrity":"sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=","dev":true,"requires":{"lodash._bindcallback":"3.0.1","lodash._isiterateecall":"3.0.9","lodash.restparam":"3.6.1"}},"lodash._getnative":{"version":"3.9.1","resolved":"https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz","integrity":"sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=","dev":true},"lodash._isiterateecall":{"version":"3.0.9","resolved":"https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz","integrity":"sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=","dev":true},"lodash.assign":{"version":"4.2.0","resolved":"https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz","integrity":"sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=","dev":true},"lodash.camelcase":{"version":"4.3.0","resolved":"https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz","integrity":"sha1-soqmKIorn8ZRA1x3EfZathkDMaY=","dev":true},"lodash.capitalize":{"version":"4.2.1","resolved":"https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz","integrity":"sha1-+CbJtOKoUR2E46yinbBeGk87cqk=","dev":true},"lodash.clonedeep":{"version":"4.5.0","resolved":"https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz","integrity":"sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=","dev":true},"lodash.create":{"version":"3.1.1","resolved":"https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz","integrity":"sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=","dev":true,"requires":{"lodash._baseassign":"3.2.0","lodash._basecreate":"3.0.3","lodash._isiterateecall":"3.0.9"}},"lodash.defaults":{"version":"4.2.0","resolved":"https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz","integrity":"sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=","dev":true},"lodash.isarguments":{"version":"3.1.0","resolved":"https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz","integrity":"sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=","dev":true},"lodash.isarray":{"version":"3.0.4","resolved":"https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz","integrity":"sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=","dev":true},"lodash.isequal":{"version":"4.5.0","resolved":"https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz","integrity":"sha1-QVxEePK8wwEgwizhDtMib30+GOA="},"lodash.isfunction":{"version":"3.0.8","resolved":"https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz","integrity":"sha1-TbcJ/IG8So/XEnpFilNGxc3OLGs="},"lodash.isobject":{"version":"3.0.2","resolved":"https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz","integrity":"sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="},"lodash.kebabcase":{"version":"4.1.1","resolved":"https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz","integrity":"sha1-hImxyw0p/4gZXM7KRI/21swpXDY=","dev":true},"lodash.keys":{"version":"3.1.2","resolved":"https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz","integrity":"sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=","dev":true,"requires":{"lodash._getnative":"3.9.1","lodash.isarguments":"3.1.0","lodash.isarray":"3.0.4"}},"lodash.memoize":{"version":"4.1.2","resolved":"https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz","integrity":"sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=","dev":true},"lodash.mergewith":{"version":"4.6.0","resolved":"https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz","integrity":"sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=","dev":true},"lodash.once":{"version":"4.1.1","resolved":"https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz","integrity":"sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=","dev":true},"lodash.restparam":{"version":"3.6.1","resolved":"https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz","integrity":"sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=","dev":true},"lodash.sortby":{"version":"4.7.0","resolved":"https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz","integrity":"sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=","dev":true},"lodash.tail":{"version":"4.1.1","resolved":"https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz","integrity":"sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=","dev":true},"lodash.toarray":{"version":"4.4.0","resolved":"https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz","integrity":"sha1-JMS/zWsvuji/0FlNsRedjptlZWE=","dev":true},"lodash.tonumber":{"version":"4.0.3","resolved":"https://registry.npmjs.org/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz","integrity":"sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk="},"lodash.uniq":{"version":"4.5.0","resolved":"https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz","integrity":"sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=","dev":true},"log-symbols":{"version":"2.1.0","resolved":"https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz","integrity":"sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==","dev":true,"requires":{"chalk":"2.3.0"},"dependencies":{"ansi-styles":{"version":"3.2.0","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz","integrity":"sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==","dev":true,"requires":{"color-convert":"1.9.0"}},"chalk":{"version":"2.3.0","resolved":"https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz","integrity":"sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==","dev":true,"requires":{"ansi-styles":"3.2.0","escape-string-regexp":"1.0.5","supports-color":"4.5.0"}},"has-flag":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz","integrity":"sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=","dev":true},"supports-color":{"version":"4.5.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz","integrity":"sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=","dev":true,"requires":{"has-flag":"2.0.0"}}}},"log-update":{"version":"1.0.2","resolved":"https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz","integrity":"sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=","dev":true,"requires":{"ansi-escapes":"1.4.0","cli-cursor":"1.0.2"}},"loglevel":{"version":"1.5.1","resolved":"https://registry.npmjs.org/loglevel/-/loglevel-1.5.1.tgz","integrity":"sha1-GJB4yUq5BT7iFaCs2/JCROoPZQI=","dev":true},"longest":{"version":"1.0.1","resolved":"https://registry.npmjs.org/longest/-/longest-1.0.1.tgz","integrity":"sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=","dev":true},"loose-envify":{"version":"1.3.1","resolved":"https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz","integrity":"sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=","requires":{"js-tokens":"3.0.2"}},"loud-rejection":{"version":"1.6.0","resolved":"https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz","integrity":"sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=","dev":true,"requires":{"currently-unhandled":"0.4.1","signal-exit":"3.0.2"}},"lowercase-keys":{"version":"1.0.0","resolved":"https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz","integrity":"sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=","dev":true},"lru-cache":{"version":"4.1.1","resolved":"https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz","integrity":"sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==","dev":true,"requires":{"pseudomap":"1.0.2","yallist":"2.1.2"}},"lzma-native":{"version":"3.0.1","resolved":"https://registry.npmjs.org/lzma-native/-/lzma-native-3.0.1.tgz","integrity":"sha512-RZsLWwvuCpkaXEt2p2pmx7dI20UUfXK9OTyG8KGxSiZA79i67TWLnhlNtCMGGZ0xP3NaWjkq4W5+gol7l7RyPQ==","requires":{"nan":"2.5.1","node-pre-gyp":"0.6.36","readable-stream":"2.2.11","rimraf":"2.6.1"},"dependencies":{"abbrev":{"version":"1.1.0","bundled":true},"ajv":{"version":"4.11.8","bundled":true,"requires":{"co":"4.6.0","json-stable-stringify":"1.0.1"}},"ansi-regex":{"version":"2.1.1","bundled":true},"aproba":{"version":"1.1.2","bundled":true},"are-we-there-yet":{"version":"1.1.4","bundled":true,"requires":{"delegates":"1.0.0","readable-stream":"2.2.11"}},"asn1":{"version":"0.2.3","bundled":true},"assert-plus":{"version":"0.2.0","bundled":true},"asynckit":{"version":"0.4.0","bundled":true},"aws-sign2":{"version":"0.6.0","bundled":true},"aws4":{"version":"1.6.0","bundled":true},"balanced-match":{"version":"0.4.2","bundled":true},"bcrypt-pbkdf":{"version":"1.0.1","bundled":true,"optional":true,"requires":{"tweetnacl":"0.14.5"}},"block-stream":{"version":"0.0.9","bundled":true,"requires":{"inherits":"2.0.3"}},"boom":{"version":"2.10.1","bundled":true,"requires":{"hoek":"2.16.3"}},"brace-expansion":{"version":"1.1.7","bundled":true,"requires":{"balanced-match":"0.4.2","concat-map":"0.0.1"}},"caseless":{"version":"0.12.0","bundled":true},"co":{"version":"4.6.0","bundled":true},"code-point-at":{"version":"1.1.0","bundled":true},"combined-stream":{"version":"1.0.5","bundled":true,"requires":{"delayed-stream":"1.0.0"}},"concat-map":{"version":"0.0.1","bundled":true},"console-control-strings":{"version":"1.1.0","bundled":true},"core-util-is":{"version":"1.0.2","bundled":true},"cryptiles":{"version":"2.0.5","bundled":true,"requires":{"boom":"2.10.1"}},"dashdash":{"version":"1.14.1","bundled":true,"requires":{"assert-plus":"1.0.0"},"dependencies":{"assert-plus":{"version":"1.0.0","bundled":true}}},"debug":{"version":"2.6.8","bundled":true,"requires":{"ms":"2.0.0"}},"deep-extend":{"version":"0.4.2","bundled":true},"delayed-stream":{"version":"1.0.0","bundled":true},"delegates":{"version":"1.0.0","bundled":true},"ecc-jsbn":{"version":"0.1.1","bundled":true,"optional":true,"requires":{"jsbn":"0.1.1"}},"extend":{"version":"3.0.1","bundled":true},"extsprintf":{"version":"1.0.2","bundled":true},"forever-agent":{"version":"0.6.1","bundled":true},"form-data":{"version":"2.1.4","bundled":true,"requires":{"asynckit":"0.4.0","combined-stream":"1.0.5","mime-types":"2.1.15"}},"fs.realpath":{"version":"1.0.0","bundled":true},"fstream":{"version":"1.0.11","bundled":true,"requires":{"graceful-fs":"4.1.11","inherits":"2.0.3","mkdirp":"0.5.1","rimraf":"2.6.1"}},"fstream-ignore":{"version":"1.0.5","bundled":true,"requires":{"fstream":"1.0.11","inherits":"2.0.3","minimatch":"3.0.4"}},"gauge":{"version":"2.7.4","bundled":true,"requires":{"aproba":"1.1.2","console-control-strings":"1.1.0","has-unicode":"2.0.1","object-assign":"4.1.1","signal-exit":"3.0.2","string-width":"1.0.2","strip-ansi":"3.0.1","wide-align":"1.1.2"}},"getpass":{"version":"0.1.7","bundled":true,"requires":{"assert-plus":"1.0.0"},"dependencies":{"assert-plus":{"version":"1.0.0","bundled":true}}},"glob":{"version":"7.1.2","bundled":true,"requires":{"fs.realpath":"1.0.0","inflight":"1.0.6","inherits":"2.0.3","minimatch":"3.0.4","once":"1.4.0","path-is-absolute":"1.0.1"}},"graceful-fs":{"version":"4.1.11","bundled":true},"har-schema":{"version":"1.0.5","bundled":true},"har-validator":{"version":"4.2.1","bundled":true,"requires":{"ajv":"4.11.8","har-schema":"1.0.5"}},"has-unicode":{"version":"2.0.1","bundled":true},"hawk":{"version":"3.1.3","bundled":true,"requires":{"boom":"2.10.1","cryptiles":"2.0.5","hoek":"2.16.3","sntp":"1.0.9"}},"hoek":{"version":"2.16.3","bundled":true},"http-signature":{"version":"1.1.1","bundled":true,"requires":{"assert-plus":"0.2.0","jsprim":"1.4.0","sshpk":"1.13.0"}},"inflight":{"version":"1.0.6","bundled":true,"requires":{"once":"1.4.0","wrappy":"1.0.2"}},"inherits":{"version":"2.0.3","bundled":true},"ini":{"version":"1.3.4","bundled":true},"is-fullwidth-code-point":{"version":"1.0.0","bundled":true,"requires":{"number-is-nan":"1.0.1"}},"is-typedarray":{"version":"1.0.0","bundled":true},"isarray":{"version":"1.0.0","bundled":true},"isstream":{"version":"0.1.2","bundled":true},"jodid25519":{"version":"1.0.2","bundled":true,"optional":true,"requires":{"jsbn":"0.1.1"}},"jsbn":{"version":"0.1.1","bundled":true,"optional":true},"json-schema":{"version":"0.2.3","bundled":true},"json-stable-stringify":{"version":"1.0.1","bundled":true,"requires":{"jsonify":"0.0.0"}},"json-stringify-safe":{"version":"5.0.1","bundled":true},"jsonify":{"version":"0.0.0","bundled":true},"jsprim":{"version":"1.4.0","bundled":true,"requires":{"assert-plus":"1.0.0","extsprintf":"1.0.2","json-schema":"0.2.3","verror":"1.3.6"},"dependencies":{"assert-plus":{"version":"1.0.0","bundled":true}}},"mime-db":{"version":"1.27.0","bundled":true},"mime-types":{"version":"2.1.15","bundled":true,"requires":{"mime-db":"1.27.0"}},"minimatch":{"version":"3.0.4","bundled":true,"requires":{"brace-expansion":"1.1.7"}},"minimist":{"version":"0.0.8","bundled":true},"mkdirp":{"version":"0.5.1","bundled":true,"requires":{"minimist":"0.0.8"}},"ms":{"version":"2.0.0","bundled":true},"nan":{"version":"2.5.1","resolved":"https://registry.npmjs.org/nan/-/nan-2.5.1.tgz","integrity":"sha1-1bAWkSUzJql6K77p5hxV2NYDUeI="},"node-pre-gyp":{"version":"0.6.36","bundled":true,"requires":{"mkdirp":"0.5.1","nopt":"4.0.1","npmlog":"4.1.0","rc":"1.2.1","request":"2.81.0","rimraf":"2.6.1","semver":"5.3.0","tar":"2.2.1","tar-pack":"3.4.0"}},"nopt":{"version":"4.0.1","bundled":true,"requires":{"abbrev":"1.1.0","osenv":"0.1.4"}},"npmlog":{"version":"4.1.0","bundled":true,"requires":{"are-we-there-yet":"1.1.4","console-control-strings":"1.1.0","gauge":"2.7.4","set-blocking":"2.0.0"}},"number-is-nan":{"version":"1.0.1","bundled":true},"oauth-sign":{"version":"0.8.2","bundled":true},"object-assign":{"version":"4.1.1","bundled":true},"once":{"version":"1.4.0","bundled":true,"requires":{"wrappy":"1.0.2"}},"os-homedir":{"version":"1.0.2","bundled":true},"os-tmpdir":{"version":"1.0.2","bundled":true},"osenv":{"version":"0.1.4","bundled":true,"requires":{"os-homedir":"1.0.2","os-tmpdir":"1.0.2"}},"path-is-absolute":{"version":"1.0.1","bundled":true},"performance-now":{"version":"0.2.0","bundled":true},"process-nextick-args":{"version":"1.0.7","bundled":true},"punycode":{"version":"1.4.1","bundled":true},"qs":{"version":"6.4.0","bundled":true},"rc":{"version":"1.2.1","bundled":true,"requires":{"deep-extend":"0.4.2","ini":"1.3.4","minimist":"1.2.0","strip-json-comments":"2.0.1"},"dependencies":{"minimist":{"version":"1.2.0","bundled":true}}},"readable-stream":{"version":"2.2.11","bundled":true,"requires":{"core-util-is":"1.0.2","inherits":"2.0.3","isarray":"1.0.0","process-nextick-args":"1.0.7","safe-buffer":"5.0.1","string_decoder":"1.0.2","util-deprecate":"1.0.2"}},"request":{"version":"2.81.0","bundled":true,"requires":{"aws-sign2":"0.6.0","aws4":"1.6.0","caseless":"0.12.0","combined-stream":"1.0.5","extend":"3.0.1","forever-agent":"0.6.1","form-data":"2.1.4","har-validator":"4.2.1","hawk":"3.1.3","http-signature":"1.1.1","is-typedarray":"1.0.0","isstream":"0.1.2","json-stringify-safe":"5.0.1","mime-types":"2.1.15","oauth-sign":"0.8.2","performance-now":"0.2.0","qs":"6.4.0","safe-buffer":"5.0.1","stringstream":"0.0.5","tough-cookie":"2.3.2","tunnel-agent":"0.6.0","uuid":"3.0.1"}},"rimraf":{"version":"2.6.1","bundled":true,"requires":{"glob":"7.1.2"}},"safe-buffer":{"version":"5.0.1","bundled":true},"semver":{"version":"5.3.0","bundled":true},"set-blocking":{"version":"2.0.0","bundled":true},"signal-exit":{"version":"3.0.2","bundled":true},"sntp":{"version":"1.0.9","bundled":true,"requires":{"hoek":"2.16.3"}},"sshpk":{"version":"1.13.0","bundled":true,"requires":{"asn1":"0.2.3","assert-plus":"1.0.0","bcrypt-pbkdf":"1.0.1","dashdash":"1.14.1","ecc-jsbn":"0.1.1","getpass":"0.1.7","jodid25519":"1.0.2","jsbn":"0.1.1","tweetnacl":"0.14.5"},"dependencies":{"assert-plus":{"version":"1.0.0","bundled":true}}},"string_decoder":{"version":"1.0.2","bundled":true,"requires":{"safe-buffer":"5.0.1"}},"string-width":{"version":"1.0.2","bundled":true,"requires":{"code-point-at":"1.1.0","is-fullwidth-code-point":"1.0.0","strip-ansi":"3.0.1"}},"stringstream":{"version":"0.0.5","bundled":true},"strip-ansi":{"version":"3.0.1","bundled":true,"requires":{"ansi-regex":"2.1.1"}},"strip-json-comments":{"version":"2.0.1","bundled":true},"tar":{"version":"2.2.1","bundled":true,"requires":{"block-stream":"0.0.9","fstream":"1.0.11","inherits":"2.0.3"}},"tar-pack":{"version":"3.4.0","bundled":true,"requires":{"debug":"2.6.8","fstream":"1.0.11","fstream-ignore":"1.0.5","once":"1.4.0","readable-stream":"2.2.11","rimraf":"2.6.1","tar":"2.2.1","uid-number":"0.0.6"}},"tough-cookie":{"version":"2.3.2","bundled":true,"requires":{"punycode":"1.4.1"}},"tunnel-agent":{"version":"0.6.0","bundled":true,"requires":{"safe-buffer":"5.0.1"}},"tweetnacl":{"version":"0.14.5","bundled":true,"optional":true},"uid-number":{"version":"0.0.6","bundled":true},"util-deprecate":{"version":"1.0.2","bundled":true},"uuid":{"version":"3.0.1","bundled":true},"verror":{"version":"1.3.6","bundled":true,"requires":{"extsprintf":"1.0.2"}},"wide-align":{"version":"1.1.2","bundled":true,"requires":{"string-width":"1.0.2"}},"wrappy":{"version":"1.0.2","bundled":true}}},"macaddress":{"version":"0.2.8","resolved":"https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz","integrity":"sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=","dev":true},"make-dir":{"version":"1.1.0","resolved":"https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz","integrity":"sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==","requires":{"pify":"3.0.0"},"dependencies":{"pify":{"version":"3.0.0","resolved":"https://registry.npmjs.org/pify/-/pify-3.0.0.tgz","integrity":"sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="}}},"map-cache":{"version":"0.2.2","resolved":"https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz","integrity":"sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=","dev":true},"map-obj":{"version":"1.0.1","resolved":"https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz","integrity":"sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=","dev":true},"map-visit":{"version":"1.0.0","resolved":"https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz","integrity":"sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=","dev":true,"requires":{"object-visit":"1.0.1"}},"math-expression-evaluator":{"version":"1.2.17","resolved":"https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz","integrity":"sha1-3oGf282E3M2PrlnGrreWFbnSZqw=","dev":true},"md5":{"version":"2.2.1","resolved":"https://registry.npmjs.org/md5/-/md5-2.2.1.tgz","integrity":"sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=","dev":true,"requires":{"charenc":"0.0.2","crypt":"0.0.2","is-buffer":"1.1.5"}},"md5.js":{"version":"1.3.4","resolved":"https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz","integrity":"sha1-6b296UogpawYsENA/Fdk1bCdkB0=","dev":true,"requires":{"hash-base":"3.0.4","inherits":"2.0.3"},"dependencies":{"hash-base":{"version":"3.0.4","resolved":"https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz","integrity":"sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=","dev":true,"requires":{"inherits":"2.0.3","safe-buffer":"5.1.1"}}}},"media-typer":{"version":"0.3.0","resolved":"https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz","integrity":"sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=","dev":true},"mem":{"version":"1.1.0","resolved":"https://registry.npmjs.org/mem/-/mem-1.1.0.tgz","integrity":"sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=","dev":true,"requires":{"mimic-fn":"1.1.0"}},"memory-fs":{"version":"0.4.1","resolved":"https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz","integrity":"sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=","dev":true,"requires":{"errno":"0.1.4","readable-stream":"2.3.3"}},"meow":{"version":"3.7.0","resolved":"https://registry.npmjs.org/meow/-/meow-3.7.0.tgz","integrity":"sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=","dev":true,"requires":{"camelcase-keys":"2.1.0","decamelize":"1.2.0","loud-rejection":"1.6.0","map-obj":"1.0.1","minimist":"1.2.0","normalize-package-data":"2.4.0","object-assign":"4.1.1","read-pkg-up":"1.0.1","redent":"1.0.0","trim-newlines":"1.0.0"},"dependencies":{"minimist":{"version":"1.2.0","resolved":"https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz","integrity":"sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=","dev":true}}},"merge":{"version":"1.2.0","resolved":"https://registry.npmjs.org/merge/-/merge-1.2.0.tgz","integrity":"sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=","dev":true},"merge-descriptors":{"version":"1.0.1","resolved":"https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz","integrity":"sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=","dev":true},"merge-options":{"version":"0.0.64","resolved":"https://registry.npmjs.org/merge-options/-/merge-options-0.0.64.tgz","integrity":"sha1-y+BPWUppheryf3+PCyo6z2+dVi0=","dev":true,"requires":{"is-plain-obj":"1.1.0"}},"methods":{"version":"1.1.2","resolved":"https://registry.npmjs.org/methods/-/methods-1.1.2.tgz","integrity":"sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=","dev":true},"micromatch":{"version":"3.1.3","resolved":"https://registry.npmjs.org/micromatch/-/micromatch-3.1.3.tgz","integrity":"sha512-gVCSW2StFfuHZYfh/p/HJpdTyB/YX/mr/EATvmw9zMQa6BSUioG4hg4duKEKc47OaXioikzhgFYS/m4EyLmXXg==","dev":true,"requires":{"arr-diff":"4.0.0","array-unique":"0.3.2","braces":"2.3.0","define-property":"1.0.0","extend-shallow":"2.0.1","extglob":"2.0.2","fragment-cache":"0.2.1","kind-of":"6.0.0","nanomatch":"1.2.5","object.pick":"1.3.0","regex-not":"1.0.0","snapdragon":"0.8.1","to-regex":"3.0.1"}},"miller-rabin":{"version":"4.0.1","resolved":"https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz","integrity":"sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==","dev":true,"requires":{"bn.js":"4.11.8","brorand":"1.1.0"}},"mime":{"version":"2.0.3","resolved":"https://registry.npmjs.org/mime/-/mime-2.0.3.tgz","integrity":"sha512-TrpAd/vX3xaLPDgVRm6JkZwLR0KHfukMdU2wTEbqMDdCnY6Yo3mE+mjs9YE6oMNw2QRfXVeBEYpmpO94BIqiug==","dev":true},"mime-db":{"version":"1.30.0","resolved":"https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz","integrity":"sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="},"mime-types":{"version":"2.1.17","resolved":"https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz","integrity":"sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=","requires":{"mime-db":"1.30.0"}},"mimic-fn":{"version":"1.1.0","resolved":"https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz","integrity":"sha1-5md4PZLonb00KBi1IwudYqZyrRg=","dev":true},"min-document":{"version":"2.19.0","resolved":"https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz","integrity":"sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=","dev":true,"requires":{"dom-walk":"0.1.1"}},"minimalistic-assert":{"version":"1.0.0","resolved":"https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz","integrity":"sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=","dev":true},"minimalistic-crypto-utils":{"version":"1.0.1","resolved":"https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz","integrity":"sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=","dev":true},"minimatch":{"version":"3.0.4","resolved":"https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz","integrity":"sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==","requires":{"brace-expansion":"1.1.8"}},"minimist":{"version":"0.0.8","resolved":"https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz","integrity":"sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="},"mitt":{"version":"1.1.2","resolved":"https://registry.npmjs.org/mitt/-/mitt-1.1.2.tgz","integrity":"sha1-OA5hSA1qYVtmDwertg1R4KTkvtY=","dev":true},"mixin-deep":{"version":"1.2.0","resolved":"https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz","integrity":"sha1-0CuMb4ttS49ZgtP9AJxJGYUcP+I=","dev":true,"requires":{"for-in":"1.0.2","is-extendable":"0.1.1"}},"mixin-object":{"version":"2.0.1","resolved":"https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz","integrity":"sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=","dev":true,"requires":{"for-in":"0.1.8","is-extendable":"0.1.1"},"dependencies":{"for-in":{"version":"0.1.8","resolved":"https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz","integrity":"sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=","dev":true}}},"mixpanel":{"version":"0.7.0","resolved":"https://registry.npmjs.org/mixpanel/-/mixpanel-0.7.0.tgz","integrity":"sha1-KXGqbhmmJi98hfwi4RVPT14vYW8=","dev":true,"requires":{"https-proxy-agent":"1.0.0"}},"mixpanel-browser":{"version":"2.13.0","resolved":"https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.13.0.tgz","integrity":"sha1-61JsjTT4FnWV36oPOJT8ZZU0Gu8="},"mkdirp":{"version":"0.5.1","resolved":"https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz","integrity":"sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=","requires":{"minimist":"0.0.8"}},"mocha":{"version":"3.5.3","resolved":"https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz","integrity":"sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==","dev":true,"requires":{"browser-stdout":"1.3.0","commander":"2.9.0","debug":"2.6.8","diff":"3.2.0","escape-string-regexp":"1.0.5","glob":"7.1.1","growl":"1.9.2","he":"1.1.1","json3":"3.3.2","lodash.create":"3.1.1","mkdirp":"0.5.1","supports-color":"3.1.2"},"dependencies":{"commander":{"version":"2.9.0","resolved":"https://registry.npmjs.org/commander/-/commander-2.9.0.tgz","integrity":"sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=","dev":true,"requires":{"graceful-readlink":"1.0.1"}},"debug":{"version":"2.6.8","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.8.tgz","integrity":"sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=","dev":true,"requires":{"ms":"2.0.0"}},"glob":{"version":"7.1.1","resolved":"https://registry.npmjs.org/glob/-/glob-7.1.1.tgz","integrity":"sha1-gFIR3wT6rxxjo2ADBs31reULLsg=","dev":true,"requires":{"fs.realpath":"1.0.0","inflight":"1.0.6","inherits":"2.0.3","minimatch":"3.0.4","once":"1.4.0","path-is-absolute":"1.0.1"}},"supports-color":{"version":"3.1.2","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz","integrity":"sha1-cqJiiU2dQIuVbKBf83su2KbiotU=","dev":true,"requires":{"has-flag":"1.0.0"}}}},"mocha-junit-reporter":{"version":"1.15.0","resolved":"https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-1.15.0.tgz","integrity":"sha1-MJ9LeiD82ibQrWnJt9CAjXcjAsI=","dev":true,"requires":{"debug":"2.6.9","md5":"2.2.1","mkdirp":"0.5.1","xml":"1.0.1"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}}}},"mocha-webpack":{"version":"1.0.0-rc.1","resolved":"https://registry.npmjs.org/mocha-webpack/-/mocha-webpack-1.0.0-rc.1.tgz","integrity":"sha512-9e0whjKF+NpmT1qM5nQ+iUkS314Sw8UJcxFUr3iMP2epTG/JJj/kscQWGgf8V1BK9kvxuePw3jU6db+M5r82Uw==","dev":true,"requires":{"babel-runtime":"6.26.0","chalk":"1.1.3","chokidar":"1.7.0","glob-parent":"2.0.0","globby":"6.1.0","interpret":"1.0.4","is-glob":"2.0.1","loader-utils":"1.1.0","lodash":"4.17.4","memory-fs":"0.4.1","nodent-runtime":"3.0.4","normalize-path":"2.1.1","progress":"1.1.8","source-map-support":"0.4.18","toposort":"1.0.6","yargs":"4.8.1"},"dependencies":{"ansi-styles":{"version":"2.2.1","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz","integrity":"sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=","dev":true},"camelcase":{"version":"3.0.0","resolved":"https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz","integrity":"sha1-MvxLn82vhF/N9+c7uXysImHwqwo=","dev":true},"chalk":{"version":"1.1.3","resolved":"https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz","integrity":"sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=","dev":true,"requires":{"ansi-styles":"2.2.1","escape-string-regexp":"1.0.5","has-ansi":"2.0.0","strip-ansi":"3.0.1","supports-color":"2.0.0"}},"has-ansi":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz","integrity":"sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=","dev":true,"requires":{"ansi-regex":"2.1.1"}},"is-extglob":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz","integrity":"sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=","dev":true},"is-glob":{"version":"2.0.1","resolved":"https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz","integrity":"sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=","dev":true,"requires":{"is-extglob":"1.0.0"}},"normalize-path":{"version":"2.1.1","resolved":"https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz","integrity":"sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=","dev":true,"requires":{"remove-trailing-separator":"1.1.0"}},"os-locale":{"version":"1.4.0","resolved":"https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz","integrity":"sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=","dev":true,"requires":{"lcid":"1.0.0"}},"progress":{"version":"1.1.8","resolved":"https://registry.npmjs.org/progress/-/progress-1.1.8.tgz","integrity":"sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=","dev":true},"source-map":{"version":"0.5.7","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz","integrity":"sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=","dev":true},"source-map-support":{"version":"0.4.18","resolved":"https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz","integrity":"sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==","dev":true,"requires":{"source-map":"0.5.7"}},"supports-color":{"version":"2.0.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz","integrity":"sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=","dev":true},"which-module":{"version":"1.0.0","resolved":"https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz","integrity":"sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=","dev":true},"yargs":{"version":"4.8.1","resolved":"https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz","integrity":"sha1-wMQpJMpKqmsObaFznfshZDn53cA=","dev":true,"requires":{"cliui":"3.2.0","decamelize":"1.2.0","get-caller-file":"1.0.2","lodash.assign":"4.2.0","os-locale":"1.4.0","read-pkg-up":"1.0.1","require-directory":"2.1.1","require-main-filename":"1.0.1","set-blocking":"2.0.0","string-width":"1.0.2","which-module":"1.0.0","window-size":"0.2.0","y18n":"3.2.1","yargs-parser":"2.4.1"}},"yargs-parser":{"version":"2.4.1","resolved":"https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz","integrity":"sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=","dev":true,"requires":{"camelcase":"3.0.0","lodash.assign":"4.2.0"}}}},"moment":{"version":"2.19.1","resolved":"https://registry.npmjs.org/moment/-/moment-2.19.1.tgz","integrity":"sha1-VtoaLRy/AdOLfhr8McELz6GSkWc="},"morgan":{"version":"1.9.0","resolved":"https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz","integrity":"sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=","dev":true,"requires":{"basic-auth":"2.0.0","debug":"2.6.9","depd":"1.1.1","on-finished":"2.3.0","on-headers":"1.0.1"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}}}},"ms":{"version":"2.0.0","resolved":"https://registry.npmjs.org/ms/-/ms-2.0.0.tgz","integrity":"sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="},"multicast-dns":{"version":"6.1.1","resolved":"https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.1.tgz","integrity":"sha1-bn3oalcIcqsXBYrepxYLvsqBTd4=","dev":true,"requires":{"dns-packet":"1.2.2","thunky":"0.1.0"}},"multicast-dns-service-types":{"version":"1.1.0","resolved":"https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz","integrity":"sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=","dev":true},"mute-stream":{"version":"0.0.7","resolved":"https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz","integrity":"sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=","dev":true},"nan":{"version":"2.7.0","resolved":"https://registry.npmjs.org/nan/-/nan-2.7.0.tgz","integrity":"sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="},"nanomatch":{"version":"1.2.5","resolved":"https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.5.tgz","integrity":"sha512-ZHJamn1utzcUvW8Bais+Kk7pobp6dKmUEKOSQ/HI2glGwOMA/GvjRRKlLyORBUrdRXnwTU/6LIBcW7jYSlutgg==","dev":true,"requires":{"arr-diff":"4.0.0","array-unique":"0.3.2","define-property":"1.0.0","extend-shallow":"2.0.1","fragment-cache":"0.2.1","is-odd":"1.0.0","kind-of":"5.1.0","object.pick":"1.3.0","regex-not":"1.0.0","snapdragon":"0.8.1","to-regex":"3.0.1"},"dependencies":{"kind-of":{"version":"5.1.0","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz","integrity":"sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==","dev":true}}},"negotiator":{"version":"0.6.1","resolved":"https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz","integrity":"sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=","dev":true},"node-abi":{"version":"2.1.1","resolved":"https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz","integrity":"sha512-6oxV13poCOv7TfGvhsSz6XZWpXeKkdGVh72++cs33OfMh3KAX8lN84dCvmqSETyDXAFcUHtV7eJrgFBoOqZbNQ==","dev":true},"node-emoji":{"version":"1.8.1","resolved":"https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz","integrity":"sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==","dev":true,"requires":{"lodash.toarray":"4.4.0"}},"node-fetch":{"version":"1.7.3","resolved":"https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz","integrity":"sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==","requires":{"encoding":"0.1.12","is-stream":"1.1.0"}},"node-forge":{"version":"0.6.33","resolved":"https://registry.npmjs.org/node-forge/-/node-forge-0.6.33.tgz","integrity":"sha1-RjgRh59XPUUVWtap9D3ClujoXrw=","dev":true},"node-gyp":{"version":"3.6.2","resolved":"https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz","integrity":"sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=","dev":true,"requires":{"fstream":"1.0.11","glob":"7.1.2","graceful-fs":"4.1.11","minimatch":"3.0.4","mkdirp":"0.5.1","nopt":"3.0.6","npmlog":"4.1.2","osenv":"0.1.4","request":"2.83.0","rimraf":"2.6.2","semver":"5.3.0","tar":"2.2.1","which":"1.3.0"},"dependencies":{"nopt":{"version":"3.0.6","resolved":"https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz","integrity":"sha1-xkZdvwirzU2zWTF/eaxopkayj/k=","dev":true,"requires":{"abbrev":"1.1.1"}},"semver":{"version":"5.3.0","resolved":"https://registry.npmjs.org/semver/-/semver-5.3.0.tgz","integrity":"sha1-myzl094C0XxgEq0yaqa00M9U+U8=","dev":true}}},"node-libs-browser":{"version":"2.0.0","resolved":"https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz","integrity":"sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=","dev":true,"requires":{"assert":"1.4.1","browserify-zlib":"0.1.4","buffer":"4.9.1","console-browserify":"1.1.0","constants-browserify":"1.0.0","crypto-browserify":"3.11.1","domain-browser":"1.1.7","events":"1.1.1","https-browserify":"0.0.1","os-browserify":"0.2.1","path-browserify":"0.0.0","process":"0.11.10","punycode":"1.4.1","querystring-es3":"0.2.1","readable-stream":"2.3.3","stream-browserify":"2.0.1","stream-http":"2.7.2","string_decoder":"0.10.31","timers-browserify":"2.0.4","tty-browserify":"0.0.0","url":"0.11.0","util":"0.10.3","vm-browserify":"0.0.4"},"dependencies":{"base64-js":{"version":"1.2.1","resolved":"https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz","integrity":"sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==","dev":true},"buffer":{"version":"4.9.1","resolved":"https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz","integrity":"sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=","dev":true,"requires":{"base64-js":"1.2.1","ieee754":"1.1.8","isarray":"1.0.0"}},"crypto-browserify":{"version":"3.11.1","resolved":"https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz","integrity":"sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==","dev":true,"requires":{"browserify-cipher":"1.0.0","browserify-sign":"4.0.4","create-ecdh":"4.0.0","create-hash":"1.1.3","create-hmac":"1.1.6","diffie-hellman":"5.0.2","inherits":"2.0.3","pbkdf2":"3.0.14","public-encrypt":"4.0.0","randombytes":"2.0.5"}},"process":{"version":"0.11.10","resolved":"https://registry.npmjs.org/process/-/process-0.11.10.tgz","integrity":"sha1-czIwDoQBYb2j5podHZGn1LwW8YI=","dev":true},"string_decoder":{"version":"0.10.31","resolved":"https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz","integrity":"sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=","dev":true},"url":{"version":"0.11.0","resolved":"https://registry.npmjs.org/url/-/url-0.11.0.tgz","integrity":"sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=","dev":true,"requires":{"punycode":"1.3.2","querystring":"0.2.0"},"dependencies":{"punycode":{"version":"1.3.2","resolved":"https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz","integrity":"sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=","dev":true}}}}},"node-pre-gyp":{"version":"0.6.38","resolved":"https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.38.tgz","integrity":"sha1-6Sog+DQWQVu0CG9tH7eLPac9ET0=","requires":{"hawk":"3.1.3","mkdirp":"0.5.1","nopt":"4.0.1","npmlog":"4.1.2","rc":"1.2.2","request":"2.81.0","rimraf":"2.6.2","semver":"5.4.1","tar":"2.2.1","tar-pack":"3.4.1"},"dependencies":{"request":{"version":"2.81.0","resolved":"https://registry.npmjs.org/request/-/request-2.81.0.tgz","integrity":"sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=","requires":{"aws-sign2":"0.6.0","aws4":"1.6.0","caseless":"0.12.0","combined-stream":"1.0.5","extend":"3.0.1","forever-agent":"0.6.1","form-data":"2.1.4","har-validator":"4.2.1","hawk":"3.1.3","http-signature":"1.1.1","is-typedarray":"1.0.0","isstream":"0.1.2","json-stringify-safe":"5.0.1","mime-types":"2.1.17","oauth-sign":"0.8.2","performance-now":"0.2.0","qs":"6.4.0","safe-buffer":"5.1.1","stringstream":"0.0.5","tough-cookie":"2.3.3","tunnel-agent":"0.6.0","uuid":"3.1.0"}}}},"node-sass":{"version":"4.5.3","resolved":"https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz","integrity":"sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=","dev":true,"requires":{"async-foreach":"0.1.3","chalk":"1.1.3","cross-spawn":"3.0.1","gaze":"1.1.2","get-stdin":"4.0.1","glob":"7.1.2","in-publish":"2.0.0","lodash.assign":"4.2.0","lodash.clonedeep":"4.5.0","lodash.mergewith":"4.6.0","meow":"3.7.0","mkdirp":"0.5.1","nan":"2.7.0","node-gyp":"3.6.2","npmlog":"4.1.2","request":"2.83.0","sass-graph":"2.2.4","stdout-stream":"1.4.0"},"dependencies":{"ansi-styles":{"version":"2.2.1","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz","integrity":"sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=","dev":true},"chalk":{"version":"1.1.3","resolved":"https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz","integrity":"sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=","dev":true,"requires":{"ansi-styles":"2.2.1","escape-string-regexp":"1.0.5","has-ansi":"2.0.0","strip-ansi":"3.0.1","supports-color":"2.0.0"}},"cross-spawn":{"version":"3.0.1","resolved":"https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz","integrity":"sha1-ElYDfsufDF9549bvE14wdwGEuYI=","dev":true,"requires":{"lru-cache":"4.1.1","which":"1.3.0"}},"has-ansi":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz","integrity":"sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=","dev":true,"requires":{"ansi-regex":"2.1.1"}},"supports-color":{"version":"2.0.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz","integrity":"sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=","dev":true}}},"nodent-runtime":{"version":"3.0.4","resolved":"https://registry.npmjs.org/nodent-runtime/-/nodent-runtime-3.0.4.tgz","integrity":"sha1-qAHst7sPbDmmmyTML6Nwz6i0kto=","dev":true},"noop-logger":{"version":"0.1.1","resolved":"https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz","integrity":"sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=","dev":true},"nopt":{"version":"4.0.1","resolved":"https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz","integrity":"sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=","requires":{"abbrev":"1.1.1","osenv":"0.1.4"}},"normalize-package-data":{"version":"2.4.0","resolved":"https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz","integrity":"sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==","dev":true,"requires":{"hosted-git-info":"2.5.0","is-builtin-module":"1.0.0","semver":"5.4.1","validate-npm-package-license":"3.0.1"}},"normalize-path":{"version":"1.0.0","resolved":"https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz","integrity":"sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=","dev":true},"normalize-range":{"version":"0.1.2","resolved":"https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz","integrity":"sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=","dev":true},"normalize-url":{"version":"1.9.1","resolved":"https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz","integrity":"sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=","dev":true,"requires":{"object-assign":"4.1.1","prepend-http":"1.0.4","query-string":"4.3.4","sort-keys":"1.1.2"}},"npm-install-package":{"version":"2.1.0","resolved":"https://registry.npmjs.org/npm-install-package/-/npm-install-package-2.1.0.tgz","integrity":"sha1-1+/jz816sAYUuJbqUxGdyaslkSU=","dev":true},"npm-path":{"version":"2.0.3","resolved":"https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz","integrity":"sha1-Fc/04ciaONp39W9gVbJPl137K74=","dev":true,"requires":{"which":"1.3.0"}},"npm-run-path":{"version":"2.0.2","resolved":"https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz","integrity":"sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=","dev":true,"requires":{"path-key":"2.0.1"}},"npm-which":{"version":"3.0.1","resolved":"https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz","integrity":"sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=","dev":true,"requires":{"commander":"2.11.0","npm-path":"2.0.3","which":"1.3.0"},"dependencies":{"commander":{"version":"2.11.0","resolved":"https://registry.npmjs.org/commander/-/commander-2.11.0.tgz","integrity":"sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==","dev":true}}},"npmlog":{"version":"4.1.2","resolved":"https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz","integrity":"sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==","requires":{"are-we-there-yet":"1.1.4","console-control-strings":"1.1.0","gauge":"2.7.4","set-blocking":"2.0.0"}},"nugget":{"version":"2.0.1","resolved":"https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz","integrity":"sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=","dev":true,"requires":{"debug":"2.6.9","minimist":"1.2.0","pretty-bytes":"1.0.4","progress-stream":"1.2.0","request":"2.83.0","single-line-log":"1.1.2","throttleit":"0.0.2"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}},"minimist":{"version":"1.2.0","resolved":"https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz","integrity":"sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=","dev":true}}},"null-loader":{"version":"0.1.1","resolved":"https://registry.npmjs.org/null-loader/-/null-loader-0.1.1.tgz","integrity":"sha1-F76av80/8OFRL2/Er8sfUDk3j64=","dev":true},"num2fraction":{"version":"1.2.2","resolved":"https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz","integrity":"sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=","dev":true},"number-is-nan":{"version":"1.0.1","resolved":"https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz","integrity":"sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="},"nwmatcher":{"version":"1.4.3","resolved":"https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz","integrity":"sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==","dev":true},"oauth-sign":{"version":"0.8.2","resolved":"https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz","integrity":"sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="},"object-assign":{"version":"4.1.1","resolved":"https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz","integrity":"sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="},"object-copy":{"version":"0.1.0","resolved":"https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz","integrity":"sha1-fn2Fi3gb18mRpBupde04EnVOmYw=","dev":true,"requires":{"copy-descriptor":"0.1.1","define-property":"0.2.5","kind-of":"3.2.2"},"dependencies":{"define-property":{"version":"0.2.5","resolved":"https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz","integrity":"sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=","dev":true,"requires":{"is-descriptor":"0.1.6"}},"is-descriptor":{"version":"0.1.6","resolved":"https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz","integrity":"sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==","dev":true,"requires":{"is-accessor-descriptor":"0.1.6","is-data-descriptor":"0.1.4","kind-of":"5.1.0"},"dependencies":{"kind-of":{"version":"5.1.0","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz","integrity":"sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==","dev":true}}},"kind-of":{"version":"3.2.2","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz","integrity":"sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=","dev":true,"requires":{"is-buffer":"1.1.5"}}}},"object-keys":{"version":"0.4.0","resolved":"https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz","integrity":"sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=","dev":true},"object-path":{"version":"0.9.2","resolved":"https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz","integrity":"sha1-D9mnT8X60a45aLWGvaXGMr1sBaU=","dev":true},"object-visit":{"version":"1.0.1","resolved":"https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz","integrity":"sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=","dev":true,"requires":{"isobject":"3.0.1"}},"object.omit":{"version":"2.0.1","resolved":"https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz","integrity":"sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=","dev":true,"requires":{"for-own":"0.1.5","is-extendable":"0.1.1"}},"object.pick":{"version":"1.3.0","resolved":"https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz","integrity":"sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=","dev":true,"requires":{"isobject":"3.0.1"}},"obuf":{"version":"1.1.1","resolved":"https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz","integrity":"sha1-EEEktsYCxnlogaBCVB0220OlJk4=","dev":true},"on-finished":{"version":"2.3.0","resolved":"https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz","integrity":"sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=","dev":true,"requires":{"ee-first":"1.1.1"}},"on-headers":{"version":"1.0.1","resolved":"https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz","integrity":"sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=","dev":true},"once":{"version":"1.4.0","resolved":"https://registry.npmjs.org/once/-/once-1.4.0.tgz","integrity":"sha1-WDsap3WWHUsROsF9nFC6753Xa9E=","requires":{"wrappy":"1.0.2"}},"onetime":{"version":"1.1.0","resolved":"https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz","integrity":"sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=","dev":true},"opn":{"version":"5.1.0","resolved":"https://registry.npmjs.org/opn/-/opn-5.1.0.tgz","integrity":"sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==","dev":true,"requires":{"is-wsl":"1.1.0"}},"optimist":{"version":"0.6.1","resolved":"https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz","integrity":"sha1-2j6nRob6IaGaERwybpDrFaAZZoY=","dev":true,"requires":{"minimist":"0.0.8","wordwrap":"0.0.3"},"dependencies":{"wordwrap":{"version":"0.0.3","resolved":"https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz","integrity":"sha1-o9XabNXAvAAI03I0u68b7WMFkQc=","dev":true}}},"optionator":{"version":"0.8.2","resolved":"https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz","integrity":"sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=","dev":true,"requires":{"deep-is":"0.1.3","fast-levenshtein":"2.0.6","levn":"0.3.0","prelude-ls":"1.1.2","type-check":"0.3.2","wordwrap":"1.0.0"}},"ora":{"version":"0.2.3","resolved":"https://registry.npmjs.org/ora/-/ora-0.2.3.tgz","integrity":"sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=","dev":true,"requires":{"chalk":"1.1.3","cli-cursor":"1.0.2","cli-spinners":"0.1.2","object-assign":"4.1.1"},"dependencies":{"ansi-styles":{"version":"2.2.1","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz","integrity":"sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=","dev":true},"chalk":{"version":"1.1.3","resolved":"https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz","integrity":"sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=","dev":true,"requires":{"ansi-styles":"2.2.1","escape-string-regexp":"1.0.5","has-ansi":"2.0.0","strip-ansi":"3.0.1","supports-color":"2.0.0"}},"has-ansi":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz","integrity":"sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=","dev":true,"requires":{"ansi-regex":"2.1.1"}},"supports-color":{"version":"2.0.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz","integrity":"sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=","dev":true}}},"original":{"version":"1.0.0","resolved":"https://registry.npmjs.org/original/-/original-1.0.0.tgz","integrity":"sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=","dev":true,"requires":{"url-parse":"1.0.5"},"dependencies":{"querystringify":{"version":"0.0.4","resolved":"https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz","integrity":"sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw=","dev":true},"url-parse":{"version":"1.0.5","resolved":"https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz","integrity":"sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=","dev":true,"requires":{"querystringify":"0.0.4","requires-port":"1.0.0"}}}},"os-browserify":{"version":"0.2.1","resolved":"https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz","integrity":"sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=","dev":true},"os-homedir":{"version":"1.0.2","resolved":"https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz","integrity":"sha1-/7xJiDNuDoM94MFox+8VISGqf7M="},"os-locale":{"version":"2.1.0","resolved":"https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz","integrity":"sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==","dev":true,"requires":{"execa":"0.7.0","lcid":"1.0.0","mem":"1.1.0"}},"os-tmpdir":{"version":"1.0.2","resolved":"https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz","integrity":"sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="},"osenv":{"version":"0.1.4","resolved":"https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz","integrity":"sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=","requires":{"os-homedir":"1.0.2","os-tmpdir":"1.0.2"}},"p-finally":{"version":"1.0.0","resolved":"https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz","integrity":"sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=","dev":true},"p-limit":{"version":"1.1.0","resolved":"https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz","integrity":"sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=","dev":true},"p-locate":{"version":"2.0.0","resolved":"https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz","integrity":"sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=","dev":true,"requires":{"p-limit":"1.1.0"}},"p-map":{"version":"1.2.0","resolved":"https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz","integrity":"sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==","dev":true},"package-json":{"version":"4.0.1","resolved":"https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz","integrity":"sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=","dev":true,"requires":{"got":"6.7.1","registry-auth-token":"3.3.1","registry-url":"3.1.0","semver":"5.4.1"}},"pako":{"version":"0.2.9","resolved":"https://registry.npmjs.org/pako/-/pako-0.2.9.tgz","integrity":"sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=","dev":true},"parse-asn1":{"version":"5.1.0","resolved":"https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz","integrity":"sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=","dev":true,"requires":{"asn1.js":"4.9.1","browserify-aes":"1.1.1","create-hash":"1.1.3","evp_bytestokey":"1.0.3","pbkdf2":"3.0.14"}},"parse-color":{"version":"1.0.0","resolved":"https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz","integrity":"sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=","dev":true,"requires":{"color-convert":"0.5.3"},"dependencies":{"color-convert":{"version":"0.5.3","resolved":"https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz","integrity":"sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=","dev":true}}},"parse-glob":{"version":"3.0.4","resolved":"https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz","integrity":"sha1-ssN2z7EfNVE7rdFz7wu246OIORw=","dev":true,"requires":{"glob-base":"0.3.0","is-dotfile":"1.0.3","is-extglob":"1.0.0","is-glob":"2.0.1"},"dependencies":{"is-extglob":{"version":"1.0.0","resolved":"https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz","integrity":"sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=","dev":true},"is-glob":{"version":"2.0.1","resolved":"https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz","integrity":"sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=","dev":true,"requires":{"is-extglob":"1.0.0"}}}},"parse-json":{"version":"2.2.0","resolved":"https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz","integrity":"sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=","dev":true,"requires":{"error-ex":"1.3.1"}},"parse5":{"version":"3.0.2","resolved":"https://registry.npmjs.org/parse5/-/parse5-3.0.2.tgz","integrity":"sha1-Be/1fw70V3+xRKefi5qWemzERRA=","dev":true,"requires":{"@types/node":"6.0.90"},"dependencies":{"@types/node":{"version":"6.0.90","resolved":"https://registry.npmjs.org/@types/node/-/node-6.0.90.tgz","integrity":"sha512-tXoGRVdi7wZX7P1VWoV9Wfk0uYDOAHdEYXAttuWgSrN76Q32wQlSrMX0Rgyv3RTEaQY2ZLQrzYHVM2e8rfo8sA==","dev":true}}},"parseurl":{"version":"1.3.2","resolved":"https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz","integrity":"sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=","dev":true},"pascalcase":{"version":"0.1.1","resolved":"https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz","integrity":"sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=","dev":true},"path-browserify":{"version":"0.0.0","resolved":"https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz","integrity":"sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=","dev":true},"path-exists":{"version":"2.1.0","resolved":"https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz","integrity":"sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=","dev":true,"requires":{"pinkie-promise":"2.0.1"}},"path-is-absolute":{"version":"1.0.1","resolved":"https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz","integrity":"sha1-F0uSaHNVNP+8es5r9TpanhtcX18="},"path-is-inside":{"version":"1.0.2","resolved":"https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz","integrity":"sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=","dev":true},"path-key":{"version":"2.0.1","resolved":"https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz","integrity":"sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=","dev":true},"path-parse":{"version":"1.0.5","resolved":"https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz","integrity":"sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=","dev":true},"path-to-regexp":{"version":"2.1.0","resolved":"https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.1.0.tgz","integrity":"sha512-dZY7QPCPp5r9cnNuQ955mOv4ZFVDXY/yvqeV7Y1W2PJA3PEFcuow9xKFfJxbBj1pIjOAP+M2B4/7xubmykLrXw==","dev":true},"path-type":{"version":"1.1.0","resolved":"https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz","integrity":"sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=","dev":true,"requires":{"graceful-fs":"4.1.11","pify":"2.3.0","pinkie-promise":"2.0.1"}},"pbkdf2":{"version":"3.0.14","resolved":"https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz","integrity":"sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==","dev":true,"requires":{"create-hash":"1.1.3","create-hmac":"1.1.6","ripemd160":"2.0.1","safe-buffer":"5.1.1","sha.js":"2.4.9"}},"pend":{"version":"1.2.0","resolved":"https://registry.npmjs.org/pend/-/pend-1.2.0.tgz","integrity":"sha1-elfrVQpng/kRUzH89GY9XI4AelA="},"performance-now":{"version":"0.2.0","resolved":"https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz","integrity":"sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="},"pify":{"version":"2.3.0","resolved":"https://registry.npmjs.org/pify/-/pify-2.3.0.tgz","integrity":"sha1-7RQaasBDqEnqWISY59yosVMw6Qw="},"pinkie":{"version":"2.0.4","resolved":"https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz","integrity":"sha1-clVrgM+g1IqXToDnckjoDtT3+HA="},"pinkie-promise":{"version":"2.0.1","resolved":"https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz","integrity":"sha1-ITXW36ejWMBprJsXh3YogihFD/o=","requires":{"pinkie":"2.0.4"}},"pkg-dir":{"version":"2.0.0","resolved":"https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz","integrity":"sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=","dev":true,"requires":{"find-up":"2.1.0"},"dependencies":{"find-up":{"version":"2.1.0","resolved":"https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz","integrity":"sha1-RdG35QbHF93UgndaK3eSCjwMV6c=","dev":true,"requires":{"locate-path":"2.0.0"}}}},"plist":{"version":"2.1.0","resolved":"https://registry.npmjs.org/plist/-/plist-2.1.0.tgz","integrity":"sha1-V8zbeggh3yGDEhejytVOPhRqECU=","dev":true,"requires":{"base64-js":"1.2.0","xmlbuilder":"8.2.2","xmldom":"0.1.27"},"dependencies":{"base64-js":{"version":"1.2.0","resolved":"https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz","integrity":"sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=","dev":true}}},"pluralize":{"version":"1.2.1","resolved":"https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz","integrity":"sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=","dev":true},"pn":{"version":"1.0.0","resolved":"https://registry.npmjs.org/pn/-/pn-1.0.0.tgz","integrity":"sha1-HPWjCw2AbNGPiPxBprXUrWFbO6k=","dev":true},"portfinder":{"version":"1.0.13","resolved":"https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz","integrity":"sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=","dev":true,"requires":{"async":"1.5.2","debug":"2.6.9","mkdirp":"0.5.1"},"dependencies":{"async":{"version":"1.5.2","resolved":"https://registry.npmjs.org/async/-/async-1.5.2.tgz","integrity":"sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=","dev":true},"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}}}},"posix-character-classes":{"version":"0.1.1","resolved":"https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz","integrity":"sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=","dev":true},"postcss":{"version":"5.2.18","resolved":"https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz","integrity":"sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==","dev":true,"requires":{"chalk":"1.1.3","js-base64":"2.3.2","source-map":"0.5.7","supports-color":"3.2.3"},"dependencies":{"ansi-styles":{"version":"2.2.1","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz","integrity":"sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=","dev":true},"chalk":{"version":"1.1.3","resolved":"https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz","integrity":"sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=","dev":true,"requires":{"ansi-styles":"2.2.1","escape-string-regexp":"1.0.5","has-ansi":"2.0.0","strip-ansi":"3.0.1","supports-color":"2.0.0"},"dependencies":{"supports-color":{"version":"2.0.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz","integrity":"sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=","dev":true}}},"has-ansi":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz","integrity":"sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=","dev":true,"requires":{"ansi-regex":"2.1.1"}},"source-map":{"version":"0.5.7","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz","integrity":"sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=","dev":true}}},"postcss-calc":{"version":"5.3.1","resolved":"https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz","integrity":"sha1-d7rnypKK2FcW4v2kLyYb98HWW14=","dev":true,"requires":{"postcss":"5.2.18","postcss-message-helpers":"2.0.0","reduce-css-calc":"1.3.0"}},"postcss-colormin":{"version":"2.2.2","resolved":"https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz","integrity":"sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=","dev":true,"requires":{"colormin":"1.1.2","postcss":"5.2.18","postcss-value-parser":"3.3.0"}},"postcss-convert-values":{"version":"2.6.1","resolved":"https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz","integrity":"sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=","dev":true,"requires":{"postcss":"5.2.18","postcss-value-parser":"3.3.0"}},"postcss-discard-comments":{"version":"2.0.4","resolved":"https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz","integrity":"sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=","dev":true,"requires":{"postcss":"5.2.18"}},"postcss-discard-duplicates":{"version":"2.1.0","resolved":"https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz","integrity":"sha1-uavye4isGIFYpesSq8riAmO5GTI=","dev":true,"requires":{"postcss":"5.2.18"}},"postcss-discard-empty":{"version":"2.1.0","resolved":"https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz","integrity":"sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=","dev":true,"requires":{"postcss":"5.2.18"}},"postcss-discard-overridden":{"version":"0.1.1","resolved":"https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz","integrity":"sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=","dev":true,"requires":{"postcss":"5.2.18"}},"postcss-discard-unused":{"version":"2.2.3","resolved":"https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz","integrity":"sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=","dev":true,"requires":{"postcss":"5.2.18","uniqs":"2.0.0"}},"postcss-filter-plugins":{"version":"2.0.2","resolved":"https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz","integrity":"sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=","dev":true,"requires":{"postcss":"5.2.18","uniqid":"4.1.1"}},"postcss-merge-idents":{"version":"2.1.7","resolved":"https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz","integrity":"sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=","dev":true,"requires":{"has":"1.0.1","postcss":"5.2.18","postcss-value-parser":"3.3.0"}},"postcss-merge-longhand":{"version":"2.0.2","resolved":"https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz","integrity":"sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=","dev":true,"requires":{"postcss":"5.2.18"}},"postcss-merge-rules":{"version":"2.1.2","resolved":"https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz","integrity":"sha1-0d9d+qexrMO+VT8OnhDofGG19yE=","dev":true,"requires":{"browserslist":"1.7.7","caniuse-api":"1.6.1","postcss":"5.2.18","postcss-selector-parser":"2.2.3","vendors":"1.0.1"}},"postcss-message-helpers":{"version":"2.0.0","resolved":"https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz","integrity":"sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=","dev":true},"postcss-minify-font-values":{"version":"1.0.5","resolved":"https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz","integrity":"sha1-S1jttWZB66fIR0qzUmyv17vey2k=","dev":true,"requires":{"object-assign":"4.1.1","postcss":"5.2.18","postcss-value-parser":"3.3.0"}},"postcss-minify-gradients":{"version":"1.0.5","resolved":"https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz","integrity":"sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=","dev":true,"requires":{"postcss":"5.2.18","postcss-value-parser":"3.3.0"}},"postcss-minify-params":{"version":"1.2.2","resolved":"https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz","integrity":"sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=","dev":true,"requires":{"alphanum-sort":"1.0.2","postcss":"5.2.18","postcss-value-parser":"3.3.0","uniqs":"2.0.0"}},"postcss-minify-selectors":{"version":"2.1.1","resolved":"https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz","integrity":"sha1-ssapjAByz5G5MtGkllCBFDEXNb8=","dev":true,"requires":{"alphanum-sort":"1.0.2","has":"1.0.1","postcss":"5.2.18","postcss-selector-parser":"2.2.3"}},"postcss-modules-extract-imports":{"version":"1.1.0","resolved":"https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz","integrity":"sha1-thTJcgvmgW6u41+zpfqh26agXds=","dev":true,"requires":{"postcss":"6.0.13"},"dependencies":{"ansi-styles":{"version":"3.2.0","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz","integrity":"sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==","dev":true,"requires":{"color-convert":"1.9.0"}},"chalk":{"version":"2.3.0","resolved":"https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz","integrity":"sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==","dev":true,"requires":{"ansi-styles":"3.2.0","escape-string-regexp":"1.0.5","supports-color":"4.5.0"}},"has-flag":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz","integrity":"sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=","dev":true},"postcss":{"version":"6.0.13","resolved":"https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz","integrity":"sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==","dev":true,"requires":{"chalk":"2.3.0","source-map":"0.6.1","supports-color":"4.5.0"}},"supports-color":{"version":"4.5.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz","integrity":"sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=","dev":true,"requires":{"has-flag":"2.0.0"}}}},"postcss-modules-local-by-default":{"version":"1.2.0","resolved":"https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz","integrity":"sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=","dev":true,"requires":{"css-selector-tokenizer":"0.7.0","postcss":"6.0.13"},"dependencies":{"ansi-styles":{"version":"3.2.0","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz","integrity":"sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==","dev":true,"requires":{"color-convert":"1.9.0"}},"chalk":{"version":"2.3.0","resolved":"https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz","integrity":"sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==","dev":true,"requires":{"ansi-styles":"3.2.0","escape-string-regexp":"1.0.5","supports-color":"4.5.0"}},"has-flag":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz","integrity":"sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=","dev":true},"postcss":{"version":"6.0.13","resolved":"https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz","integrity":"sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==","dev":true,"requires":{"chalk":"2.3.0","source-map":"0.6.1","supports-color":"4.5.0"}},"supports-color":{"version":"4.5.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz","integrity":"sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=","dev":true,"requires":{"has-flag":"2.0.0"}}}},"postcss-modules-scope":{"version":"1.1.0","resolved":"https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz","integrity":"sha1-1upkmUx5+XtipytCb75gVqGUu5A=","dev":true,"requires":{"css-selector-tokenizer":"0.7.0","postcss":"6.0.13"},"dependencies":{"ansi-styles":{"version":"3.2.0","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz","integrity":"sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==","dev":true,"requires":{"color-convert":"1.9.0"}},"chalk":{"version":"2.3.0","resolved":"https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz","integrity":"sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==","dev":true,"requires":{"ansi-styles":"3.2.0","escape-string-regexp":"1.0.5","supports-color":"4.5.0"}},"has-flag":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz","integrity":"sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=","dev":true},"postcss":{"version":"6.0.13","resolved":"https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz","integrity":"sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==","dev":true,"requires":{"chalk":"2.3.0","source-map":"0.6.1","supports-color":"4.5.0"}},"supports-color":{"version":"4.5.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz","integrity":"sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=","dev":true,"requires":{"has-flag":"2.0.0"}}}},"postcss-modules-values":{"version":"1.3.0","resolved":"https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz","integrity":"sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=","dev":true,"requires":{"icss-replace-symbols":"1.1.0","postcss":"6.0.13"},"dependencies":{"ansi-styles":{"version":"3.2.0","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz","integrity":"sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==","dev":true,"requires":{"color-convert":"1.9.0"}},"chalk":{"version":"2.3.0","resolved":"https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz","integrity":"sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==","dev":true,"requires":{"ansi-styles":"3.2.0","escape-string-regexp":"1.0.5","supports-color":"4.5.0"}},"has-flag":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz","integrity":"sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=","dev":true},"postcss":{"version":"6.0.13","resolved":"https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz","integrity":"sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==","dev":true,"requires":{"chalk":"2.3.0","source-map":"0.6.1","supports-color":"4.5.0"}},"supports-color":{"version":"4.5.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz","integrity":"sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=","dev":true,"requires":{"has-flag":"2.0.0"}}}},"postcss-normalize-charset":{"version":"1.1.1","resolved":"https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz","integrity":"sha1-757nEhLX/nWceO0WL2HtYrXLk/E=","dev":true,"requires":{"postcss":"5.2.18"}},"postcss-normalize-url":{"version":"3.0.8","resolved":"https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz","integrity":"sha1-EI90s/L82viRov+j6kWSJ5/HgiI=","dev":true,"requires":{"is-absolute-url":"2.1.0","normalize-url":"1.9.1","postcss":"5.2.18","postcss-value-parser":"3.3.0"}},"postcss-ordered-values":{"version":"2.2.3","resolved":"https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz","integrity":"sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=","dev":true,"requires":{"postcss":"5.2.18","postcss-value-parser":"3.3.0"}},"postcss-prefix-selector":{"version":"1.6.0","resolved":"https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.6.0.tgz","integrity":"sha1-tJWUnWOcYxRxRWSDJoUyFvPBCQA=","dev":true,"requires":{"postcss":"5.2.18"}},"postcss-reduce-idents":{"version":"2.4.0","resolved":"https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz","integrity":"sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=","dev":true,"requires":{"postcss":"5.2.18","postcss-value-parser":"3.3.0"}},"postcss-reduce-initial":{"version":"1.0.1","resolved":"https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz","integrity":"sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=","dev":true,"requires":{"postcss":"5.2.18"}},"postcss-reduce-transforms":{"version":"1.0.4","resolved":"https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz","integrity":"sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=","dev":true,"requires":{"has":"1.0.1","postcss":"5.2.18","postcss-value-parser":"3.3.0"}},"postcss-selector-parser":{"version":"2.2.3","resolved":"https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz","integrity":"sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=","dev":true,"requires":{"flatten":"1.0.2","indexes-of":"1.0.1","uniq":"1.0.1"}},"postcss-svgo":{"version":"2.1.6","resolved":"https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz","integrity":"sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=","dev":true,"requires":{"is-svg":"2.1.0","postcss":"5.2.18","postcss-value-parser":"3.3.0","svgo":"0.7.2"}},"postcss-unique-selectors":{"version":"2.0.2","resolved":"https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz","integrity":"sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=","dev":true,"requires":{"alphanum-sort":"1.0.2","postcss":"5.2.18","uniqs":"2.0.0"}},"postcss-value-parser":{"version":"3.3.0","resolved":"https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz","integrity":"sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=","dev":true},"postcss-zindex":{"version":"2.2.0","resolved":"https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz","integrity":"sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=","dev":true,"requires":{"has":"1.0.1","postcss":"5.2.18","uniqs":"2.0.0"}},"posthtml":{"version":"0.9.2","resolved":"https://registry.npmjs.org/posthtml/-/posthtml-0.9.2.tgz","integrity":"sha1-9MBtufZ7Yf0XxOJW5+PZUVv3Jv0=","dev":true,"requires":{"posthtml-parser":"0.2.1","posthtml-render":"1.0.6"}},"posthtml-parser":{"version":"0.2.1","resolved":"https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.2.1.tgz","integrity":"sha1-NdUw3jhnQMK6JP8usvrznM3ycd0=","dev":true,"requires":{"htmlparser2":"3.9.2","isobject":"2.1.0"},"dependencies":{"isobject":{"version":"2.1.0","resolved":"https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz","integrity":"sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=","dev":true,"requires":{"isarray":"1.0.0"}}}},"posthtml-rename-id":{"version":"1.0.3","resolved":"https://registry.npmjs.org/posthtml-rename-id/-/posthtml-rename-id-1.0.3.tgz","integrity":"sha512-zaaHJSTihw1fsx2L81npO6gmDYu4yZuHfRX89IsJDhcRIV1P8SKJY5m1xDRZQh542flidwNS+70/pVAK8yMYOA==","dev":true,"requires":{"escape-string-regexp":"1.0.5"}},"posthtml-render":{"version":"1.0.6","resolved":"https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.0.6.tgz","integrity":"sha1-G4i454YKjr3+LyoTEKRkKlXPW9o=","dev":true},"posthtml-svg-mode":{"version":"1.0.2","resolved":"https://registry.npmjs.org/posthtml-svg-mode/-/posthtml-svg-mode-1.0.2.tgz","integrity":"sha512-yH4w0CULTg6v3YW5hVUY2z14R+11XWvtxMRqk30FDgxg0JWv+BhS9FLtKNIu858/1mrO1NcIC4heb6IezLAfHw==","dev":true,"requires":{"merge-options":"0.0.64","posthtml":"0.9.2","posthtml-parser":"0.2.1","posthtml-render":"1.0.6"}},"prebuild-install":{"version":"2.3.0","resolved":"https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.3.0.tgz","integrity":"sha512-gzjq2oHB8oMbzJSsSh9MQ64zrXZGt092/uT4TLZlz2qnrPxpWqp4vYB7LZrDxnlxf5RfbCjkgDI/z0EIVuYzAw==","dev":true,"requires":{"expand-template":"1.1.0","github-from-package":"0.0.0","minimist":"1.2.0","mkdirp":"0.5.1","node-abi":"2.1.1","noop-logger":"0.1.1","npmlog":"4.1.2","os-homedir":"1.0.2","pump":"1.0.2","rc":"1.2.2","simple-get":"1.4.3","tar-fs":"1.16.0","tunnel-agent":"0.6.0","xtend":"4.0.1"},"dependencies":{"minimist":{"version":"1.2.0","resolved":"https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz","integrity":"sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=","dev":true}}},"prelude-ls":{"version":"1.1.2","resolved":"https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz","integrity":"sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=","dev":true},"prepend-http":{"version":"1.0.4","resolved":"https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz","integrity":"sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=","dev":true},"preserve":{"version":"0.2.0","resolved":"https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz","integrity":"sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=","dev":true},"prettier":{"version":"1.7.4","resolved":"https://registry.npmjs.org/prettier/-/prettier-1.7.4.tgz","integrity":"sha1-XoYkrpNjyA+V7GRFhOzfVddPk/o=","dev":true},"pretty-bytes":{"version":"1.0.4","resolved":"https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz","integrity":"sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=","dev":true,"requires":{"get-stdin":"4.0.1","meow":"3.7.0"}},"pretty-format":{"version":"21.2.1","resolved":"https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz","integrity":"sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==","dev":true,"requires":{"ansi-regex":"3.0.0","ansi-styles":"3.2.0"},"dependencies":{"ansi-regex":{"version":"3.0.0","resolved":"https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz","integrity":"sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=","dev":true},"ansi-styles":{"version":"3.2.0","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz","integrity":"sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==","dev":true,"requires":{"color-convert":"1.9.0"}}}},"private":{"version":"0.1.8","resolved":"https://registry.npmjs.org/private/-/private-0.1.8.tgz","integrity":"sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==","dev":true},"process":{"version":"0.5.2","resolved":"https://registry.npmjs.org/process/-/process-0.5.2.tgz","integrity":"sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=","dev":true},"process-nextick-args":{"version":"1.0.7","resolved":"https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz","integrity":"sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="},"progress":{"version":"2.0.0","resolved":"https://registry.npmjs.org/progress/-/progress-2.0.0.tgz","integrity":"sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="},"progress-stream":{"version":"1.2.0","resolved":"https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz","integrity":"sha1-LNPP6jO6OonJwSHsM0er6asSX3c=","dev":true,"requires":{"speedometer":"0.1.4","through2":"0.2.3"}},"promise":{"version":"7.3.1","resolved":"https://registry.npmjs.org/promise/-/promise-7.3.1.tgz","integrity":"sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==","requires":{"asap":"2.0.6"}},"promptly":{"version":"2.2.0","resolved":"https://registry.npmjs.org/promptly/-/promptly-2.2.0.tgz","integrity":"sha1-KhP6BjaIoqWYOxYf/wEIoH0m/HQ=","dev":true,"requires":{"read":"1.0.7"}},"prop-types":{"version":"15.6.0","resolved":"https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz","integrity":"sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=","requires":{"fbjs":"0.8.16","loose-envify":"1.3.1","object-assign":"4.1.1"}},"proxy-addr":{"version":"2.0.2","resolved":"https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz","integrity":"sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=","dev":true,"requires":{"forwarded":"0.1.2","ipaddr.js":"1.5.2"}},"prr":{"version":"0.0.0","resolved":"https://registry.npmjs.org/prr/-/prr-0.0.0.tgz","integrity":"sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=","dev":true},"pseudomap":{"version":"1.0.2","resolved":"https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz","integrity":"sha1-8FKijacOYYkX7wqKw0wa5aaChrM=","dev":true},"public-encrypt":{"version":"4.0.0","resolved":"https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz","integrity":"sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=","dev":true,"requires":{"bn.js":"4.11.8","browserify-rsa":"4.0.1","create-hash":"1.1.3","parse-asn1":"5.1.0","randombytes":"2.0.5"}},"pump":{"version":"1.0.2","resolved":"https://registry.npmjs.org/pump/-/pump-1.0.2.tgz","integrity":"sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=","dev":true,"requires":{"end-of-stream":"1.4.0","once":"1.4.0"}},"punycode":{"version":"1.4.1","resolved":"https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz","integrity":"sha1-wNWmOycYgArY4esPpSachN1BhF4="},"q":{"version":"1.5.1","resolved":"https://registry.npmjs.org/q/-/q-1.5.1.tgz","integrity":"sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=","dev":true},"qs":{"version":"6.4.0","resolved":"https://registry.npmjs.org/qs/-/qs-6.4.0.tgz","integrity":"sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="},"query-string":{"version":"4.3.4","resolved":"https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz","integrity":"sha1-u7aTucqRXCMlFbIosaArYJBD2+s=","dev":true,"requires":{"object-assign":"4.1.1","strict-uri-encode":"1.1.0"}},"querystring":{"version":"0.2.0","resolved":"https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz","integrity":"sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=","dev":true},"querystring-es3":{"version":"0.2.1","resolved":"https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz","integrity":"sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=","dev":true},"querystringify":{"version":"1.0.0","resolved":"https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz","integrity":"sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="},"rabin-bindings":{"version":"1.7.3","resolved":"https://registry.npmjs.org/rabin-bindings/-/rabin-bindings-1.7.3.tgz","integrity":"sha512-zeVdstq+EWdwQ5JCyuuvOsP2fmGc6993laN+v8eEQsahHwZCy8bt5TefohUpgsetiwQhMMk/o+m/2sYng13Txw==","dev":true,"requires":{"bindings":"1.3.0","nan":"2.7.0","prebuild-install":"2.3.0"}},"randomatic":{"version":"1.1.7","resolved":"https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz","integrity":"sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==","dev":true,"requires":{"is-number":"3.0.0","kind-of":"4.0.0"},"dependencies":{"kind-of":{"version":"4.0.0","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz","integrity":"sha1-IIE989cSkosgc3hpGkUGb65y3Vc=","dev":true,"requires":{"is-buffer":"1.1.5"}}}},"randombytes":{"version":"2.0.5","resolved":"https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz","integrity":"sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==","dev":true,"requires":{"safe-buffer":"5.1.1"}},"range-parser":{"version":"1.2.0","resolved":"https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz","integrity":"sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=","dev":true},"raw-body":{"version":"2.3.2","resolved":"https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz","integrity":"sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=","dev":true,"requires":{"bytes":"3.0.0","http-errors":"1.6.2","iconv-lite":"0.4.19","unpipe":"1.0.0"}},"rc":{"version":"1.2.2","resolved":"https://registry.npmjs.org/rc/-/rc-1.2.2.tgz","integrity":"sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=","requires":{"deep-extend":"0.4.2","ini":"1.3.4","minimist":"1.2.0","strip-json-comments":"2.0.1"},"dependencies":{"minimist":{"version":"1.2.0","resolved":"https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz","integrity":"sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="}}},"react":{"version":"15.6.2","resolved":"https://registry.npmjs.org/react/-/react-15.6.2.tgz","integrity":"sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=","requires":{"create-react-class":"15.6.2","fbjs":"0.8.16","loose-envify":"1.3.1","object-assign":"4.1.1","prop-types":"15.6.0"}},"react-addons-css-transition-group":{"version":"15.6.2","resolved":"https://registry.npmjs.org/react-addons-css-transition-group/-/react-addons-css-transition-group-15.6.2.tgz","integrity":"sha1-nkN2vPQLUhfRTsaFUwgc7ksIptY=","requires":{"react-transition-group":"1.2.1"}},"react-addons-transition-group":{"version":"15.6.2","resolved":"https://registry.npmjs.org/react-addons-transition-group/-/react-addons-transition-group-15.6.2.tgz","integrity":"sha1-i668Kukczb8kX+Kcn9PTb4tHGSM=","requires":{"react-transition-group":"1.2.1"}},"react-deep-force-update":{"version":"2.1.1","resolved":"https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz","integrity":"sha1-jqQmPNZFWgULN0RbPwj9g52G6Qk=","dev":true},"react-dom":{"version":"15.6.2","resolved":"https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz","integrity":"sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=","dev":true,"requires":{"fbjs":"0.8.16","loose-envify":"1.3.1","object-assign":"4.1.1","prop-types":"15.6.0"}},"react-draggable":{"version":"3.0.3","resolved":"https://registry.npmjs.org/react-draggable/-/react-draggable-3.0.3.tgz","integrity":"sha512-ekb3dKvZFC6QaBNBpAWwGk9aoaDPkSVkrZl/LEU92THoX72Pv6uQ2ZpfYjmBrbrTQcAYmuUAkp9pHJ7j8FUYJA==","requires":{"classnames":"2.2.5","prop-types":"15.6.0"}},"react-hot-loader":{"version":"3.1.1","resolved":"https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-3.1.1.tgz","integrity":"sha512-TxvSs1KN+YZxdXIX5sq0AKEy8dBdyiUE9nK9ML4Op6S06tkvNAg51V8OSvlQemCQkOfk8gTc5O8azUCvV4vTUw==","dev":true,"requires":{"global":"4.3.2","react-deep-force-update":"2.1.1","react-proxy":"3.0.0-alpha.1","redbox-react":"1.5.0","source-map":"0.6.1"}},"react-proxy":{"version":"3.0.0-alpha.1","resolved":"https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz","integrity":"sha1-RABCa8+oDKpnJMd1VpUxUgn6Swc=","dev":true,"requires":{"lodash":"4.17.4"}},"react-sortable-hoc":{"version":"0.6.8","resolved":"https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-0.6.8.tgz","integrity":"sha512-sUUAtNdV84AKZ2o+F5lVOOFWcyWG6aGDkNFgHoieB1zFLeWLWENkix06asPS4/GhigfuRh06aZix1j3Qx8+NSQ==","requires":{"babel-runtime":"6.26.0","invariant":"2.2.2","lodash":"4.17.4","prop-types":"15.6.0"}},"react-transition-group":{"version":"1.2.1","resolved":"https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz","integrity":"sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==","requires":{"chain-function":"1.0.0","dom-helpers":"3.2.1","loose-envify":"1.3.1","prop-types":"15.6.0","warning":"3.0.0"}},"react-virtualized":{"version":"9.12.0","resolved":"https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.12.0.tgz","integrity":"sha512-QxqGUq7vktRsPnV/FclAGQ943rIYizTe9RIuyJGE75/3BA/7KJPXwXCQ9XW/3pnPKix+Jar0CCo3uTqoA4hFOg==","requires":{"babel-runtime":"6.26.0","classnames":"2.2.5","dom-helpers":"3.2.1","loose-envify":"1.3.1","prop-types":"15.6.0"}},"reactstrap":{"version":"4.8.0","resolved":"https://registry.npmjs.org/reactstrap/-/reactstrap-4.8.0.tgz","integrity":"sha1-6zUGQqYoLHnH4b2Nb3XGJxMaQvY=","requires":{"classnames":"2.2.5","lodash.isfunction":"3.0.8","lodash.isobject":"3.0.2","lodash.tonumber":"4.0.3","prop-types":"15.6.0","reactstrap-tether":"1.3.4"}},"reactstrap-tether":{"version":"1.3.4","resolved":"https://registry.npmjs.org/reactstrap-tether/-/reactstrap-tether-1.3.4.tgz","integrity":"sha1-htlNMCFv+jTOssYm9LmRLA0ZOJQ="},"read":{"version":"1.0.7","resolved":"https://registry.npmjs.org/read/-/read-1.0.7.tgz","integrity":"sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=","dev":true,"requires":{"mute-stream":"0.0.7"}},"read-config-file":{"version":"1.2.0","resolved":"https://registry.npmjs.org/read-config-file/-/read-config-file-1.2.0.tgz","integrity":"sha512-A1MNfKNIfYV7vXMOQ/CPCuVpCdWoPULu8whmrkKxwN8FUsv6EjwU2SPSNueeTKR6tZPl7+Qeondyb4/pAcoozQ==","dev":true,"requires":{"ajv":"5.3.0","ajv-keywords":"2.1.0","bluebird-lst":"1.0.5","dotenv":"4.0.0","dotenv-expand":"4.0.1","fs-extra-p":"4.4.4","js-yaml":"3.10.0","json5":"0.5.1","lazy-val":"1.0.2"},"dependencies":{"ajv":{"version":"5.3.0","resolved":"https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz","integrity":"sha1-RBT/dKUIecII7l/cgm4ywwNUnto=","dev":true,"requires":{"co":"4.6.0","fast-deep-equal":"1.0.0","fast-json-stable-stringify":"2.0.0","json-schema-traverse":"0.3.1"}}}},"read-pkg":{"version":"1.1.0","resolved":"https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz","integrity":"sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=","dev":true,"requires":{"load-json-file":"1.1.0","normalize-package-data":"2.4.0","path-type":"1.1.0"}},"read-pkg-up":{"version":"1.0.1","resolved":"https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz","integrity":"sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=","dev":true,"requires":{"find-up":"1.1.2","read-pkg":"1.1.0"}},"readable-stream":{"version":"2.3.3","resolved":"https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz","integrity":"sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==","requires":{"core-util-is":"1.0.2","inherits":"2.0.3","isarray":"1.0.0","process-nextick-args":"1.0.7","safe-buffer":"5.1.1","string_decoder":"1.0.3","util-deprecate":"1.0.2"}},"readdirp":{"version":"2.1.0","resolved":"https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz","integrity":"sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=","dev":true,"requires":{"graceful-fs":"4.1.11","minimatch":"3.0.4","readable-stream":"2.3.3","set-immediate-shim":"1.0.1"}},"readline2":{"version":"1.0.1","resolved":"https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz","integrity":"sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=","dev":true,"requires":{"code-point-at":"1.1.0","is-fullwidth-code-point":"1.0.0","mute-stream":"0.0.5"},"dependencies":{"mute-stream":{"version":"0.0.5","resolved":"https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz","integrity":"sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=","dev":true}}},"realm":{"version":"2.0.0","resolved":"https://registry.npmjs.org/realm/-/realm-2.0.0.tgz","integrity":"sha1-IhCqXFgxtGgS/8w1gpTwSFsnvrc=","requires":{"command-line-args":"4.0.7","decompress":"4.2.0","decompress-tarxz":"2.1.1","fs-extra":"4.0.2","ini":"1.3.4","nan":"2.7.0","node-fetch":"1.7.3","node-pre-gyp":"0.6.38","progress":"2.0.0","prop-types":"15.6.0","request":"2.83.0","stream-counter":"1.0.0","sync-request":"3.0.1","url-parse":"1.1.9"}},"realm-object-server":{"version":"2.0.4","resolved":"https://registry.npmjs.org/realm-object-server/-/realm-object-server-2.0.4.tgz","integrity":"sha1-i1UKGP6bEUSHhlbc6O3/Je1KelE=","dev":true,"requires":{"@types/bcrypt":"1.0.0","@types/body-parser":"1.16.6","@types/colors":"1.1.3","@types/commander":"2.11.0","@types/del":"3.0.0","@types/express":"4.0.37","@types/faker":"4.1.1","@types/fs-extra":"4.0.3","@types/http-proxy":"1.12.2","@types/jsonwebtoken":"7.2.3","@types/lodash":"4.14.79","@types/morgan":"1.7.34","@types/promptly":"1.1.28","@types/proxyquire":"1.3.28","@types/superagent":"3.5.6","@types/tmp":"0.0.33","@types/urijs":"1.15.34","@types/uuid":"3.4.3","@types/uws":"0.13.0","bcrypt":"1.0.3","body-parser":"1.18.2","circular-buffer":"1.0.2","colors":"1.1.2","commander":"2.11.0","express":"4.16.2","fs-extra":"4.0.2","http-proxy":"1.16.2","JSONStream":"1.3.1","jsonwebtoken":"7.4.3","lodash":"4.17.4","minimist":"1.2.0","mixpanel":"0.7.0","moment":"2.19.1","morgan":"1.9.0","npm-which":"3.0.1","path-to-regexp":"2.1.0","promptly":"2.2.0","realm":"2.0.0","realm-one":"1.12.0","realm-sync-server":"https://s3.amazonaws.com/static.realm.io/downloads/node/realm-sync-server-2.0.2.tgz","superagent":"3.7.0","tmp":"0.0.33","urijs":"1.19.0","ursa":"0.9.4","uuid":"3.1.0","uws":"8.14.1","winston":"2.4.0"},"dependencies":{"abbrev":{"version":"1.1.1","bundled":true,"dev":true},"ajv":{"version":"5.2.3","bundled":true,"dev":true,"requires":{"co":"4.6.0","fast-deep-equal":"1.0.0","json-schema-traverse":"0.3.1","json-stable-stringify":"1.0.1"}},"ansi-regex":{"version":"2.1.1","bundled":true,"dev":true},"aproba":{"version":"1.2.0","bundled":true,"dev":true},"are-we-there-yet":{"version":"1.1.4","bundled":true,"dev":true,"requires":{"delegates":"1.0.0","readable-stream":"2.3.3"}},"asap":{"version":"2.0.6","bundled":true,"dev":true},"asn1":{"version":"0.2.3","bundled":true,"dev":true},"assert-plus":{"version":"1.0.0","bundled":true,"dev":true},"asynckit":{"version":"0.4.0","bundled":true,"dev":true},"aws-sign2":{"version":"0.6.0","bundled":true,"dev":true},"aws4":{"version":"1.6.0","bundled":true,"dev":true},"balanced-match":{"version":"1.0.0","bundled":true,"dev":true},"bcrypt-pbkdf":{"version":"1.0.1","bundled":true,"dev":true,"optional":true,"requires":{"tweetnacl":"0.14.5"}},"block-stream":{"version":"0.0.9","bundled":true,"dev":true,"requires":{"inherits":"2.0.3"}},"boom":{"version":"2.10.1","bundled":true,"dev":true,"requires":{"hoek":"2.16.3"}},"brace-expansion":{"version":"1.1.8","bundled":true,"dev":true,"requires":{"balanced-match":"1.0.0","concat-map":"0.0.1"}},"caseless":{"version":"0.11.0","bundled":true,"dev":true},"co":{"version":"4.6.0","bundled":true,"dev":true},"code-point-at":{"version":"1.1.0","bundled":true,"dev":true},"combined-stream":{"version":"1.0.5","bundled":true,"dev":true,"requires":{"delayed-stream":"1.0.0"}},"commander":{"version":"2.11.0","resolved":"https://registry.npmjs.org/commander/-/commander-2.11.0.tgz","integrity":"sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==","dev":true},"concat-map":{"version":"0.0.1","bundled":true,"dev":true},"concat-stream":{"version":"1.6.0","bundled":true,"dev":true,"requires":{"inherits":"2.0.3","readable-stream":"2.3.3","typedarray":"0.0.6"}},"console-control-strings":{"version":"1.1.0","bundled":true,"dev":true},"core-js":{"version":"1.2.7","bundled":true,"dev":true},"core-util-is":{"version":"1.0.2","bundled":true,"dev":true},"cryptiles":{"version":"2.0.5","bundled":true,"dev":true,"requires":{"boom":"2.10.1"}},"dashdash":{"version":"1.14.1","bundled":true,"dev":true,"requires":{"assert-plus":"1.0.0"}},"debug":{"version":"2.6.9","bundled":true,"dev":true,"requires":{"ms":"2.0.0"}},"deep-extend":{"version":"0.4.2","bundled":true,"dev":true},"delayed-stream":{"version":"1.0.0","bundled":true,"dev":true},"delegates":{"version":"1.0.0","bundled":true,"dev":true},"ecc-jsbn":{"version":"0.1.1","bundled":true,"dev":true,"optional":true,"requires":{"jsbn":"0.1.1"}},"encoding":{"version":"0.1.12","bundled":true,"dev":true,"requires":{"iconv-lite":"0.4.19"}},"extend":{"version":"3.0.1","bundled":true,"dev":true},"extract-zip":{"version":"1.6.5","bundled":true,"dev":true,"requires":{"concat-stream":"1.6.0","debug":"2.2.0","mkdirp":"0.5.0","yauzl":"2.4.1"},"dependencies":{"debug":{"version":"2.2.0","bundled":true,"dev":true,"requires":{"ms":"0.7.1"}},"minimist":{"version":"0.0.8","bundled":true,"dev":true},"mkdirp":{"version":"0.5.0","bundled":true,"dev":true,"requires":{"minimist":"0.0.8"}},"ms":{"version":"0.7.1","bundled":true,"dev":true}}},"extsprintf":{"version":"1.3.0","bundled":true,"dev":true},"fast-deep-equal":{"version":"1.0.0","bundled":true,"dev":true},"fbjs":{"version":"0.8.16","bundled":true,"dev":true,"requires":{"core-js":"1.2.7","isomorphic-fetch":"2.2.1","loose-envify":"1.3.1","object-assign":"4.1.1","promise":"7.3.1","setimmediate":"1.0.5","ua-parser-js":"0.7.17"}},"fd-slicer":{"version":"1.0.1","bundled":true,"dev":true,"requires":{"pend":"1.2.0"}},"forever-agent":{"version":"0.6.1","bundled":true,"dev":true},"form-data":{"version":"2.1.4","bundled":true,"dev":true,"requires":{"asynckit":"0.4.0","combined-stream":"1.0.5","mime-types":"2.1.17"}},"fs.realpath":{"version":"1.0.0","bundled":true,"dev":true},"fstream":{"version":"1.0.11","bundled":true,"dev":true,"requires":{"graceful-fs":"4.1.11","inherits":"2.0.3","mkdirp":"0.5.1","rimraf":"2.6.2"}},"fstream-ignore":{"version":"1.0.5","bundled":true,"dev":true,"requires":{"fstream":"1.0.11","inherits":"2.0.3","minimatch":"3.0.4"}},"gauge":{"version":"2.7.4","bundled":true,"dev":true,"requires":{"aproba":"1.2.0","console-control-strings":"1.1.0","has-unicode":"2.0.1","object-assign":"4.1.1","signal-exit":"3.0.2","string-width":"1.0.2","strip-ansi":"3.0.1","wide-align":"1.1.2"}},"getpass":{"version":"0.1.7","bundled":true,"dev":true,"requires":{"assert-plus":"1.0.0"}},"glob":{"version":"7.1.2","bundled":true,"dev":true,"requires":{"fs.realpath":"1.0.0","inflight":"1.0.6","inherits":"2.0.3","minimatch":"3.0.4","once":"1.4.0","path-is-absolute":"1.0.1"}},"graceful-fs":{"version":"4.1.11","bundled":true,"dev":true},"har-schema":{"version":"2.0.0","bundled":true,"dev":true},"har-validator":{"version":"5.0.3","bundled":true,"dev":true,"requires":{"ajv":"5.2.3","har-schema":"2.0.0"}},"has-unicode":{"version":"2.0.1","bundled":true,"dev":true},"hawk":{"version":"3.1.3","bundled":true,"dev":true,"requires":{"boom":"2.10.1","cryptiles":"2.0.5","hoek":"2.16.3","sntp":"1.0.9"}},"hoek":{"version":"2.16.3","bundled":true,"dev":true},"http-basic":{"version":"2.5.1","bundled":true,"dev":true,"requires":{"caseless":"0.11.0","concat-stream":"1.6.0","http-response-object":"1.1.0"}},"http-response-object":{"version":"1.1.0","bundled":true,"dev":true},"http-signature":{"version":"1.1.1","bundled":true,"dev":true,"requires":{"assert-plus":"0.2.0","jsprim":"1.4.1","sshpk":"1.13.1"},"dependencies":{"assert-plus":{"version":"0.2.0","bundled":true,"dev":true}}},"iconv-lite":{"version":"0.4.19","bundled":true,"dev":true},"inflight":{"version":"1.0.6","bundled":true,"dev":true,"requires":{"once":"1.4.0","wrappy":"1.0.2"}},"inherits":{"version":"2.0.3","bundled":true,"dev":true},"ini":{"version":"1.3.4","bundled":true,"dev":true},"is-fullwidth-code-point":{"version":"1.0.0","bundled":true,"dev":true,"requires":{"number-is-nan":"1.0.1"}},"is-stream":{"version":"1.1.0","bundled":true,"dev":true},"is-typedarray":{"version":"1.0.0","bundled":true,"dev":true},"isarray":{"version":"1.0.0","bundled":true,"dev":true},"isomorphic-fetch":{"version":"2.2.1","bundled":true,"dev":true,"requires":{"node-fetch":"1.7.3","whatwg-fetch":"2.0.3"}},"isstream":{"version":"0.1.2","bundled":true,"dev":true},"js-tokens":{"version":"3.0.2","bundled":true,"dev":true},"jsbn":{"version":"0.1.1","bundled":true,"dev":true,"optional":true},"json-schema":{"version":"0.2.3","bundled":true,"dev":true},"json-schema-traverse":{"version":"0.3.1","bundled":true,"dev":true},"json-stable-stringify":{"version":"1.0.1","bundled":true,"dev":true,"requires":{"jsonify":"0.0.0"}},"json-stringify-safe":{"version":"5.0.1","bundled":true,"dev":true},"jsonify":{"version":"0.0.0","bundled":true,"dev":true},"jsprim":{"version":"1.4.1","bundled":true,"dev":true,"requires":{"assert-plus":"1.0.0","extsprintf":"1.3.0","json-schema":"0.2.3","verror":"1.10.0"}},"loose-envify":{"version":"1.3.1","bundled":true,"dev":true,"requires":{"js-tokens":"3.0.2"}},"mime-db":{"version":"1.30.0","bundled":true,"dev":true},"mime-types":{"version":"2.1.17","bundled":true,"dev":true,"requires":{"mime-db":"1.30.0"}},"minimatch":{"version":"3.0.4","bundled":true,"dev":true,"requires":{"brace-expansion":"1.1.8"}},"minimist":{"version":"1.2.0","bundled":true,"dev":true},"mkdirp":{"version":"0.5.1","bundled":true,"dev":true,"requires":{"minimist":"0.0.8"},"dependencies":{"minimist":{"version":"0.0.8","bundled":true,"dev":true}}},"ms":{"version":"2.0.0","bundled":true,"dev":true},"nan":{"version":"2.7.0","bundled":true,"dev":true},"node-fetch":{"version":"1.7.3","bundled":true,"dev":true,"requires":{"encoding":"0.1.12","is-stream":"1.1.0"}},"node-pre-gyp":{"version":"0.6.38","bundled":true,"dev":true,"requires":{"hawk":"3.1.3","mkdirp":"0.5.1","nopt":"4.0.1","npmlog":"4.1.2","rc":"1.2.2","request":"2.81.0","rimraf":"2.6.2","semver":"5.4.1","tar":"2.2.1","tar-pack":"3.4.0"},"dependencies":{"ajv":{"version":"4.11.8","bundled":true,"dev":true,"requires":{"co":"4.6.0","json-stable-stringify":"1.0.1"}},"caseless":{"version":"0.12.0","bundled":true,"dev":true},"har-schema":{"version":"1.0.5","bundled":true,"dev":true},"har-validator":{"version":"4.2.1","bundled":true,"dev":true,"requires":{"ajv":"4.11.8","har-schema":"1.0.5"}},"performance-now":{"version":"0.2.0","bundled":true,"dev":true},"qs":{"version":"6.4.0","bundled":true,"dev":true},"request":{"version":"2.81.0","bundled":true,"dev":true,"requires":{"aws-sign2":"0.6.0","aws4":"1.6.0","caseless":"0.12.0","combined-stream":"1.0.5","extend":"3.0.1","forever-agent":"0.6.1","form-data":"2.1.4","har-validator":"4.2.1","hawk":"3.1.3","http-signature":"1.1.1","is-typedarray":"1.0.0","isstream":"0.1.2","json-stringify-safe":"5.0.1","mime-types":"2.1.17","oauth-sign":"0.8.2","performance-now":"0.2.0","qs":"6.4.0","safe-buffer":"5.1.1","stringstream":"0.0.5","tough-cookie":"2.3.3","tunnel-agent":"0.6.0","uuid":"3.1.0"}},"tar":{"version":"2.2.1","bundled":true,"dev":true,"requires":{"block-stream":"0.0.9","fstream":"1.0.11","inherits":"2.0.3"}}}},"nopt":{"version":"4.0.1","bundled":true,"dev":true,"requires":{"abbrev":"1.1.1","osenv":"0.1.4"}},"npmlog":{"version":"4.1.2","bundled":true,"dev":true,"requires":{"are-we-there-yet":"1.1.4","console-control-strings":"1.1.0","gauge":"2.7.4","set-blocking":"2.0.0"}},"number-is-nan":{"version":"1.0.1","bundled":true,"dev":true},"oauth-sign":{"version":"0.8.2","bundled":true,"dev":true},"object-assign":{"version":"4.1.1","bundled":true,"dev":true},"once":{"version":"1.4.0","bundled":true,"dev":true,"requires":{"wrappy":"1.0.2"}},"os-homedir":{"version":"1.0.2","bundled":true,"dev":true},"os-tmpdir":{"version":"1.0.2","bundled":true,"dev":true},"osenv":{"version":"0.1.4","bundled":true,"dev":true,"requires":{"os-homedir":"1.0.2","os-tmpdir":"1.0.2"}},"path-is-absolute":{"version":"1.0.1","bundled":true,"dev":true},"pend":{"version":"1.2.0","bundled":true,"dev":true},"performance-now":{"version":"2.1.0","bundled":true,"dev":true},"process-nextick-args":{"version":"1.0.7","bundled":true,"dev":true},"promise":{"version":"7.3.1","bundled":true,"dev":true,"requires":{"asap":"2.0.6"}},"prop-types":{"version":"15.6.0","bundled":true,"dev":true,"requires":{"fbjs":"0.8.16","loose-envify":"1.3.1","object-assign":"4.1.1"}},"punycode":{"version":"1.4.1","bundled":true,"dev":true},"qs":{"version":"6.5.1","bundled":true,"dev":true},"querystringify":{"version":"1.0.0","bundled":true,"dev":true},"rc":{"version":"1.2.2","bundled":true,"dev":true,"requires":{"deep-extend":"0.4.2","ini":"1.3.4","minimist":"1.2.0","strip-json-comments":"2.0.1"}},"readable-stream":{"version":"2.3.3","bundled":true,"dev":true,"requires":{"core-util-is":"1.0.2","inherits":"2.0.3","isarray":"1.0.0","process-nextick-args":"1.0.7","safe-buffer":"5.1.1","string_decoder":"1.0.3","util-deprecate":"1.0.2"}},"realm-one":{"version":"1.12.0","bundled":true,"dev":true,"requires":{"realm":"1.12.0"},"dependencies":{"realm":{"version":"1.12.0","bundled":true,"dev":true,"requires":{"extract-zip":"1.6.5","ini":"1.3.4","nan":"2.7.0","node-fetch":"1.7.3","node-pre-gyp":"0.6.38","prop-types":"15.6.0","request":"2.83.0","sync-request":"3.0.1","url-parse":"1.1.9"}}}},"realm-sync-server":{"version":"https://s3.amazonaws.com/static.realm.io/downloads/node/realm-sync-server-2.0.2.tgz","integrity":"sha1-HN5aQENEWuMyPrh/5KPx72HoRzk=","dev":true},"request":{"version":"2.83.0","bundled":true,"dev":true,"requires":{"aws-sign2":"0.7.0","aws4":"1.6.0","caseless":"0.12.0","combined-stream":"1.0.5","extend":"3.0.1","forever-agent":"0.6.1","form-data":"2.3.1","har-validator":"5.0.3","hawk":"6.0.2","http-signature":"1.2.0","is-typedarray":"1.0.0","isstream":"0.1.2","json-stringify-safe":"5.0.1","mime-types":"2.1.17","oauth-sign":"0.8.2","performance-now":"2.1.0","qs":"6.5.1","safe-buffer":"5.1.1","stringstream":"0.0.5","tough-cookie":"2.3.3","tunnel-agent":"0.6.0","uuid":"3.1.0"},"dependencies":{"aws-sign2":{"version":"0.7.0","bundled":true,"dev":true},"boom":{"version":"4.3.1","bundled":true,"dev":true,"requires":{"hoek":"4.2.0"}},"caseless":{"version":"0.12.0","bundled":true,"dev":true},"cryptiles":{"version":"3.1.2","bundled":true,"dev":true,"requires":{"boom":"5.2.0"},"dependencies":{"boom":{"version":"5.2.0","bundled":true,"dev":true,"requires":{"hoek":"4.2.0"}}}},"form-data":{"version":"2.3.1","bundled":true,"dev":true,"requires":{"asynckit":"0.4.0","combined-stream":"1.0.5","mime-types":"2.1.17"}},"hawk":{"version":"6.0.2","bundled":true,"dev":true,"requires":{"boom":"4.3.1","cryptiles":"3.1.2","hoek":"4.2.0","sntp":"2.0.2"}},"hoek":{"version":"4.2.0","bundled":true,"dev":true},"http-signature":{"version":"1.2.0","bundled":true,"dev":true,"requires":{"assert-plus":"1.0.0","jsprim":"1.4.1","sshpk":"1.13.1"}},"sntp":{"version":"2.0.2","bundled":true,"dev":true,"requires":{"hoek":"4.2.0"}}}},"requires-port":{"version":"1.0.0","bundled":true,"dev":true},"rimraf":{"version":"2.6.2","bundled":true,"dev":true,"requires":{"glob":"7.1.2"}},"safe-buffer":{"version":"5.1.1","bundled":true,"dev":true},"semver":{"version":"5.4.1","bundled":true,"dev":true},"set-blocking":{"version":"2.0.0","bundled":true,"dev":true},"setimmediate":{"version":"1.0.5","bundled":true,"dev":true},"signal-exit":{"version":"3.0.2","bundled":true,"dev":true},"sntp":{"version":"1.0.9","bundled":true,"dev":true,"requires":{"hoek":"2.16.3"}},"sshpk":{"version":"1.13.1","bundled":true,"dev":true,"requires":{"asn1":"0.2.3","assert-plus":"1.0.0","bcrypt-pbkdf":"1.0.1","dashdash":"1.14.1","ecc-jsbn":"0.1.1","getpass":"0.1.7","jsbn":"0.1.1","tweetnacl":"0.14.5"}},"string_decoder":{"version":"1.0.3","bundled":true,"dev":true,"requires":{"safe-buffer":"5.1.1"}},"string-width":{"version":"1.0.2","bundled":true,"dev":true,"requires":{"code-point-at":"1.1.0","is-fullwidth-code-point":"1.0.0","strip-ansi":"3.0.1"}},"stringstream":{"version":"0.0.5","bundled":true,"dev":true},"strip-ansi":{"version":"3.0.1","bundled":true,"dev":true,"requires":{"ansi-regex":"2.1.1"}},"strip-json-comments":{"version":"2.0.1","bundled":true,"dev":true},"sync-request":{"version":"3.0.1","bundled":true,"dev":true,"requires":{"concat-stream":"1.6.0","http-response-object":"1.1.0","then-request":"2.2.0"}},"tar-pack":{"version":"3.4.0","bundled":true,"dev":true,"requires":{"debug":"2.6.9","fstream":"1.0.11","fstream-ignore":"1.0.5","once":"1.4.0","readable-stream":"2.3.3","rimraf":"2.6.2","tar":"2.2.1","uid-number":"0.0.6"},"dependencies":{"tar":{"version":"2.2.1","bundled":true,"dev":true,"requires":{"block-stream":"0.0.9","fstream":"1.0.11","inherits":"2.0.3"}}}},"then-request":{"version":"2.2.0","bundled":true,"dev":true,"requires":{"caseless":"0.11.0","concat-stream":"1.6.0","http-basic":"2.5.1","http-response-object":"1.1.0","promise":"7.3.1","qs":"6.5.1"}},"tough-cookie":{"version":"2.3.3","bundled":true,"dev":true,"requires":{"punycode":"1.4.1"}},"tunnel-agent":{"version":"0.6.0","bundled":true,"dev":true,"requires":{"safe-buffer":"5.1.1"}},"tweetnacl":{"version":"0.14.5","bundled":true,"dev":true,"optional":true},"typedarray":{"version":"0.0.6","bundled":true,"dev":true},"ua-parser-js":{"version":"0.7.17","bundled":true,"dev":true},"uid-number":{"version":"0.0.6","bundled":true,"dev":true},"url-parse":{"version":"1.1.9","bundled":true,"dev":true,"requires":{"querystringify":"1.0.0","requires-port":"1.0.0"}},"util-deprecate":{"version":"1.0.2","bundled":true,"dev":true},"uuid":{"version":"3.1.0","bundled":true,"dev":true},"verror":{"version":"1.10.0","bundled":true,"dev":true,"requires":{"assert-plus":"1.0.0","core-util-is":"1.0.2","extsprintf":"1.3.0"}},"whatwg-fetch":{"version":"2.0.3","bundled":true,"dev":true},"wide-align":{"version":"1.1.2","bundled":true,"dev":true,"requires":{"string-width":"1.0.2"}},"wrappy":{"version":"1.0.2","bundled":true,"dev":true},"yauzl":{"version":"2.4.1","bundled":true,"dev":true,"requires":{"fd-slicer":"1.0.1"}}}},"recast":{"version":"0.11.23","resolved":"https://registry.npmjs.org/recast/-/recast-0.11.23.tgz","integrity":"sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=","dev":true,"requires":{"ast-types":"0.9.6","esprima":"3.1.3","private":"0.1.8","source-map":"0.5.7"},"dependencies":{"esprima":{"version":"3.1.3","resolved":"https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz","integrity":"sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=","dev":true},"source-map":{"version":"0.5.7","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz","integrity":"sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=","dev":true}}},"redbox-react":{"version":"1.5.0","resolved":"https://registry.npmjs.org/redbox-react/-/redbox-react-1.5.0.tgz","integrity":"sha512-mdxArOI3sF8K5Nay5NG+lv/VW516TbXjjd4h1wcV1Iy4IMDQPnCayjoQXBAycAFSME4nyXRUXCjHxsw2rYpVRw==","dev":true,"requires":{"error-stack-parser":"1.3.6","object-assign":"4.1.1","prop-types":"15.6.0","sourcemapped-stacktrace":"1.1.7"}},"redent":{"version":"1.0.0","resolved":"https://registry.npmjs.org/redent/-/redent-1.0.0.tgz","integrity":"sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=","dev":true,"requires":{"indent-string":"2.1.0","strip-indent":"1.0.1"}},"reduce-css-calc":{"version":"1.3.0","resolved":"https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz","integrity":"sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=","dev":true,"requires":{"balanced-match":"0.4.2","math-expression-evaluator":"1.2.17","reduce-function-call":"1.0.2"},"dependencies":{"balanced-match":{"version":"0.4.2","resolved":"https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz","integrity":"sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=","dev":true}}},"reduce-function-call":{"version":"1.0.2","resolved":"https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz","integrity":"sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=","dev":true,"requires":{"balanced-match":"0.4.2"},"dependencies":{"balanced-match":{"version":"0.4.2","resolved":"https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz","integrity":"sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=","dev":true}}},"regenerate":{"version":"1.3.3","resolved":"https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz","integrity":"sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==","dev":true},"regenerator-runtime":{"version":"0.11.0","resolved":"https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz","integrity":"sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="},"regex-cache":{"version":"0.4.4","resolved":"https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz","integrity":"sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==","dev":true,"requires":{"is-equal-shallow":"0.1.3"}},"regex-not":{"version":"1.0.0","resolved":"https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz","integrity":"sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=","dev":true,"requires":{"extend-shallow":"2.0.1"}},"regex-parser":{"version":"2.2.8","resolved":"https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.8.tgz","integrity":"sha1-2kwM2lqChVkJQWiTD0VfUytv+6w=","dev":true},"regexpu-core":{"version":"1.0.0","resolved":"https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz","integrity":"sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=","dev":true,"requires":{"regenerate":"1.3.3","regjsgen":"0.2.0","regjsparser":"0.1.5"}},"registry-auth-token":{"version":"3.3.1","resolved":"https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz","integrity":"sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=","dev":true,"requires":{"rc":"1.2.2","safe-buffer":"5.1.1"}},"registry-url":{"version":"3.1.0","resolved":"https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz","integrity":"sha1-PU74cPc93h138M+aOBQyRE4XSUI=","dev":true,"requires":{"rc":"1.2.2"}},"regjsgen":{"version":"0.2.0","resolved":"https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz","integrity":"sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=","dev":true},"regjsparser":{"version":"0.1.5","resolved":"https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz","integrity":"sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=","dev":true,"requires":{"jsesc":"0.5.0"}},"remove-trailing-separator":{"version":"1.1.0","resolved":"https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz","integrity":"sha1-wkvOKig62tW8P1jg1IJJuSN52O8=","dev":true},"repeat-element":{"version":"1.1.2","resolved":"https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz","integrity":"sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=","dev":true},"repeat-string":{"version":"1.6.1","resolved":"https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz","integrity":"sha1-jcrkcOHIirwtYA//Sndihtp15jc=","dev":true},"repeating":{"version":"2.0.1","resolved":"https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz","integrity":"sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=","dev":true,"requires":{"is-finite":"1.0.2"}},"request":{"version":"2.83.0","resolved":"https://registry.npmjs.org/request/-/request-2.83.0.tgz","integrity":"sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==","requires":{"aws-sign2":"0.7.0","aws4":"1.6.0","caseless":"0.12.0","combined-stream":"1.0.5","extend":"3.0.1","forever-agent":"0.6.1","form-data":"2.3.1","har-validator":"5.0.3","hawk":"6.0.2","http-signature":"1.2.0","is-typedarray":"1.0.0","isstream":"0.1.2","json-stringify-safe":"5.0.1","mime-types":"2.1.17","oauth-sign":"0.8.2","performance-now":"2.1.0","qs":"6.5.1","safe-buffer":"5.1.1","stringstream":"0.0.5","tough-cookie":"2.3.3","tunnel-agent":"0.6.0","uuid":"3.1.0"},"dependencies":{"ajv":{"version":"5.3.0","resolved":"https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz","integrity":"sha1-RBT/dKUIecII7l/cgm4ywwNUnto=","requires":{"co":"4.6.0","fast-deep-equal":"1.0.0","fast-json-stable-stringify":"2.0.0","json-schema-traverse":"0.3.1"}},"assert-plus":{"version":"1.0.0","resolved":"https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz","integrity":"sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="},"aws-sign2":{"version":"0.7.0","resolved":"https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz","integrity":"sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="},"boom":{"version":"4.3.1","resolved":"https://registry.npmjs.org/boom/-/boom-4.3.1.tgz","integrity":"sha1-T4owBctKfjiJ90kDD9JbluAdLjE=","requires":{"hoek":"4.2.0"}},"cryptiles":{"version":"3.1.2","resolved":"https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz","integrity":"sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=","requires":{"boom":"5.2.0"},"dependencies":{"boom":{"version":"5.2.0","resolved":"https://registry.npmjs.org/boom/-/boom-5.2.0.tgz","integrity":"sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==","requires":{"hoek":"4.2.0"}}}},"form-data":{"version":"2.3.1","resolved":"https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz","integrity":"sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=","requires":{"asynckit":"0.4.0","combined-stream":"1.0.5","mime-types":"2.1.17"}},"har-schema":{"version":"2.0.0","resolved":"https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz","integrity":"sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="},"har-validator":{"version":"5.0.3","resolved":"https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz","integrity":"sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=","requires":{"ajv":"5.3.0","har-schema":"2.0.0"}},"hawk":{"version":"6.0.2","resolved":"https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz","integrity":"sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==","requires":{"boom":"4.3.1","cryptiles":"3.1.2","hoek":"4.2.0","sntp":"2.0.2"}},"hoek":{"version":"4.2.0","resolved":"https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz","integrity":"sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="},"http-signature":{"version":"1.2.0","resolved":"https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz","integrity":"sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=","requires":{"assert-plus":"1.0.0","jsprim":"1.4.1","sshpk":"1.13.1"}},"performance-now":{"version":"2.1.0","resolved":"https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz","integrity":"sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="},"qs":{"version":"6.5.1","resolved":"https://registry.npmjs.org/qs/-/qs-6.5.1.tgz","integrity":"sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="},"sntp":{"version":"2.0.2","resolved":"https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz","integrity":"sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=","requires":{"hoek":"4.2.0"}}}},"request-promise-core":{"version":"1.1.1","resolved":"https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz","integrity":"sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=","dev":true,"requires":{"lodash":"4.17.4"}},"request-promise-native":{"version":"1.0.5","resolved":"https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz","integrity":"sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=","dev":true,"requires":{"request-promise-core":"1.1.1","stealthy-require":"1.1.1","tough-cookie":"2.3.3"}},"require-directory":{"version":"2.1.1","resolved":"https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz","integrity":"sha1-jGStX9MNqxyXbiNE/+f3kqam30I=","dev":true},"require-from-string":{"version":"1.2.1","resolved":"https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz","integrity":"sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=","dev":true},"require-main-filename":{"version":"1.0.1","resolved":"https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz","integrity":"sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=","dev":true},"require-uncached":{"version":"1.0.3","resolved":"https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz","integrity":"sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=","dev":true,"requires":{"caller-path":"0.1.0","resolve-from":"1.0.1"}},"requires-port":{"version":"1.0.0","resolved":"https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz","integrity":"sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="},"resolve":{"version":"1.5.0","resolved":"https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz","integrity":"sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==","dev":true,"requires":{"path-parse":"1.0.5"}},"resolve-cwd":{"version":"2.0.0","resolved":"https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz","integrity":"sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=","dev":true,"requires":{"resolve-from":"3.0.0"},"dependencies":{"resolve-from":{"version":"3.0.0","resolved":"https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz","integrity":"sha1-six699nWiBvItuZTM17rywoYh0g=","dev":true}}},"resolve-from":{"version":"1.0.1","resolved":"https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz","integrity":"sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=","dev":true},"resolve-url":{"version":"0.2.1","resolved":"https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz","integrity":"sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=","dev":true},"resolve-url-loader":{"version":"2.1.1","resolved":"https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-2.1.1.tgz","integrity":"sha512-ZrMHMPJ8boX5peNuuHfw/waNpWAgvEj8+f8mEE/W61tC9L4NcyEBnruK7LsKamnNTbf0gUoJdPmV1okjSUVJgA==","dev":true,"requires":{"adjust-sourcemap-loader":"1.1.0","camelcase":"4.1.0","convert-source-map":"1.5.0","loader-utils":"1.1.0","lodash.defaults":"4.2.0","rework":"1.0.1","rework-visit":"1.0.0","source-map":"0.5.7","urix":"0.1.0"},"dependencies":{"camelcase":{"version":"4.1.0","resolved":"https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz","integrity":"sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=","dev":true},"source-map":{"version":"0.5.7","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz","integrity":"sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=","dev":true}}},"restore-cursor":{"version":"1.0.1","resolved":"https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz","integrity":"sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=","dev":true,"requires":{"exit-hook":"1.1.1","onetime":"1.1.0"}},"rework":{"version":"1.0.1","resolved":"https://registry.npmjs.org/rework/-/rework-1.0.1.tgz","integrity":"sha1-MIBqhBNCtUUQqkEQhQzUhTQUSqc=","dev":true,"requires":{"convert-source-map":"0.3.5","css":"2.2.1"},"dependencies":{"convert-source-map":{"version":"0.3.5","resolved":"https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz","integrity":"sha1-8dgClQr33SYxof6+BZZVDIarMZA=","dev":true}}},"rework-visit":{"version":"1.0.0","resolved":"https://registry.npmjs.org/rework-visit/-/rework-visit-1.0.0.tgz","integrity":"sha1-mUWygD8hni96ygCtuLyfZA+ELJo=","dev":true},"rgb2hex":{"version":"0.1.0","resolved":"https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.0.tgz","integrity":"sha1-zNVfhgrgxcTqN1BLlY5ELY0SMls=","dev":true},"right-align":{"version":"0.1.3","resolved":"https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz","integrity":"sha1-YTObci/mo1FWiSENJOFMlhSGE+8=","dev":true,"requires":{"align-text":"0.1.4"}},"rimraf":{"version":"2.6.2","resolved":"https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz","integrity":"sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==","requires":{"glob":"7.1.2"}},"ripemd160":{"version":"2.0.1","resolved":"https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz","integrity":"sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=","dev":true,"requires":{"hash-base":"2.0.2","inherits":"2.0.3"}},"run-async":{"version":"0.1.0","resolved":"https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz","integrity":"sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=","dev":true,"requires":{"once":"1.4.0"}},"rx":{"version":"2.3.24","resolved":"https://registry.npmjs.org/rx/-/rx-2.3.24.tgz","integrity":"sha1-FPlQpCF9fjXapxu8vljv9o6ksrc=","dev":true},"rx-lite":{"version":"3.1.2","resolved":"https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz","integrity":"sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=","dev":true},"rxjs":{"version":"5.5.1","resolved":"https://registry.npmjs.org/rxjs/-/rxjs-5.5.1.tgz","integrity":"sha512-LmsJqk/i5D3e9eD7WR0v1XkHos2Rjo6qJkmVK7k6r74UZnesqcyVl6xTado4FxdjuNKWexnJJF6U8rCCz8BaFw==","dev":true,"requires":{"symbol-observable":"1.0.4"}},"safe-buffer":{"version":"5.1.1","resolved":"https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz","integrity":"sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="},"sanitize-filename":{"version":"1.6.1","resolved":"https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz","integrity":"sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=","dev":true,"requires":{"truncate-utf8-bytes":"1.0.2"}},"sass-graph":{"version":"2.2.4","resolved":"https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz","integrity":"sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=","dev":true,"requires":{"glob":"7.1.2","lodash":"4.17.4","scss-tokenizer":"0.2.3","yargs":"7.1.0"},"dependencies":{"camelcase":{"version":"3.0.0","resolved":"https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz","integrity":"sha1-MvxLn82vhF/N9+c7uXysImHwqwo=","dev":true},"os-locale":{"version":"1.4.0","resolved":"https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz","integrity":"sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=","dev":true,"requires":{"lcid":"1.0.0"}},"which-module":{"version":"1.0.0","resolved":"https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz","integrity":"sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=","dev":true},"yargs":{"version":"7.1.0","resolved":"https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz","integrity":"sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=","dev":true,"requires":{"camelcase":"3.0.0","cliui":"3.2.0","decamelize":"1.2.0","get-caller-file":"1.0.2","os-locale":"1.4.0","read-pkg-up":"1.0.1","require-directory":"2.1.1","require-main-filename":"1.0.1","set-blocking":"2.0.0","string-width":"1.0.2","which-module":"1.0.0","y18n":"3.2.1","yargs-parser":"5.0.0"}},"yargs-parser":{"version":"5.0.0","resolved":"https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz","integrity":"sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=","dev":true,"requires":{"camelcase":"3.0.0"}}}},"sass-lint":{"version":"1.12.1","resolved":"https://registry.npmjs.org/sass-lint/-/sass-lint-1.12.1.tgz","integrity":"sha1-Yw9pwhaqIGuCMvsqqQe98zNrbYM=","dev":true,"requires":{"commander":"2.8.1","eslint":"2.13.1","front-matter":"2.1.2","fs-extra":"3.0.1","glob":"7.1.2","globule":"1.2.0","gonzales-pe-sl":"4.2.3","js-yaml":"3.10.0","known-css-properties":"0.3.0","lodash.capitalize":"4.2.1","lodash.kebabcase":"4.1.1","merge":"1.2.0","path-is-absolute":"1.0.1","util":"0.10.3"},"dependencies":{"fs-extra":{"version":"3.0.1","resolved":"https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz","integrity":"sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=","dev":true,"requires":{"graceful-fs":"4.1.11","jsonfile":"3.0.1","universalify":"0.1.1"}},"jsonfile":{"version":"3.0.1","resolved":"https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz","integrity":"sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=","dev":true,"requires":{"graceful-fs":"4.1.11"}}}},"sass-loader":{"version":"6.0.6","resolved":"https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.6.tgz","integrity":"sha512-c3/Zc+iW+qqDip6kXPYLEgsAu2lf4xz0EZDplB7EmSUMda12U1sGJPetH55B/j9eu0bTtKzKlNPWWyYC7wFNyQ==","dev":true,"requires":{"async":"2.5.0","clone-deep":"0.3.0","loader-utils":"1.1.0","lodash.tail":"4.1.1","pify":"3.0.0"},"dependencies":{"async":{"version":"2.5.0","resolved":"https://registry.npmjs.org/async/-/async-2.5.0.tgz","integrity":"sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==","dev":true,"requires":{"lodash":"4.17.4"}},"pify":{"version":"3.0.0","resolved":"https://registry.npmjs.org/pify/-/pify-3.0.0.tgz","integrity":"sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=","dev":true}}},"sax":{"version":"1.2.4","resolved":"https://registry.npmjs.org/sax/-/sax-1.2.4.tgz","integrity":"sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="},"schema-utils":{"version":"0.3.0","resolved":"https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz","integrity":"sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=","dev":true,"requires":{"ajv":"5.3.0"},"dependencies":{"ajv":{"version":"5.3.0","resolved":"https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz","integrity":"sha1-RBT/dKUIecII7l/cgm4ywwNUnto=","dev":true,"requires":{"co":"4.6.0","fast-deep-equal":"1.0.0","fast-json-stable-stringify":"2.0.0","json-schema-traverse":"0.3.1"}}}},"scss-tokenizer":{"version":"0.2.3","resolved":"https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz","integrity":"sha1-jrBtualyMzOCTT9VMGQRSYR85dE=","dev":true,"requires":{"js-base64":"2.3.2","source-map":"0.4.4"},"dependencies":{"source-map":{"version":"0.4.4","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz","integrity":"sha1-66T12pwNyZneaAMti092FzZSA2s=","dev":true,"requires":{"amdefine":"1.0.1"}}}},"seek-bzip":{"version":"1.0.5","resolved":"https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz","integrity":"sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=","requires":{"commander":"2.8.1"}},"select-hose":{"version":"2.0.0","resolved":"https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz","integrity":"sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=","dev":true},"selfsigned":{"version":"1.10.1","resolved":"https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.1.tgz","integrity":"sha1-v4y3uDJWxFUeMTR8YxF3jbme7FI=","dev":true,"requires":{"node-forge":"0.6.33"}},"semver":{"version":"5.4.1","resolved":"https://registry.npmjs.org/semver/-/semver-5.4.1.tgz","integrity":"sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="},"semver-diff":{"version":"2.1.0","resolved":"https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz","integrity":"sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=","dev":true,"requires":{"semver":"5.4.1"}},"send":{"version":"0.16.1","resolved":"https://registry.npmjs.org/send/-/send-0.16.1.tgz","integrity":"sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==","dev":true,"requires":{"debug":"2.6.9","depd":"1.1.1","destroy":"1.0.4","encodeurl":"1.0.1","escape-html":"1.0.3","etag":"1.8.1","fresh":"0.5.2","http-errors":"1.6.2","mime":"1.4.1","ms":"2.0.0","on-finished":"2.3.0","range-parser":"1.2.0","statuses":"1.3.1"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}},"mime":{"version":"1.4.1","resolved":"https://registry.npmjs.org/mime/-/mime-1.4.1.tgz","integrity":"sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==","dev":true},"statuses":{"version":"1.3.1","resolved":"https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz","integrity":"sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=","dev":true}}},"serve-index":{"version":"1.9.1","resolved":"https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz","integrity":"sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=","dev":true,"requires":{"accepts":"1.3.4","batch":"0.6.1","debug":"2.6.9","escape-html":"1.0.3","http-errors":"1.6.2","mime-types":"2.1.17","parseurl":"1.3.2"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}}}},"serve-static":{"version":"1.13.1","resolved":"https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz","integrity":"sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==","dev":true,"requires":{"encodeurl":"1.0.1","escape-html":"1.0.3","parseurl":"1.3.2","send":"0.16.1"}},"set-blocking":{"version":"2.0.0","resolved":"https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz","integrity":"sha1-BF+XgtARrppoA93TgrJDkrPYkPc="},"set-getter":{"version":"0.1.0","resolved":"https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz","integrity":"sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=","dev":true,"requires":{"to-object-path":"0.3.0"}},"set-immediate-shim":{"version":"1.0.1","resolved":"https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz","integrity":"sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=","dev":true},"set-value":{"version":"2.0.0","resolved":"https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz","integrity":"sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==","dev":true,"requires":{"extend-shallow":"2.0.1","is-extendable":"0.1.1","is-plain-object":"2.0.4","split-string":"3.0.2"}},"setimmediate":{"version":"1.0.5","resolved":"https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz","integrity":"sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="},"setprototypeof":{"version":"1.0.3","resolved":"https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz","integrity":"sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=","dev":true},"sha.js":{"version":"2.4.9","resolved":"https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz","integrity":"sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==","dev":true,"requires":{"inherits":"2.0.3","safe-buffer":"5.1.1"}},"shallow-clone":{"version":"0.1.2","resolved":"https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz","integrity":"sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=","dev":true,"requires":{"is-extendable":"0.1.1","kind-of":"2.0.1","lazy-cache":"0.2.7","mixin-object":"2.0.1"},"dependencies":{"kind-of":{"version":"2.0.1","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz","integrity":"sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=","dev":true,"requires":{"is-buffer":"1.1.5"}},"lazy-cache":{"version":"0.2.7","resolved":"https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz","integrity":"sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=","dev":true}}},"shebang-command":{"version":"1.2.0","resolved":"https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz","integrity":"sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=","dev":true,"requires":{"shebang-regex":"1.0.0"}},"shebang-regex":{"version":"1.0.0","resolved":"https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz","integrity":"sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=","dev":true},"shelljs":{"version":"0.6.1","resolved":"https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz","integrity":"sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=","dev":true},"signal-exit":{"version":"3.0.2","resolved":"https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz","integrity":"sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="},"simple-get":{"version":"1.4.3","resolved":"https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz","integrity":"sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=","dev":true,"requires":{"once":"1.4.0","unzip-response":"1.0.2","xtend":"4.0.1"}},"simple-git":{"version":"1.80.1","resolved":"https://registry.npmjs.org/simple-git/-/simple-git-1.80.1.tgz","integrity":"sha1-SBBMtKxyV2k3hT4a/R7v/cl6yyk=","dev":true,"requires":{"debug":"2.6.9"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}}}},"single-line-log":{"version":"1.1.2","resolved":"https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz","integrity":"sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=","dev":true,"requires":{"string-width":"1.0.2"}},"slice-ansi":{"version":"0.0.4","resolved":"https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz","integrity":"sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=","dev":true},"snapdragon":{"version":"0.8.1","resolved":"https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz","integrity":"sha1-4StUh/re0+PeoKyR6UAL91tAE3A=","dev":true,"requires":{"base":"0.11.2","debug":"2.6.9","define-property":"0.2.5","extend-shallow":"2.0.1","map-cache":"0.2.2","source-map":"0.5.7","source-map-resolve":"0.5.1","use":"2.0.2"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}},"define-property":{"version":"0.2.5","resolved":"https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz","integrity":"sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=","dev":true,"requires":{"is-descriptor":"0.1.6"}},"is-descriptor":{"version":"0.1.6","resolved":"https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz","integrity":"sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==","dev":true,"requires":{"is-accessor-descriptor":"0.1.6","is-data-descriptor":"0.1.4","kind-of":"5.1.0"}},"kind-of":{"version":"5.1.0","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz","integrity":"sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==","dev":true},"source-map":{"version":"0.5.7","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz","integrity":"sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=","dev":true}}},"snapdragon-node":{"version":"2.1.1","resolved":"https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz","integrity":"sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==","dev":true,"requires":{"define-property":"1.0.0","isobject":"3.0.1","snapdragon-util":"3.0.1"}},"snapdragon-util":{"version":"3.0.1","resolved":"https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz","integrity":"sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==","dev":true,"requires":{"kind-of":"3.2.2"},"dependencies":{"kind-of":{"version":"3.2.2","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz","integrity":"sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=","dev":true,"requires":{"is-buffer":"1.1.5"}}}},"sntp":{"version":"1.0.9","resolved":"https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz","integrity":"sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=","requires":{"hoek":"2.16.3"}},"sockjs":{"version":"0.3.18","resolved":"https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz","integrity":"sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=","dev":true,"requires":{"faye-websocket":"0.10.0","uuid":"2.0.3"},"dependencies":{"uuid":{"version":"2.0.3","resolved":"https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz","integrity":"sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=","dev":true}}},"sockjs-client":{"version":"1.1.4","resolved":"https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz","integrity":"sha1-W6vjhrd15M8U51IJEUUmVAFsixI=","dev":true,"requires":{"debug":"2.6.9","eventsource":"0.1.6","faye-websocket":"0.11.1","inherits":"2.0.3","json3":"3.3.2","url-parse":"1.1.9"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}},"faye-websocket":{"version":"0.11.1","resolved":"https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz","integrity":"sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=","dev":true,"requires":{"websocket-driver":"0.7.0"}}}},"sort-keys":{"version":"1.1.2","resolved":"https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz","integrity":"sha1-RBttTTRnmPG05J6JIK37oOVD+a0=","dev":true,"requires":{"is-plain-obj":"1.1.0"}},"source-list-map":{"version":"2.0.0","resolved":"https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz","integrity":"sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==","dev":true},"source-map":{"version":"0.6.1","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz","integrity":"sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="},"source-map-resolve":{"version":"0.5.1","resolved":"https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz","integrity":"sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==","dev":true,"requires":{"atob":"2.0.3","decode-uri-component":"0.2.0","resolve-url":"0.2.1","source-map-url":"0.4.0","urix":"0.1.0"}},"source-map-support":{"version":"0.5.0","resolved":"https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz","integrity":"sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==","requires":{"source-map":"0.6.1"}},"source-map-url":{"version":"0.4.0","resolved":"https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz","integrity":"sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=","dev":true},"sourcemapped-stacktrace":{"version":"1.1.7","resolved":"https://registry.npmjs.org/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.7.tgz","integrity":"sha512-pgHNUACbafkQ+M5zR00NSOtSKBc/i40prgN+SY07J/pghClwVNWNTTMa0JuXj4lriR2TvMKcPAHw5KN9tVFRhA==","dev":true,"requires":{"source-map":"0.5.6"},"dependencies":{"source-map":{"version":"0.5.6","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz","integrity":"sha1-dc449SvwczxafwwRjYEzSiu19BI=","dev":true}}},"spawn-command":{"version":"0.0.2-1","resolved":"https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz","integrity":"sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=","dev":true},"spdx-correct":{"version":"1.0.2","resolved":"https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz","integrity":"sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=","dev":true,"requires":{"spdx-license-ids":"1.2.2"}},"spdx-expression-parse":{"version":"1.0.4","resolved":"https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz","integrity":"sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=","dev":true},"spdx-license-ids":{"version":"1.2.2","resolved":"https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz","integrity":"sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=","dev":true},"spdy":{"version":"3.4.7","resolved":"https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz","integrity":"sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=","dev":true,"requires":{"debug":"2.6.9","handle-thing":"1.2.5","http-deceiver":"1.2.7","safe-buffer":"5.1.1","select-hose":"2.0.0","spdy-transport":"2.0.20"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}}}},"spdy-transport":{"version":"2.0.20","resolved":"https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz","integrity":"sha1-c15yBUxIayNU/onnAiVgBKOazk0=","dev":true,"requires":{"debug":"2.6.9","detect-node":"2.0.3","hpack.js":"2.1.6","obuf":"1.1.1","readable-stream":"2.3.3","safe-buffer":"5.1.1","wbuf":"1.7.2"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}}}},"spectron":{"version":"3.7.2","resolved":"https://registry.npmjs.org/spectron/-/spectron-3.7.2.tgz","integrity":"sha1-hvQTBqm3DtbuFQD399Otw4mvtEY=","dev":true,"requires":{"dev-null":"0.1.1","electron-chromedriver":"1.7.1","request":"2.83.0","split":"1.0.1","webdriverio":"4.8.0"}},"speedometer":{"version":"0.1.4","resolved":"https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz","integrity":"sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0=","dev":true},"split":{"version":"1.0.1","resolved":"https://registry.npmjs.org/split/-/split-1.0.1.tgz","integrity":"sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==","dev":true,"requires":{"through":"2.3.8"}},"split-string":{"version":"3.0.2","resolved":"https://registry.npmjs.org/split-string/-/split-string-3.0.2.tgz","integrity":"sha512-d6myUSfwmBz1izkY4r7r7I0PL41rh21qUDYK1OgclmGHeoqQoujduGxMbzw6BlF3HKmJR4sMpbWVo7/Xzg4YBQ==","dev":true,"requires":{"extend-shallow":"2.0.1"}},"sprintf-js":{"version":"1.0.3","resolved":"https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz","integrity":"sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="},"sshpk":{"version":"1.13.1","resolved":"https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz","integrity":"sha1-US322mKHFEMW3EwY/hzx2UBzm+M=","requires":{"asn1":"0.2.3","assert-plus":"1.0.0","bcrypt-pbkdf":"1.0.1","dashdash":"1.14.1","ecc-jsbn":"0.1.1","getpass":"0.1.7","jsbn":"0.1.1","tweetnacl":"0.14.5"},"dependencies":{"assert-plus":{"version":"1.0.0","resolved":"https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz","integrity":"sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="}}},"stack-trace":{"version":"0.0.10","resolved":"https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz","integrity":"sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=","dev":true},"stackframe":{"version":"0.3.1","resolved":"https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz","integrity":"sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=","dev":true},"staged-git-files":{"version":"0.0.4","resolved":"https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz","integrity":"sha1-15fhtVHKemOd7AI33G60u5vhfTU=","dev":true},"stat-mode":{"version":"0.2.2","resolved":"https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz","integrity":"sha1-5sgLYjEj19gM8TLOU480YokHJQI=","dev":true},"static-extend":{"version":"0.1.2","resolved":"https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz","integrity":"sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=","dev":true,"requires":{"define-property":"0.2.5","object-copy":"0.1.0"},"dependencies":{"define-property":{"version":"0.2.5","resolved":"https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz","integrity":"sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=","dev":true,"requires":{"is-descriptor":"0.1.6"}},"is-descriptor":{"version":"0.1.6","resolved":"https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz","integrity":"sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==","dev":true,"requires":{"is-accessor-descriptor":"0.1.6","is-data-descriptor":"0.1.4","kind-of":"5.1.0"}},"kind-of":{"version":"5.1.0","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz","integrity":"sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==","dev":true}}},"statuses":{"version":"1.4.0","resolved":"https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz","integrity":"sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==","dev":true},"stdout-stream":{"version":"1.4.0","resolved":"https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz","integrity":"sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=","dev":true,"requires":{"readable-stream":"2.3.3"}},"stealthy-require":{"version":"1.1.1","resolved":"https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz","integrity":"sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=","dev":true},"stream-browserify":{"version":"2.0.1","resolved":"https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz","integrity":"sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=","dev":true,"requires":{"inherits":"2.0.3","readable-stream":"2.3.3"}},"stream-counter":{"version":"1.0.0","resolved":"https://registry.npmjs.org/stream-counter/-/stream-counter-1.0.0.tgz","integrity":"sha1-kc8lac5NxQYf6816yyY5SloRR1E="},"stream-http":{"version":"2.7.2","resolved":"https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz","integrity":"sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==","dev":true,"requires":{"builtin-status-codes":"3.0.0","inherits":"2.0.3","readable-stream":"2.3.3","to-arraybuffer":"1.0.1","xtend":"4.0.1"}},"stream-to-observable":{"version":"0.1.0","resolved":"https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz","integrity":"sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=","dev":true},"strict-uri-encode":{"version":"1.1.0","resolved":"https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz","integrity":"sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=","dev":true},"string_decoder":{"version":"1.0.3","resolved":"https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz","integrity":"sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==","requires":{"safe-buffer":"5.1.1"}},"string-width":{"version":"1.0.2","resolved":"https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz","integrity":"sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=","requires":{"code-point-at":"1.1.0","is-fullwidth-code-point":"1.0.0","strip-ansi":"3.0.1"}},"stringify-object":{"version":"3.2.1","resolved":"https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz","integrity":"sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==","dev":true,"requires":{"get-own-enumerable-property-symbols":"2.0.1","is-obj":"1.0.1","is-regexp":"1.0.0"}},"stringstream":{"version":"0.0.5","resolved":"https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz","integrity":"sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="},"strip-ansi":{"version":"3.0.1","resolved":"https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz","integrity":"sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=","requires":{"ansi-regex":"2.1.1"}},"strip-bom":{"version":"2.0.0","resolved":"https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz","integrity":"sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=","dev":true,"requires":{"is-utf8":"0.2.1"}},"strip-dirs":{"version":"2.1.0","resolved":"https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz","integrity":"sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==","requires":{"is-natural-number":"4.0.1"}},"strip-eof":{"version":"1.0.0","resolved":"https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz","integrity":"sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=","dev":true},"strip-indent":{"version":"1.0.1","resolved":"https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz","integrity":"sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=","dev":true,"requires":{"get-stdin":"4.0.1"}},"strip-json-comments":{"version":"2.0.1","resolved":"https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz","integrity":"sha1-PFMZQukIwml8DsNEhYwobHygpgo="},"style-loader":{"version":"0.19.0","resolved":"https://registry.npmjs.org/style-loader/-/style-loader-0.19.0.tgz","integrity":"sha512-9mx9sC9nX1dgP96MZOODpGC6l1RzQBITI2D5WJhu+wnbrSYVKLGuy14XJSLVQih/0GFrPpjelt+s//VcZQ2Evw==","dev":true,"requires":{"loader-utils":"1.1.0","schema-utils":"0.3.0"}},"sumchecker":{"version":"1.3.1","resolved":"https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz","integrity":"sha1-ebs7RFbdBPGOvbwNcDodHa7FEF0=","dev":true,"requires":{"debug":"2.6.9","es6-promise":"4.1.1"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}}}},"superagent":{"version":"3.7.0","resolved":"https://registry.npmjs.org/superagent/-/superagent-3.7.0.tgz","integrity":"sha512-/8trxO6NbLx4YXb7IeeFTSmsQ35pQBiTBsLNvobZx7qBzBeHYvKCyIIhW2gNcWbLzYxPAjdgFbiepd8ypwC0Gw==","dev":true,"requires":{"component-emitter":"1.2.1","cookiejar":"2.1.1","debug":"3.1.0","extend":"3.0.1","form-data":"2.3.1","formidable":"1.1.1","methods":"1.1.2","mime":"1.4.1","qs":"6.5.1","readable-stream":"2.3.3"},"dependencies":{"form-data":{"version":"2.3.1","resolved":"https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz","integrity":"sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=","dev":true,"requires":{"asynckit":"0.4.0","combined-stream":"1.0.5","mime-types":"2.1.17"}},"mime":{"version":"1.4.1","resolved":"https://registry.npmjs.org/mime/-/mime-1.4.1.tgz","integrity":"sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==","dev":true},"qs":{"version":"6.5.1","resolved":"https://registry.npmjs.org/qs/-/qs-6.5.1.tgz","integrity":"sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==","dev":true}}},"supports-color":{"version":"3.2.3","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz","integrity":"sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=","dev":true,"requires":{"has-flag":"1.0.0"}},"svg-baker":{"version":"1.2.16","resolved":"https://registry.npmjs.org/svg-baker/-/svg-baker-1.2.16.tgz","integrity":"sha512-L8ftwzm9ig4TjWrzp1/fZ9j8qo6oDD+COUHmNhhhvb5/FjIT+X0f+1Id9BsQ7eCAmRimFWI72Nzk5etnuLc5hg==","dev":true,"requires":{"bluebird":"3.5.1","clone":"2.1.1","he":"1.1.1","image-size":"0.5.5","loader-utils":"1.1.0","merge-options":"0.0.64","micromatch":"3.1.0","postcss":"5.2.18","postcss-prefix-selector":"1.6.0","posthtml-rename-id":"1.0.3","posthtml-svg-mode":"1.0.2","query-string":"4.3.4","traverse":"0.6.6"},"dependencies":{"clone":{"version":"2.1.1","resolved":"https://registry.npmjs.org/clone/-/clone-2.1.1.tgz","integrity":"sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=","dev":true},"kind-of":{"version":"5.1.0","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz","integrity":"sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==","dev":true},"micromatch":{"version":"3.1.0","resolved":"https://registry.npmjs.org/micromatch/-/micromatch-3.1.0.tgz","integrity":"sha512-3StSelAE+hnRvMs8IdVW7Uhk8CVed5tp+kLLGlBP6WiRAXS21GPGu/Nat4WNPXj2Eoc24B02SaeoyozPMfj0/g==","dev":true,"requires":{"arr-diff":"4.0.0","array-unique":"0.3.2","braces":"2.3.0","define-property":"1.0.0","extend-shallow":"2.0.1","extglob":"2.0.2","fragment-cache":"0.2.1","kind-of":"5.1.0","nanomatch":"1.2.5","object.pick":"1.3.0","regex-not":"1.0.0","snapdragon":"0.8.1","to-regex":"3.0.1"}}}},"svg-baker-runtime":{"version":"1.3.3","resolved":"https://registry.npmjs.org/svg-baker-runtime/-/svg-baker-runtime-1.3.3.tgz","integrity":"sha512-yDnHhVM+nGxLu+Oj/zG07yUPXmJ7XLmekU2XQqL0jaLUazLjxj61uO8IMyww2roUjdMQo4x+J+KIlAp37qIbZQ==","dev":true,"requires":{"deepmerge":"1.3.2","mitt":"1.1.2","svg-baker":"1.2.16"}},"svg-sprite-loader":{"version":"3.4.1","resolved":"https://registry.npmjs.org/svg-sprite-loader/-/svg-sprite-loader-3.4.1.tgz","integrity":"sha512-M6d2JVOXo6eUEpOCF8A4ZDHZRdfiitXiGFJYxXX6F/1f0TE7pedAsZ9NAY+mLnGFrMYn5qc/DqAk2l5ed+rz2A==","dev":true,"requires":{"bluebird":"3.5.1","deepmerge":"1.3.2","domready":"1.0.8","escape-string-regexp":"1.0.5","loader-utils":"1.1.0","svg-baker":"1.2.16","svg-baker-runtime":"1.3.3","url-slug":"2.0.0"}},"svgo":{"version":"0.7.2","resolved":"https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz","integrity":"sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=","dev":true,"requires":{"coa":"1.0.4","colors":"1.1.2","csso":"2.3.2","js-yaml":"3.7.0","mkdirp":"0.5.1","sax":"1.2.4","whet.extend":"0.9.9"},"dependencies":{"esprima":{"version":"2.7.3","resolved":"https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz","integrity":"sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=","dev":true},"js-yaml":{"version":"3.7.0","resolved":"https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz","integrity":"sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=","dev":true,"requires":{"argparse":"1.0.9","esprima":"2.7.3"}}}},"symbol-observable":{"version":"1.0.4","resolved":"https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz","integrity":"sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=","dev":true},"symbol-tree":{"version":"3.2.2","resolved":"https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz","integrity":"sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=","dev":true},"sync-request":{"version":"3.0.1","resolved":"https://registry.npmjs.org/sync-request/-/sync-request-3.0.1.tgz","integrity":"sha1-yqEjWq+Im6UBB2oYNMQ2gwqC+3M=","requires":{"concat-stream":"1.6.0","http-response-object":"1.1.0","then-request":"2.2.0"}},"table":{"version":"3.8.3","resolved":"https://registry.npmjs.org/table/-/table-3.8.3.tgz","integrity":"sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=","dev":true,"requires":{"ajv":"4.11.8","ajv-keywords":"1.5.1","chalk":"1.1.3","lodash":"4.17.4","slice-ansi":"0.0.4","string-width":"2.1.1"},"dependencies":{"ajv-keywords":{"version":"1.5.1","resolved":"https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz","integrity":"sha1-MU3QpLM2j609/NxU7eYXG4htrzw=","dev":true},"ansi-styles":{"version":"2.2.1","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz","integrity":"sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=","dev":true},"chalk":{"version":"1.1.3","resolved":"https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz","integrity":"sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=","dev":true,"requires":{"ansi-styles":"2.2.1","escape-string-regexp":"1.0.5","has-ansi":"2.0.0","strip-ansi":"3.0.1","supports-color":"2.0.0"}},"has-ansi":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz","integrity":"sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=","dev":true,"requires":{"ansi-regex":"2.1.1"}},"is-fullwidth-code-point":{"version":"2.0.0","resolved":"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz","integrity":"sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=","dev":true},"string-width":{"version":"2.1.1","resolved":"https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz","integrity":"sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==","dev":true,"requires":{"is-fullwidth-code-point":"2.0.0","strip-ansi":"4.0.0"},"dependencies":{"ansi-regex":{"version":"3.0.0","resolved":"https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz","integrity":"sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=","dev":true},"strip-ansi":{"version":"4.0.0","resolved":"https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz","integrity":"sha1-qEeQIusaw2iocTibY1JixQXuNo8=","dev":true,"requires":{"ansi-regex":"3.0.0"}}}},"supports-color":{"version":"2.0.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz","integrity":"sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=","dev":true}}},"tapable":{"version":"0.2.8","resolved":"https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz","integrity":"sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=","dev":true},"tar":{"version":"2.2.1","resolved":"https://registry.npmjs.org/tar/-/tar-2.2.1.tgz","integrity":"sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=","requires":{"block-stream":"0.0.9","fstream":"1.0.11","inherits":"2.0.3"}},"tar-fs":{"version":"1.16.0","resolved":"https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz","integrity":"sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==","dev":true,"requires":{"chownr":"1.0.1","mkdirp":"0.5.1","pump":"1.0.2","tar-stream":"1.5.4"}},"tar-pack":{"version":"3.4.1","resolved":"https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz","integrity":"sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==","requires":{"debug":"2.6.9","fstream":"1.0.11","fstream-ignore":"1.0.5","once":"1.4.0","readable-stream":"2.3.3","rimraf":"2.6.2","tar":"2.2.1","uid-number":"0.0.6"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","requires":{"ms":"2.0.0"}}}},"tar-stream":{"version":"1.5.4","resolved":"https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz","integrity":"sha1-NlSc8E7RrumyowwBQyUiONr5QBY=","requires":{"bl":"1.2.1","end-of-stream":"1.4.0","readable-stream":"2.3.3","xtend":"4.0.1"}},"temp-file":{"version":"2.0.3","resolved":"https://registry.npmjs.org/temp-file/-/temp-file-2.0.3.tgz","integrity":"sha512-qN0iNW0DFNmog1BFS8J3rQK4sZRIqqUZJ/zFlFo+0PwE7adUTEpPrQ3toWxwTcDjtGL9HjsQWe8CqMKq1kM7Gw==","dev":true,"requires":{"async-exit-hook":"2.0.1","bluebird-lst":"1.0.5","fs-extra-p":"4.4.4","lazy-val":"1.0.2"}},"term-size":{"version":"1.2.0","resolved":"https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz","integrity":"sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=","dev":true,"requires":{"execa":"0.7.0"}},"test-value":{"version":"2.1.0","resolved":"https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz","integrity":"sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=","requires":{"array-back":"1.0.4","typical":"2.6.1"},"dependencies":{"array-back":{"version":"1.0.4","resolved":"https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz","integrity":"sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=","requires":{"typical":"2.6.1"}}}},"tether":{"version":"1.4.0","resolved":"https://registry.npmjs.org/tether/-/tether-1.4.0.tgz","integrity":"sha1-D5+hcfdb9YSF2BSelHmdeudNHBo=","dev":true},"text-table":{"version":"0.2.0","resolved":"https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz","integrity":"sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=","dev":true},"then-request":{"version":"2.2.0","resolved":"https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz","integrity":"sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=","requires":{"caseless":"0.11.0","concat-stream":"1.6.0","http-basic":"2.5.1","http-response-object":"1.1.0","promise":"7.3.1","qs":"6.4.0"},"dependencies":{"caseless":{"version":"0.11.0","resolved":"https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz","integrity":"sha1-cVuW6phBWTzDMGeSP17GDr2k99c="}}},"throttleit":{"version":"0.0.2","resolved":"https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz","integrity":"sha1-z+34jmDADdlpe2H90qg0OptoDq8=","dev":true},"through":{"version":"2.3.8","resolved":"https://registry.npmjs.org/through/-/through-2.3.8.tgz","integrity":"sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="},"through2":{"version":"0.2.3","resolved":"https://registry.npmjs.org/through2/-/through2-0.2.3.tgz","integrity":"sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=","dev":true,"requires":{"readable-stream":"1.1.14","xtend":"2.1.2"},"dependencies":{"isarray":{"version":"0.0.1","resolved":"https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz","integrity":"sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=","dev":true},"readable-stream":{"version":"1.1.14","resolved":"https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz","integrity":"sha1-fPTFTvZI44EwhMY23SB54WbAgdk=","dev":true,"requires":{"core-util-is":"1.0.2","inherits":"2.0.3","isarray":"0.0.1","string_decoder":"0.10.31"}},"string_decoder":{"version":"0.10.31","resolved":"https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz","integrity":"sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=","dev":true},"xtend":{"version":"2.1.2","resolved":"https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz","integrity":"sha1-bv7MKk2tjmlixJAbM3znuoe10os=","dev":true,"requires":{"object-keys":"0.4.0"}}}},"thunky":{"version":"0.1.0","resolved":"https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz","integrity":"sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4=","dev":true},"time-stamp":{"version":"2.0.0","resolved":"https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz","integrity":"sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=","dev":true},"timed-out":{"version":"4.0.1","resolved":"https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz","integrity":"sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=","dev":true},"timers-browserify":{"version":"2.0.4","resolved":"https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz","integrity":"sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==","dev":true,"requires":{"setimmediate":"1.0.5"}},"tmp":{"version":"0.0.33","resolved":"https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz","integrity":"sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==","dev":true,"requires":{"os-tmpdir":"1.0.2"}},"to-arraybuffer":{"version":"1.0.1","resolved":"https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz","integrity":"sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=","dev":true},"to-object-path":{"version":"0.3.0","resolved":"https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz","integrity":"sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=","dev":true,"requires":{"kind-of":"3.2.2"},"dependencies":{"kind-of":{"version":"3.2.2","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz","integrity":"sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=","dev":true,"requires":{"is-buffer":"1.1.5"}}}},"to-regex":{"version":"3.0.1","resolved":"https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz","integrity":"sha1-FTWL7kosg712N3uh3ASdDxiDeq4=","dev":true,"requires":{"define-property":"0.2.5","extend-shallow":"2.0.1","regex-not":"1.0.0"},"dependencies":{"define-property":{"version":"0.2.5","resolved":"https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz","integrity":"sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=","dev":true,"requires":{"is-descriptor":"0.1.6"}},"is-descriptor":{"version":"0.1.6","resolved":"https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz","integrity":"sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==","dev":true,"requires":{"is-accessor-descriptor":"0.1.6","is-data-descriptor":"0.1.4","kind-of":"5.1.0"}},"kind-of":{"version":"5.1.0","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz","integrity":"sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==","dev":true}}},"to-regex-range":{"version":"2.1.1","resolved":"https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz","integrity":"sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=","dev":true,"requires":{"is-number":"3.0.0","repeat-string":"1.6.1"}},"topo":{"version":"1.1.0","resolved":"https://registry.npmjs.org/topo/-/topo-1.1.0.tgz","integrity":"sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=","dev":true,"requires":{"hoek":"2.16.3"}},"toposort":{"version":"1.0.6","resolved":"https://registry.npmjs.org/toposort/-/toposort-1.0.6.tgz","integrity":"sha1-wxdI5V0hDv/AD9zcfW5o19e7nOw=","dev":true},"tough-cookie":{"version":"2.3.3","resolved":"https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz","integrity":"sha1-C2GKVWW23qkL80JdBNVe3EdadWE=","requires":{"punycode":"1.4.1"}},"tr46":{"version":"1.0.1","resolved":"https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz","integrity":"sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=","dev":true,"requires":{"punycode":"2.1.0"},"dependencies":{"punycode":{"version":"2.1.0","resolved":"https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz","integrity":"sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=","dev":true}}},"traverse":{"version":"0.6.6","resolved":"https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz","integrity":"sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=","dev":true},"tree-kill":{"version":"1.2.0","resolved":"https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz","integrity":"sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg==","dev":true},"trim-newlines":{"version":"1.0.0","resolved":"https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz","integrity":"sha1-WIeWa7WCpFA6QetST301ARgVphM=","dev":true},"truncate-utf8-bytes":{"version":"1.0.2","resolved":"https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz","integrity":"sha1-QFkjkJWS1W94pYGENLC3hInKXys=","dev":true,"requires":{"utf8-byte-length":"1.0.4"}},"tryit":{"version":"1.0.3","resolved":"https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz","integrity":"sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=","dev":true},"tslib":{"version":"1.8.0","resolved":"https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz","integrity":"sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg==","dev":true},"tslint":{"version":"5.8.0","resolved":"https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz","integrity":"sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=","dev":true,"requires":{"babel-code-frame":"6.26.0","builtin-modules":"1.1.1","chalk":"2.3.0","commander":"2.11.0","diff":"3.2.0","glob":"7.1.2","minimatch":"3.0.4","resolve":"1.5.0","semver":"5.4.1","tslib":"1.8.0","tsutils":"2.12.1"},"dependencies":{"ansi-styles":{"version":"3.2.0","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz","integrity":"sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==","dev":true,"requires":{"color-convert":"1.9.0"}},"chalk":{"version":"2.3.0","resolved":"https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz","integrity":"sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==","dev":true,"requires":{"ansi-styles":"3.2.0","escape-string-regexp":"1.0.5","supports-color":"4.5.0"}},"commander":{"version":"2.11.0","resolved":"https://registry.npmjs.org/commander/-/commander-2.11.0.tgz","integrity":"sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==","dev":true},"has-flag":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz","integrity":"sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=","dev":true},"supports-color":{"version":"4.5.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz","integrity":"sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=","dev":true,"requires":{"has-flag":"2.0.0"}}}},"tslint-config-prettier":{"version":"1.6.0","resolved":"https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.6.0.tgz","integrity":"sha512-39xsbQGnv20r0iraRNR/tlIaW4Fk2rj6mTk+V1r0TV1NztFfP0WTFKYP7JDq91w+wsfEfMNqWG4GPA6FjpDZEA==","dev":true},"tslint-eslint-rules":{"version":"4.1.1","resolved":"https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-4.1.1.tgz","integrity":"sha1-fDDniC8mvCdr/5HSOEl1xp2viLo=","dev":true,"requires":{"doctrine":"0.7.2","tslib":"1.8.0","tsutils":"1.9.1"},"dependencies":{"doctrine":{"version":"0.7.2","resolved":"https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz","integrity":"sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=","dev":true,"requires":{"esutils":"1.1.6","isarray":"0.0.1"}},"esutils":{"version":"1.1.6","resolved":"https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz","integrity":"sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=","dev":true},"isarray":{"version":"0.0.1","resolved":"https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz","integrity":"sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=","dev":true},"tsutils":{"version":"1.9.1","resolved":"https://registry.npmjs.org/tsutils/-/tsutils-1.9.1.tgz","integrity":"sha1-ufmrROVa+WgYMdXyjQrur1x1DLA=","dev":true}}},"tslint-plugin-prettier":{"version":"1.3.0","resolved":"https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz","integrity":"sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==","dev":true,"requires":{"eslint-plugin-prettier":"2.3.1","tslib":"1.8.0"}},"tslint-react":{"version":"3.2.0","resolved":"https://registry.npmjs.org/tslint-react/-/tslint-react-3.2.0.tgz","integrity":"sha1-hR+1BSAcY9A0PFFybmNk9+mtLpk=","dev":true,"requires":{"tsutils":"2.12.1"}},"tsutils":{"version":"2.12.1","resolved":"https://registry.npmjs.org/tsutils/-/tsutils-2.12.1.tgz","integrity":"sha1-9Nlc4zkciXHkblTEzw7bCiHdWyQ=","dev":true,"requires":{"tslib":"1.8.0"}},"tty-browserify":{"version":"0.0.0","resolved":"https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz","integrity":"sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=","dev":true},"tunnel-agent":{"version":"0.6.0","resolved":"https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz","integrity":"sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=","requires":{"safe-buffer":"5.1.1"}},"tweetnacl":{"version":"0.14.5","resolved":"https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz","integrity":"sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=","optional":true},"type-check":{"version":"0.3.2","resolved":"https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz","integrity":"sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=","dev":true,"requires":{"prelude-ls":"1.1.2"}},"type-is":{"version":"1.6.15","resolved":"https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz","integrity":"sha1-yrEPtJCeRByChC6v4a1kbIGARBA=","dev":true,"requires":{"media-typer":"0.3.0","mime-types":"2.1.17"}},"typedarray":{"version":"0.0.6","resolved":"https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz","integrity":"sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="},"typescript":{"version":"2.5.3","resolved":"https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz","integrity":"sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==","dev":true},"typical":{"version":"2.6.1","resolved":"https://registry.npmjs.org/typical/-/typical-2.6.1.tgz","integrity":"sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="},"ua-parser-js":{"version":"0.7.17","resolved":"https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz","integrity":"sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="},"uglify-js":{"version":"2.8.29","resolved":"https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz","integrity":"sha1-KcVzMUgFe7Th913zW3qcty5qWd0=","dev":true,"requires":{"source-map":"0.5.7","uglify-to-browserify":"1.0.2","yargs":"3.10.0"},"dependencies":{"camelcase":{"version":"1.2.1","resolved":"https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz","integrity":"sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=","dev":true},"cliui":{"version":"2.1.0","resolved":"https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz","integrity":"sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=","dev":true,"requires":{"center-align":"0.1.3","right-align":"0.1.3","wordwrap":"0.0.2"}},"source-map":{"version":"0.5.7","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz","integrity":"sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=","dev":true},"window-size":{"version":"0.1.0","resolved":"https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz","integrity":"sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=","dev":true},"wordwrap":{"version":"0.0.2","resolved":"https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz","integrity":"sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=","dev":true},"yargs":{"version":"3.10.0","resolved":"https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz","integrity":"sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=","dev":true,"requires":{"camelcase":"1.2.1","cliui":"2.1.0","decamelize":"1.2.0","window-size":"0.1.0"}}}},"uglify-to-browserify":{"version":"1.0.2","resolved":"https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz","integrity":"sha1-bgkk1r2mta/jSeOabWMoUKD4grc=","dev":true,"optional":true},"uglifyjs-webpack-plugin":{"version":"0.4.6","resolved":"https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz","integrity":"sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=","dev":true,"requires":{"source-map":"0.5.7","uglify-js":"2.8.29","webpack-sources":"1.0.1"},"dependencies":{"source-map":{"version":"0.5.7","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz","integrity":"sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=","dev":true}}},"uid-number":{"version":"0.0.6","resolved":"https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz","integrity":"sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="},"unbzip2-stream":{"version":"1.2.5","resolved":"https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz","integrity":"sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==","requires":{"buffer":"3.6.0","through":"2.3.8"}},"unidecode":{"version":"0.1.8","resolved":"https://registry.npmjs.org/unidecode/-/unidecode-0.1.8.tgz","integrity":"sha1-77swFTi8RSRqmsjFWdcvAVMFBT4=","dev":true},"union-value":{"version":"1.0.0","resolved":"https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz","integrity":"sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=","dev":true,"requires":{"arr-union":"3.1.0","get-value":"2.0.6","is-extendable":"0.1.1","set-value":"0.4.3"},"dependencies":{"set-value":{"version":"0.4.3","resolved":"https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz","integrity":"sha1-fbCPnT0i3H945Trzw79GZuzfzPE=","dev":true,"requires":{"extend-shallow":"2.0.1","is-extendable":"0.1.1","is-plain-object":"2.0.4","to-object-path":"0.3.0"}}}},"uniq":{"version":"1.0.1","resolved":"https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz","integrity":"sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=","dev":true},"uniqid":{"version":"4.1.1","resolved":"https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz","integrity":"sha1-iSIN32t1GuUrX3JISGNShZa7hME=","dev":true,"requires":{"macaddress":"0.2.8"}},"uniqs":{"version":"2.0.0","resolved":"https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz","integrity":"sha1-/+3ks2slKQaW5uFl1KWe25mOawI=","dev":true},"unique-string":{"version":"1.0.0","resolved":"https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz","integrity":"sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=","dev":true,"requires":{"crypto-random-string":"1.0.0"}},"universalify":{"version":"0.1.1","resolved":"https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz","integrity":"sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="},"unpipe":{"version":"1.0.0","resolved":"https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz","integrity":"sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=","dev":true},"unset-value":{"version":"1.0.0","resolved":"https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz","integrity":"sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=","dev":true,"requires":{"has-value":"0.3.1","isobject":"3.0.1"},"dependencies":{"has-value":{"version":"0.3.1","resolved":"https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz","integrity":"sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=","dev":true,"requires":{"get-value":"2.0.6","has-values":"0.1.4","isobject":"2.1.0"},"dependencies":{"isobject":{"version":"2.1.0","resolved":"https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz","integrity":"sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=","dev":true,"requires":{"isarray":"1.0.0"}}}},"has-values":{"version":"0.1.4","resolved":"https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz","integrity":"sha1-bWHeldkd/Km5oCCJrThL/49it3E=","dev":true}}},"unzip-response":{"version":"1.0.2","resolved":"https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz","integrity":"sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=","dev":true},"update-notifier":{"version":"2.3.0","resolved":"https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz","integrity":"sha1-TognpruRUUCrCTVZ1wFOPruDdFE=","dev":true,"requires":{"boxen":"1.2.2","chalk":"2.3.0","configstore":"3.1.1","import-lazy":"2.1.0","is-installed-globally":"0.1.0","is-npm":"1.0.0","latest-version":"3.1.0","semver-diff":"2.1.0","xdg-basedir":"3.0.0"},"dependencies":{"ansi-styles":{"version":"3.2.0","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz","integrity":"sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==","dev":true,"requires":{"color-convert":"1.9.0"}},"chalk":{"version":"2.3.0","resolved":"https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz","integrity":"sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==","dev":true,"requires":{"ansi-styles":"3.2.0","escape-string-regexp":"1.0.5","supports-color":"4.5.0"}},"has-flag":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz","integrity":"sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=","dev":true},"supports-color":{"version":"4.5.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz","integrity":"sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=","dev":true,"requires":{"has-flag":"2.0.0"}}}},"urijs":{"version":"1.19.0","resolved":"https://registry.npmjs.org/urijs/-/urijs-1.19.0.tgz","integrity":"sha512-Qs2odXn0hST5VSPVjpi73CMqtbAoanahaqWBujGU+IyMrMqpWcIhDewxQRhCkmqYxuyvICDcSuLdv2O7ncWBGw==","dev":true},"urix":{"version":"0.1.0","resolved":"https://registry.npmjs.org/urix/-/urix-0.1.0.tgz","integrity":"sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=","dev":true},"url":{"version":"0.10.3","resolved":"https://registry.npmjs.org/url/-/url-0.10.3.tgz","integrity":"sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=","dev":true,"requires":{"punycode":"1.3.2","querystring":"0.2.0"},"dependencies":{"punycode":{"version":"1.3.2","resolved":"https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz","integrity":"sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=","dev":true}}},"url-loader":{"version":"0.6.2","resolved":"https://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz","integrity":"sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==","dev":true,"requires":{"loader-utils":"1.1.0","mime":"1.4.1","schema-utils":"0.3.0"},"dependencies":{"mime":{"version":"1.4.1","resolved":"https://registry.npmjs.org/mime/-/mime-1.4.1.tgz","integrity":"sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==","dev":true}}},"url-parse":{"version":"1.1.9","resolved":"https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz","integrity":"sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=","requires":{"querystringify":"1.0.0","requires-port":"1.0.0"}},"url-parse-lax":{"version":"1.0.0","resolved":"https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz","integrity":"sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=","dev":true,"requires":{"prepend-http":"1.0.4"}},"url-slug":{"version":"2.0.0","resolved":"https://registry.npmjs.org/url-slug/-/url-slug-2.0.0.tgz","integrity":"sha1-p4nVrtSZXA2VrzM3etHVxo1NcCc=","dev":true,"requires":{"unidecode":"0.1.8"}},"ursa":{"version":"0.9.4","resolved":"https://registry.npmjs.org/ursa/-/ursa-0.9.4.tgz","integrity":"sha1-Ciq/t9xCZ/czsPjy/H8siV1ApBM=","dev":true,"requires":{"bindings":"1.3.0","nan":"2.7.0"}},"use":{"version":"2.0.2","resolved":"https://registry.npmjs.org/use/-/use-2.0.2.tgz","integrity":"sha1-riig1y+TvyJCKhii43mZMRLeyOg=","dev":true,"requires":{"define-property":"0.2.5","isobject":"3.0.1","lazy-cache":"2.0.2"},"dependencies":{"define-property":{"version":"0.2.5","resolved":"https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz","integrity":"sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=","dev":true,"requires":{"is-descriptor":"0.1.6"}},"is-descriptor":{"version":"0.1.6","resolved":"https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz","integrity":"sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==","dev":true,"requires":{"is-accessor-descriptor":"0.1.6","is-data-descriptor":"0.1.4","kind-of":"5.1.0"}},"kind-of":{"version":"5.1.0","resolved":"https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz","integrity":"sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==","dev":true}}},"user-home":{"version":"2.0.0","resolved":"https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz","integrity":"sha1-nHC/2Babwdy/SGBODwS4tJzenp8=","dev":true,"requires":{"os-homedir":"1.0.2"}},"utf8-byte-length":{"version":"1.0.4","resolved":"https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz","integrity":"sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=","dev":true},"util":{"version":"0.10.3","resolved":"https://registry.npmjs.org/util/-/util-0.10.3.tgz","integrity":"sha1-evsa/lCAUkZInj23/g7TeTNqwPk=","dev":true,"requires":{"inherits":"2.0.1"},"dependencies":{"inherits":{"version":"2.0.1","resolved":"https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz","integrity":"sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=","dev":true}}},"util-deprecate":{"version":"1.0.2","resolved":"https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz","integrity":"sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="},"utils-merge":{"version":"1.0.1","resolved":"https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz","integrity":"sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=","dev":true},"uuid":{"version":"3.1.0","resolved":"https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz","integrity":"sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="},"uws":{"version":"8.14.1","resolved":"https://registry.npmjs.org/uws/-/uws-8.14.1.tgz","integrity":"sha1-3glhnzBfYXTVUWqcaULLEgkEsgs=","dev":true},"validate-npm-package-license":{"version":"3.0.1","resolved":"https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz","integrity":"sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=","dev":true,"requires":{"spdx-correct":"1.0.2","spdx-expression-parse":"1.0.4"}},"validator":{"version":"7.0.0","resolved":"https://registry.npmjs.org/validator/-/validator-7.0.0.tgz","integrity":"sha1-x03rgGNRL6w1VHk45vCxUEooL9I=","dev":true},"vary":{"version":"1.1.2","resolved":"https://registry.npmjs.org/vary/-/vary-1.1.2.tgz","integrity":"sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=","dev":true},"vendors":{"version":"1.0.1","resolved":"https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz","integrity":"sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=","dev":true},"verror":{"version":"1.10.0","resolved":"https://registry.npmjs.org/verror/-/verror-1.10.0.tgz","integrity":"sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=","requires":{"assert-plus":"1.0.0","core-util-is":"1.0.2","extsprintf":"1.3.0"},"dependencies":{"assert-plus":{"version":"1.0.0","resolved":"https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz","integrity":"sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="}}},"vm-browserify":{"version":"0.0.4","resolved":"https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz","integrity":"sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=","dev":true,"requires":{"indexof":"0.0.1"}},"walkdir":{"version":"0.0.11","resolved":"https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz","integrity":"sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=","dev":true},"warning":{"version":"3.0.0","resolved":"https://registry.npmjs.org/warning/-/warning-3.0.0.tgz","integrity":"sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=","requires":{"loose-envify":"1.3.1"}},"watchpack":{"version":"1.4.0","resolved":"https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz","integrity":"sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=","dev":true,"requires":{"async":"2.5.0","chokidar":"1.7.0","graceful-fs":"4.1.11"},"dependencies":{"async":{"version":"2.5.0","resolved":"https://registry.npmjs.org/async/-/async-2.5.0.tgz","integrity":"sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==","dev":true,"requires":{"lodash":"4.17.4"}}}},"wbuf":{"version":"1.7.2","resolved":"https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz","integrity":"sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=","dev":true,"requires":{"minimalistic-assert":"1.0.0"}},"wdio-dot-reporter":{"version":"0.0.9","resolved":"https://registry.npmjs.org/wdio-dot-reporter/-/wdio-dot-reporter-0.0.9.tgz","integrity":"sha1-kpsq2v1J1rBTT9oGjocxm0fjj+U=","dev":true},"webdriverio":{"version":"4.8.0","resolved":"https://registry.npmjs.org/webdriverio/-/webdriverio-4.8.0.tgz","integrity":"sha1-1Skpt0kID4mWf24WFAUcvIFy0TI=","dev":true,"requires":{"archiver":"1.3.0","babel-runtime":"6.23.0","css-parse":"2.0.0","css-value":"0.0.1","deepmerge":"1.3.2","ejs":"2.5.7","gaze":"1.1.2","glob":"7.1.2","inquirer":"3.0.6","json-stringify-safe":"5.0.1","mkdirp":"0.5.1","npm-install-package":"2.1.0","optimist":"0.6.1","q":"1.5.1","request":"2.81.0","rgb2hex":"0.1.0","safe-buffer":"5.0.1","supports-color":"3.2.3","url":"0.11.0","validator":"7.0.0","wdio-dot-reporter":"0.0.9","wgxpath":"1.0.0"},"dependencies":{"ansi-styles":{"version":"2.2.1","resolved":"https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz","integrity":"sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=","dev":true},"babel-runtime":{"version":"6.23.0","resolved":"https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz","integrity":"sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=","dev":true,"requires":{"core-js":"2.5.1","regenerator-runtime":"0.10.5"}},"chalk":{"version":"1.1.3","resolved":"https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz","integrity":"sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=","dev":true,"requires":{"ansi-styles":"2.2.1","escape-string-regexp":"1.0.5","has-ansi":"2.0.0","strip-ansi":"3.0.1","supports-color":"2.0.0"},"dependencies":{"supports-color":{"version":"2.0.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz","integrity":"sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=","dev":true}}},"cli-cursor":{"version":"2.1.0","resolved":"https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz","integrity":"sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=","dev":true,"requires":{"restore-cursor":"2.0.0"}},"core-js":{"version":"2.5.1","resolved":"https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz","integrity":"sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=","dev":true},"figures":{"version":"2.0.0","resolved":"https://registry.npmjs.org/figures/-/figures-2.0.0.tgz","integrity":"sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=","dev":true,"requires":{"escape-string-regexp":"1.0.5"}},"has-ansi":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz","integrity":"sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=","dev":true,"requires":{"ansi-regex":"2.1.1"}},"inquirer":{"version":"3.0.6","resolved":"https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz","integrity":"sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=","dev":true,"requires":{"ansi-escapes":"1.4.0","chalk":"1.1.3","cli-cursor":"2.1.0","cli-width":"2.2.0","external-editor":"2.0.5","figures":"2.0.0","lodash":"4.17.4","mute-stream":"0.0.7","run-async":"2.3.0","rx":"4.1.0","string-width":"2.1.1","strip-ansi":"3.0.1","through":"2.3.8"}},"is-fullwidth-code-point":{"version":"2.0.0","resolved":"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz","integrity":"sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=","dev":true},"onetime":{"version":"2.0.1","resolved":"https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz","integrity":"sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=","dev":true,"requires":{"mimic-fn":"1.1.0"}},"punycode":{"version":"1.3.2","resolved":"https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz","integrity":"sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=","dev":true},"regenerator-runtime":{"version":"0.10.5","resolved":"https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz","integrity":"sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=","dev":true},"request":{"version":"2.81.0","resolved":"https://registry.npmjs.org/request/-/request-2.81.0.tgz","integrity":"sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=","dev":true,"requires":{"aws-sign2":"0.6.0","aws4":"1.6.0","caseless":"0.12.0","combined-stream":"1.0.5","extend":"3.0.1","forever-agent":"0.6.1","form-data":"2.1.4","har-validator":"4.2.1","hawk":"3.1.3","http-signature":"1.1.1","is-typedarray":"1.0.0","isstream":"0.1.2","json-stringify-safe":"5.0.1","mime-types":"2.1.17","oauth-sign":"0.8.2","performance-now":"0.2.0","qs":"6.4.0","safe-buffer":"5.0.1","stringstream":"0.0.5","tough-cookie":"2.3.3","tunnel-agent":"0.6.0","uuid":"3.1.0"}},"restore-cursor":{"version":"2.0.0","resolved":"https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz","integrity":"sha1-n37ih/gv0ybU/RYpI9YhKe7g368=","dev":true,"requires":{"onetime":"2.0.1","signal-exit":"3.0.2"}},"run-async":{"version":"2.3.0","resolved":"https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz","integrity":"sha1-A3GrSuC91yDUFm19/aZP96RFpsA=","dev":true,"requires":{"is-promise":"2.1.0"}},"rx":{"version":"4.1.0","resolved":"https://registry.npmjs.org/rx/-/rx-4.1.0.tgz","integrity":"sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=","dev":true},"safe-buffer":{"version":"5.0.1","resolved":"https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz","integrity":"sha1-0mPKVGls2KMGtcplUekt5XkY++c=","dev":true},"string-width":{"version":"2.1.1","resolved":"https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz","integrity":"sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==","dev":true,"requires":{"is-fullwidth-code-point":"2.0.0","strip-ansi":"4.0.0"},"dependencies":{"ansi-regex":{"version":"3.0.0","resolved":"https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz","integrity":"sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=","dev":true},"strip-ansi":{"version":"4.0.0","resolved":"https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz","integrity":"sha1-qEeQIusaw2iocTibY1JixQXuNo8=","dev":true,"requires":{"ansi-regex":"3.0.0"}}}},"url":{"version":"0.11.0","resolved":"https://registry.npmjs.org/url/-/url-0.11.0.tgz","integrity":"sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=","dev":true,"requires":{"punycode":"1.3.2","querystring":"0.2.0"}}}},"webidl-conversions":{"version":"4.0.2","resolved":"https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz","integrity":"sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==","dev":true},"webpack":{"version":"3.8.1","resolved":"https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz","integrity":"sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==","dev":true,"requires":{"acorn":"5.1.2","acorn-dynamic-import":"2.0.2","ajv":"5.3.0","ajv-keywords":"2.1.0","async":"2.5.0","enhanced-resolve":"3.4.1","escope":"3.6.0","interpret":"1.0.4","json-loader":"0.5.7","json5":"0.5.1","loader-runner":"2.3.0","loader-utils":"1.1.0","memory-fs":"0.4.1","mkdirp":"0.5.1","node-libs-browser":"2.0.0","source-map":"0.5.7","supports-color":"4.5.0","tapable":"0.2.8","uglifyjs-webpack-plugin":"0.4.6","watchpack":"1.4.0","webpack-sources":"1.0.1","yargs":"8.0.2"},"dependencies":{"ajv":{"version":"5.3.0","resolved":"https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz","integrity":"sha1-RBT/dKUIecII7l/cgm4ywwNUnto=","dev":true,"requires":{"co":"4.6.0","fast-deep-equal":"1.0.0","fast-json-stable-stringify":"2.0.0","json-schema-traverse":"0.3.1"}},"ansi-regex":{"version":"3.0.0","resolved":"https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz","integrity":"sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=","dev":true},"async":{"version":"2.5.0","resolved":"https://registry.npmjs.org/async/-/async-2.5.0.tgz","integrity":"sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==","dev":true,"requires":{"lodash":"4.17.4"}},"camelcase":{"version":"4.1.0","resolved":"https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz","integrity":"sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=","dev":true},"enhanced-resolve":{"version":"3.4.1","resolved":"https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz","integrity":"sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=","dev":true,"requires":{"graceful-fs":"4.1.11","memory-fs":"0.4.1","object-assign":"4.1.1","tapable":"0.2.8"}},"find-up":{"version":"2.1.0","resolved":"https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz","integrity":"sha1-RdG35QbHF93UgndaK3eSCjwMV6c=","dev":true,"requires":{"locate-path":"2.0.0"}},"has-flag":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz","integrity":"sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=","dev":true},"is-fullwidth-code-point":{"version":"2.0.0","resolved":"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz","integrity":"sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=","dev":true},"load-json-file":{"version":"2.0.0","resolved":"https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz","integrity":"sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=","dev":true,"requires":{"graceful-fs":"4.1.11","parse-json":"2.2.0","pify":"2.3.0","strip-bom":"3.0.0"}},"path-type":{"version":"2.0.0","resolved":"https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz","integrity":"sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=","dev":true,"requires":{"pify":"2.3.0"}},"read-pkg":{"version":"2.0.0","resolved":"https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz","integrity":"sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=","dev":true,"requires":{"load-json-file":"2.0.0","normalize-package-data":"2.4.0","path-type":"2.0.0"}},"read-pkg-up":{"version":"2.0.0","resolved":"https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz","integrity":"sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=","dev":true,"requires":{"find-up":"2.1.0","read-pkg":"2.0.0"}},"source-map":{"version":"0.5.7","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz","integrity":"sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=","dev":true},"string-width":{"version":"2.1.1","resolved":"https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz","integrity":"sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==","dev":true,"requires":{"is-fullwidth-code-point":"2.0.0","strip-ansi":"4.0.0"}},"strip-ansi":{"version":"4.0.0","resolved":"https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz","integrity":"sha1-qEeQIusaw2iocTibY1JixQXuNo8=","dev":true,"requires":{"ansi-regex":"3.0.0"}},"strip-bom":{"version":"3.0.0","resolved":"https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz","integrity":"sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=","dev":true},"supports-color":{"version":"4.5.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz","integrity":"sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=","dev":true,"requires":{"has-flag":"2.0.0"}},"yargs":{"version":"8.0.2","resolved":"https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz","integrity":"sha1-YpmpBVsc78lp/355wdkY3Osiw2A=","dev":true,"requires":{"camelcase":"4.1.0","cliui":"3.2.0","decamelize":"1.2.0","get-caller-file":"1.0.2","os-locale":"2.1.0","read-pkg-up":"2.0.0","require-directory":"2.1.1","require-main-filename":"1.0.1","set-blocking":"2.0.0","string-width":"2.1.1","which-module":"2.0.0","y18n":"3.2.1","yargs-parser":"7.0.0"}},"yargs-parser":{"version":"7.0.0","resolved":"https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz","integrity":"sha1-jQrELxbqVd69MyyvTEA4s+P139k=","dev":true,"requires":{"camelcase":"4.1.0"}}}},"webpack-dev-middleware":{"version":"1.12.0","resolved":"https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz","integrity":"sha1-007++y7dp+HTtdvgcolRMhllFwk=","dev":true,"requires":{"memory-fs":"0.4.1","mime":"1.4.1","path-is-absolute":"1.0.1","range-parser":"1.2.0","time-stamp":"2.0.0"},"dependencies":{"mime":{"version":"1.4.1","resolved":"https://registry.npmjs.org/mime/-/mime-1.4.1.tgz","integrity":"sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==","dev":true}}},"webpack-dev-server":{"version":"2.9.3","resolved":"https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.3.tgz","integrity":"sha512-bwq7sj452FRH+oVfgOA8xXKkLYPTNsYB4dQ0Jhz3ydjNJ9MvhpGJtehFW8Z0cEcwNkRRiF4aYbReiSGQ4pbS1w==","dev":true,"requires":{"ansi-html":"0.0.7","array-includes":"3.0.3","bonjour":"3.5.0","chokidar":"1.7.0","compression":"1.7.1","connect-history-api-fallback":"1.4.0","debug":"3.1.0","del":"3.0.0","express":"4.16.2","html-entities":"1.2.1","http-proxy-middleware":"0.17.4","import-local":"0.1.1","internal-ip":"1.2.0","ip":"1.1.5","loglevel":"1.5.1","opn":"5.1.0","portfinder":"1.0.13","selfsigned":"1.10.1","serve-index":"1.9.1","sockjs":"0.3.18","sockjs-client":"1.1.4","spdy":"3.4.7","strip-ansi":"3.0.1","supports-color":"4.5.0","webpack-dev-middleware":"1.12.0","yargs":"6.6.0"},"dependencies":{"camelcase":{"version":"3.0.0","resolved":"https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz","integrity":"sha1-MvxLn82vhF/N9+c7uXysImHwqwo=","dev":true},"del":{"version":"3.0.0","resolved":"https://registry.npmjs.org/del/-/del-3.0.0.tgz","integrity":"sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=","dev":true,"requires":{"globby":"6.1.0","is-path-cwd":"1.0.0","is-path-in-cwd":"1.0.0","p-map":"1.2.0","pify":"3.0.0","rimraf":"2.6.2"}},"has-flag":{"version":"2.0.0","resolved":"https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz","integrity":"sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=","dev":true},"os-locale":{"version":"1.4.0","resolved":"https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz","integrity":"sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=","dev":true,"requires":{"lcid":"1.0.0"}},"pify":{"version":"3.0.0","resolved":"https://registry.npmjs.org/pify/-/pify-3.0.0.tgz","integrity":"sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=","dev":true},"supports-color":{"version":"4.5.0","resolved":"https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz","integrity":"sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=","dev":true,"requires":{"has-flag":"2.0.0"}},"which-module":{"version":"1.0.0","resolved":"https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz","integrity":"sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=","dev":true},"yargs":{"version":"6.6.0","resolved":"https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz","integrity":"sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=","dev":true,"requires":{"camelcase":"3.0.0","cliui":"3.2.0","decamelize":"1.2.0","get-caller-file":"1.0.2","os-locale":"1.4.0","read-pkg-up":"1.0.1","require-directory":"2.1.1","require-main-filename":"1.0.1","set-blocking":"2.0.0","string-width":"1.0.2","which-module":"1.0.0","y18n":"3.2.1","yargs-parser":"4.2.1"}},"yargs-parser":{"version":"4.2.1","resolved":"https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz","integrity":"sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=","dev":true,"requires":{"camelcase":"3.0.0"}}}},"webpack-node-externals":{"version":"1.6.0","resolved":"https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.6.0.tgz","integrity":"sha1-Iyxi7GCSsQBjWj0p2DwXRxKN+b0=","dev":true},"webpack-sources":{"version":"1.0.1","resolved":"https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz","integrity":"sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==","dev":true,"requires":{"source-list-map":"2.0.0","source-map":"0.5.7"},"dependencies":{"source-map":{"version":"0.5.7","resolved":"https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz","integrity":"sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=","dev":true}}},"webpack-visualizer-plugin":{"version":"0.1.11","resolved":"https://registry.npmjs.org/webpack-visualizer-plugin/-/webpack-visualizer-plugin-0.1.11.tgz","integrity":"sha1-uHcK2GtPZSYSxosbeCJT+vn4o04=","dev":true,"requires":{"d3":"3.5.17","mkdirp":"0.5.1","react":"0.14.9","react-dom":"0.14.9"},"dependencies":{"fbjs":{"version":"0.6.1","resolved":"https://registry.npmjs.org/fbjs/-/fbjs-0.6.1.tgz","integrity":"sha1-lja3cF9bqWhNRLcveDISVK/IYPc=","dev":true,"requires":{"core-js":"1.2.7","loose-envify":"1.3.1","promise":"7.3.1","ua-parser-js":"0.7.17","whatwg-fetch":"0.9.0"}},"react":{"version":"0.14.9","resolved":"https://registry.npmjs.org/react/-/react-0.14.9.tgz","integrity":"sha1-kRCmSXxJ1EuhwO3TF67CnC4NkdE=","dev":true,"requires":{"envify":"3.4.1","fbjs":"0.6.1"}},"react-dom":{"version":"0.14.9","resolved":"https://registry.npmjs.org/react-dom/-/react-dom-0.14.9.tgz","integrity":"sha1-BQZKPc8PsYgKOyv8nVjFXY2fYpM=","dev":true},"whatwg-fetch":{"version":"0.9.0","resolved":"https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz","integrity":"sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA=","dev":true}}},"websocket-driver":{"version":"0.7.0","resolved":"https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz","integrity":"sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=","dev":true,"requires":{"http-parser-js":"0.4.9","websocket-extensions":"0.1.2"}},"websocket-extensions":{"version":"0.1.2","resolved":"https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz","integrity":"sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0=","dev":true},"wgxpath":{"version":"1.0.0","resolved":"https://registry.npmjs.org/wgxpath/-/wgxpath-1.0.0.tgz","integrity":"sha1-7vikudVYzEla06mit1FZfs2a9pA=","dev":true},"whatwg-encoding":{"version":"1.0.2","resolved":"https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.2.tgz","integrity":"sha512-9WQ+6BvuD7A1vaGMqMjyR5zhHnR/VXKrs2WHobV/YCfeKXKEk0SJbgwg4kjdpRRrenEQbYwZ/P9vQAVUEVAzUg==","dev":true,"requires":{"iconv-lite":"0.4.13"},"dependencies":{"iconv-lite":{"version":"0.4.13","resolved":"https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz","integrity":"sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=","dev":true}}},"whatwg-fetch":{"version":"2.0.3","resolved":"https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz","integrity":"sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="},"whatwg-url":{"version":"6.3.0","resolved":"https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.3.0.tgz","integrity":"sha512-rM+hE5iYKGPAOu05mIdJR47pYSR2vDzfrTEFRc/S8D3L60yW8BuXmUJ7Kog7x/DrokFN7JNaHKadpzjouKRRAw==","dev":true,"requires":{"lodash.sortby":"4.7.0","tr46":"1.0.1","webidl-conversions":"4.0.2"}},"whet.extend":{"version":"0.9.9","resolved":"https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz","integrity":"sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=","dev":true},"which":{"version":"1.3.0","resolved":"https://registry.npmjs.org/which/-/which-1.3.0.tgz","integrity":"sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==","dev":true,"requires":{"isexe":"2.0.0"}},"which-module":{"version":"2.0.0","resolved":"https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz","integrity":"sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=","dev":true},"wide-align":{"version":"1.1.2","resolved":"https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz","integrity":"sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==","requires":{"string-width":"1.0.2"}},"widest-line":{"version":"1.0.0","resolved":"https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz","integrity":"sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=","dev":true,"requires":{"string-width":"1.0.2"}},"window-size":{"version":"0.2.0","resolved":"https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz","integrity":"sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=","dev":true},"winston":{"version":"2.4.0","resolved":"https://registry.npmjs.org/winston/-/winston-2.4.0.tgz","integrity":"sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=","dev":true,"requires":{"async":"1.0.0","colors":"1.0.3","cycle":"1.0.3","eyes":"0.1.8","isstream":"0.1.2","stack-trace":"0.0.10"},"dependencies":{"colors":{"version":"1.0.3","resolved":"https://registry.npmjs.org/colors/-/colors-1.0.3.tgz","integrity":"sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=","dev":true}}},"wordwrap":{"version":"1.0.0","resolved":"https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz","integrity":"sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=","dev":true},"wrap-ansi":{"version":"2.1.0","resolved":"https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz","integrity":"sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=","dev":true,"requires":{"string-width":"1.0.2","strip-ansi":"3.0.1"}},"wrappy":{"version":"1.0.2","resolved":"https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz","integrity":"sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="},"write":{"version":"0.2.1","resolved":"https://registry.npmjs.org/write/-/write-0.2.1.tgz","integrity":"sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=","dev":true,"requires":{"mkdirp":"0.5.1"}},"write-file-atomic":{"version":"2.3.0","resolved":"https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz","integrity":"sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==","dev":true,"requires":{"graceful-fs":"4.1.11","imurmurhash":"0.1.4","signal-exit":"3.0.2"}},"xdg-basedir":{"version":"3.0.0","resolved":"https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz","integrity":"sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=","dev":true},"xml":{"version":"1.0.1","resolved":"https://registry.npmjs.org/xml/-/xml-1.0.1.tgz","integrity":"sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=","dev":true},"xml-name-validator":{"version":"2.0.1","resolved":"https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz","integrity":"sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=","dev":true},"xml2js":{"version":"0.4.17","resolved":"https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz","integrity":"sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=","dev":true,"requires":{"sax":"1.2.4","xmlbuilder":"4.2.1"},"dependencies":{"xmlbuilder":{"version":"4.2.1","resolved":"https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz","integrity":"sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=","dev":true,"requires":{"lodash":"4.17.4"}}}},"xmlbuilder":{"version":"8.2.2","resolved":"https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz","integrity":"sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=","dev":true},"xmldom":{"version":"0.1.27","resolved":"https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz","integrity":"sha1-1QH5ezvbQDr4757MIFcxh6rawOk=","dev":true},"xtend":{"version":"4.0.1","resolved":"https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz","integrity":"sha1-pcbVMr5lbiPbgg77lDofBJmNY68="},"xvfb-maybe":{"version":"0.2.1","resolved":"https://registry.npmjs.org/xvfb-maybe/-/xvfb-maybe-0.2.1.tgz","integrity":"sha1-7YyxMpV7eEi0OZhMZvAQ6n8kNhs=","dev":true,"requires":{"debug":"2.6.9","which":"1.3.0"},"dependencies":{"debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","integrity":"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==","dev":true,"requires":{"ms":"2.0.0"}}}},"y18n":{"version":"3.2.1","resolved":"https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz","integrity":"sha1-bRX7qITAhnnA136I53WegR4H+kE=","dev":true},"yallist":{"version":"2.1.2","resolved":"https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz","integrity":"sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=","dev":true},"yargs":{"version":"10.0.3","resolved":"https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz","integrity":"sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==","dev":true,"requires":{"cliui":"3.2.0","decamelize":"1.2.0","find-up":"2.1.0","get-caller-file":"1.0.2","os-locale":"2.1.0","require-directory":"2.1.1","require-main-filename":"1.0.1","set-blocking":"2.0.0","string-width":"2.1.1","which-module":"2.0.0","y18n":"3.2.1","yargs-parser":"8.0.0"},"dependencies":{"ansi-regex":{"version":"3.0.0","resolved":"https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz","integrity":"sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=","dev":true},"find-up":{"version":"2.1.0","resolved":"https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz","integrity":"sha1-RdG35QbHF93UgndaK3eSCjwMV6c=","dev":true,"requires":{"locate-path":"2.0.0"}},"is-fullwidth-code-point":{"version":"2.0.0","resolved":"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz","integrity":"sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=","dev":true},"string-width":{"version":"2.1.1","resolved":"https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz","integrity":"sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==","dev":true,"requires":{"is-fullwidth-code-point":"2.0.0","strip-ansi":"4.0.0"}},"strip-ansi":{"version":"4.0.0","resolved":"https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz","integrity":"sha1-qEeQIusaw2iocTibY1JixQXuNo8=","dev":true,"requires":{"ansi-regex":"3.0.0"}}}},"yargs-parser":{"version":"8.0.0","resolved":"https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz","integrity":"sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=","dev":true,"requires":{"camelcase":"4.1.0"},"dependencies":{"camelcase":{"version":"4.1.0","resolved":"https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz","integrity":"sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=","dev":true}}},"yauzl":{"version":"2.8.0","resolved":"https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz","integrity":"sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=","requires":{"buffer-crc32":"0.2.13","fd-slicer":"1.0.1"}},"zip-stream":{"version":"1.2.0","resolved":"https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz","integrity":"sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=","dev":true,"requires":{"archiver-utils":"1.3.0","compress-commons":"1.2.2","lodash":"4.17.4","readable-stream":"2.3.3"}}}}
+{
+  "name": "realm-studio",
+  "version": "1.2.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/bcrypt": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-1.0.0.tgz",
+      "integrity": "sha1-LFI9oZHbfUHAbRfeI1M1yYXv/ps=",
+      "dev": true
+    },
+    "@types/body-parser": {
+      "version": "1.16.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.16.6.tgz",
+      "integrity": "sha512-B7sY963pBsP46QG/yTX8ei2R8zIUDQUOhPZjTBWBGQXcBMLGFKHc0R8DWkAmouGmval5sDSuQA3AB2C9VmHw6A==",
+      "dev": true,
+      "requires": {
+        "@types/express": "4.0.37",
+        "@types/node": "8.0.47"
+      }
+    },
+    "@types/classnames": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.3.tgz",
+      "integrity": "sha512-x15/Io+JdzrkM9gnX6SWUs/EmqQzd65TD9tcZIAQ1VIdb93XErNuYmB7Yho8JUCE189ipUSESsWvGvYXRRIvYA==",
+      "dev": true
+    },
+    "@types/colors": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/colors/-/colors-1.1.3.tgz",
+      "integrity": "sha1-VBOwp6GxbdGL4OP9V9L+7Mgcx3Y=",
+      "dev": true
+    },
+    "@types/commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-G4+ewSX5/TPqpUjltkuyJ4QhX8oTy94WEyJMvC+R8cg/qKGjq+/n+b/TRVe/+/278jV9Iot5dS186r7NCcUrtg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.47"
+      }
+    },
+    "@types/del": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/del/-/del-3.0.0.tgz",
+      "integrity": "sha512-18mSs54BvzV8+TTQxt0ancig6tsuPZySnhp3cQkWFFDmDMavU4pmWwR+bHHqRBWODYqpzIzVkqKLuk/fP6yypQ==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "5.0.33"
+      }
+    },
+    "@types/express": {
+      "version": "4.0.37",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.37.tgz",
+      "integrity": "sha512-tIULTLzQpFFs5/PKnFIAFOsXQxss76glppbVKR3/jddPK26SBsD5HF5grn5G2jOGtpRWSBvYmDYoduVv+3wOXg==",
+      "dev": true,
+      "requires": {
+        "@types/express-serve-static-core": "4.0.54",
+        "@types/serve-static": "1.7.32"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.0.54",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.54.tgz",
+      "integrity": "sha512-SAwkKnz0z3VcUyT3eiZRM2pDiZ4i2xhOXHTZHdoXu6UCC1o33lnzJMftXCYTRmLvFOUxryov8c9E0JLlY2ylNw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.47"
+      }
+    },
+    "@types/faker": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/faker/-/faker-4.1.1.tgz",
+      "integrity": "sha512-nMUlSvB+lg0DZ+J5kov54+ZogzZO+IeNqvbxQBlTvvSo34D/p0ezIb/rus1SEQY8dgzudsP/KLmjB2adz10/GA==",
+      "dev": true
+    },
+    "@types/fs-extra": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.3.tgz",
+      "integrity": "sha512-cUE7dc4RJsRPCk8mbrgMAaglugcJbf1Oxp7DYi/aOj4+ggCxzddDQFZwCKWnqrLv4LJ89apyNJ7Y3pN79tAPVg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.47"
+      }
+    },
+    "@types/glob": {
+      "version": "5.0.33",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
+      "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "3.0.1",
+        "@types/node": "8.0.47"
+      }
+    },
+    "@types/http-proxy": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.12.2.tgz",
+      "integrity": "sha512-CRr4ha0rE8wHIYweCovPB9zAeVDoZkiTFTyuvksveNPf5mF3ANZiWEuDSCdEedSNvKrVHZrCJKZ1kM1bSn5mbA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.47"
+      }
+    },
+    "@types/jquery": {
+      "version": "3.2.15",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.2.15.tgz",
+      "integrity": "sha512-SmiwGv/ISoltkDMngZ8sb9ijj6mYx3084XkHul/U4r03N2C14j6F+Lx+RfZ/f5zGOVOKEUIrRLVCNFKEaVDABQ==",
+      "dev": true
+    },
+    "@types/jsdom": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-11.0.2.tgz",
+      "integrity": "sha512-jteTb2GhpeBc284FcpDbngQ4IQizu0Z/AQT9zyk2beSiqSvC0mxtX+SnQZj7gULgWcjLswUdlW/LfMqx0GhyNg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.47",
+        "@types/tough-cookie": "2.3.2",
+        "parse5": "3.0.2"
+      }
+    },
+    "@types/jsonwebtoken": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.3.tgz",
+      "integrity": "sha512-cVhxZfVCyTZd1P+2a+xXSR9to7hZTulNRLLCQMVfAevUqx2Ee+EgsiD/7pX8qvdXWP3nWgSoTjKRLMrIpdPVjQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.47"
+      }
+    },
+    "@types/lodash": {
+      "version": "4.14.79",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.79.tgz",
+      "integrity": "sha512-EE1cINVUc0T6Wdy6qdx/P+NHCSzZAUIijlc/h4KXC+fy1Q2s/CruftBHaJSCJ7g5VRBIuO53IUaSWupDivfhJw==",
+      "dev": true
+    },
+    "@types/mime": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
+      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
+      "integrity": "sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==",
+      "dev": true
+    },
+    "@types/mixpanel": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@types/mixpanel/-/mixpanel-2.13.0.tgz",
+      "integrity": "sha512-3Oz29yXvzJlOG7PqJMHEzwoIDWZNfC+wrYOOWyP7N5qNLBhEgY2SBoWWs/bDVS2QTGb1fSYRHsVSlWdIn0xDQQ==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "2.2.43",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.43.tgz",
+      "integrity": "sha512-xNlAmH+lRJdUMXClMTI9Y0pRqIojdxfm7DHsIxoB2iTzu3fnPmSMEN8SsSx0cdwV36d02PWCWaDUoZPDSln+xw==",
+      "dev": true
+    },
+    "@types/morgan": {
+      "version": "1.7.34",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.7.34.tgz",
+      "integrity": "sha512-CIwxrnVFH4y2WDfo54SNCd5Zy9zofmkoqgTy1xgvolTx65b/bP4IF9rJVd/CmNc43UdtAJnHOJg3W0fLMGW5+g==",
+      "dev": true,
+      "requires": {
+        "@types/express": "4.0.37"
+      }
+    },
+    "@types/node": {
+      "version": "8.0.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.47.tgz",
+      "integrity": "sha512-kOwL746WVvt/9Phf6/JgX/bsGQvbrK5iUgzyfwZNcKVFcjAUVSpF9HxevLTld2SG9aywYHOILj38arDdY1r/iQ==",
+      "dev": true
+    },
+    "@types/promptly": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@types/promptly/-/promptly-1.1.28.tgz",
+      "integrity": "sha1-kBTi8SrN6kHiEAmvTjn+exH+yNE=",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.47"
+      }
+    },
+    "@types/prop-types": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.2.tgz",
+      "integrity": "sha512-pQRkAVoxiuUrLq8+CDwiQX4pTCep/PmmNgBbjIwnnsd/HoYjGpR81+FFPE030lvNXgR0haaAU6eoRtztWDE4Xw==",
+      "dev": true
+    },
+    "@types/proxyquire": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@types/proxyquire/-/proxyquire-1.3.28.tgz",
+      "integrity": "sha512-SQaNzWQ2YZSr7FqAyPPiA3FYpux2Lqh3HWMZQk47x3xbMCqgC/w0dY3dw9rGqlweDDkrySQBcaScXWeR+Yb11Q==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "15.6.5",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-15.6.5.tgz",
+      "integrity": "sha512-42p/IwYtCU0CMBKZ2MRdBfRbt3f6MO9aqIhxZ6EzHOiG6fMVY+g/pM7uHTsDmoRc0blYMZdki8XPMcOG4ob2Ng==",
+      "dev": true
+    },
+    "@types/react-dom": {
+      "version": "15.5.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-15.5.6.tgz",
+      "integrity": "sha512-dP4vEDEH4rL+uUl6f//c6mjepTVdJ6Ldx3z0dZbw047T5Z+o2PZDW/Qd+I4PkTmIgk7YNAZC/TFnm3IHT5UAhw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "15.6.5"
+      }
+    },
+    "@types/react-sortable-hoc": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/react-sortable-hoc/-/react-sortable-hoc-0.6.0.tgz",
+      "integrity": "sha512-qOWavACyVKEASlqAy0qAvszIOz5GIDW5cdAcMaTl9rge30JHIvynTnOQJFzl+HmxPiEmTuz4gipiNoBjbnP3kQ==",
+      "dev": true,
+      "requires": {
+        "@types/react": "15.6.5"
+      }
+    },
+    "@types/react-virtualized": {
+      "version": "9.7.6",
+      "resolved": "https://registry.npmjs.org/@types/react-virtualized/-/react-virtualized-9.7.6.tgz",
+      "integrity": "sha512-6GCKDWHzFHTRExQ+4zIS1bCxOcFfmwBhoBeAl8ENqstOf1/mnx8tmx9PiqL5qnGEhq3AvsZz2gFzFVX5yqp2ig==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "15.5.2",
+        "@types/react": "15.6.5"
+      }
+    },
+    "@types/reactstrap": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/@types/reactstrap/-/reactstrap-4.6.4.tgz",
+      "integrity": "sha512-0EV4Mb+j/z5XdlzVAz2rB0KuDwj6sNv3d/JtELtxmLkMyUwZXH2XMal2Ic7f5y0+SBc5qf650WdXT/zFlsCFTw==",
+      "dev": true,
+      "requires": {
+        "@types/tether": "1.4.3"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.7.32",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.7.32.tgz",
+      "integrity": "sha512-WpI0g7M1FiOmJ/a97Qrjafq2I938tjAZ3hZr9O7sXyA6oUhH3bqUNZIt7r1KZg8TQAKxcvxt6JjQ5XuLfIBFvg==",
+      "dev": true,
+      "requires": {
+        "@types/express-serve-static-core": "4.0.54",
+        "@types/mime": "2.0.0"
+      }
+    },
+    "@types/source-map": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.1.tgz",
+      "integrity": "sha512-/GVAjL1Y8puvZab63n8tsuBiYwZt1bApMdx58/msQ9ID5T05ov+wm/ZV1DvYC/DKKEygpTJViqQvkh5Rhrl4CA==",
+      "dev": true
+    },
+    "@types/source-map-support": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.4.0.tgz",
+      "integrity": "sha512-9oVAi1Jlr274pbMGPEe0S3IPImV9knVNafa6E4MookD/fjOZAE6EmLkFX5ZjtZ9OXNPi2FCIZzUSMvwAUUKeSg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.47"
+      }
+    },
+    "@types/superagent": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-3.5.6.tgz",
+      "integrity": "sha512-yGiVkRbB1qtIkRCpEJIxlHazBoILmu33xbbu4IiwxTJjwDi/EudiPYAD7QwWe035jkE40yQgTVXZsAePFtleww==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.47"
+      }
+    },
+    "@types/tapable": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-0.2.4.tgz",
+      "integrity": "sha512-pclMAvhPnXJcJu1ZZ8bQthuUcdDWzDuxDdbSf6l1U6s4fP6EBiZpPsOZYqFOrbqDV97sXGFSsb6AUpiLfv4xIA==",
+      "dev": true
+    },
+    "@types/tether": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/tether/-/tether-1.4.3.tgz",
+      "integrity": "sha512-q92yZeRwHuLL6s+HF5PAmrR0K0pFTQ3hT1ppM0ZRyj9XLziKR/qyhQcOitVO0UliClC02uQsAm4zBj08b6Pu/Q==",
+      "dev": true
+    },
+    "@types/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=",
+      "dev": true
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "integrity": "sha512-vOVmaruQG5EatOU/jM6yU2uCp3Lz6mK1P5Ztu4iJjfM4SVHU9XYktPUQtKlIXuahqXHdEyUarMrBEwg5Cwu+bA==",
+      "dev": true
+    },
+    "@types/uglify-js": {
+      "version": "2.6.29",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-2.6.29.tgz",
+      "integrity": "sha512-BdFLCZW0GTl31AbqXSak8ss/MqEZ3DN2MH9rkAyGoTuzK7ifGUlX+u0nfbWeTsa7IPcZhtn8BlpYBXSV+vqGhQ==",
+      "dev": true,
+      "requires": {
+        "@types/source-map": "0.5.1"
+      }
+    },
+    "@types/urijs": {
+      "version": "1.15.34",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.15.34.tgz",
+      "integrity": "sha512-hhYTPl+5vDeyrMM0WXwS5GVYq/OoKPhXfIoZskSP48aiYjjWQTGJOgoaJczXKlawp70xZYpLU/8B31YqQRLG9g==",
+      "dev": true,
+      "requires": {
+        "@types/jquery": "3.2.15"
+      }
+    },
+    "@types/uuid": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
+      "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.47"
+      }
+    },
+    "@types/uws": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@types/uws/-/uws-0.13.0.tgz",
+      "integrity": "sha1-ZX7+Z6405BfZA86BOobsCc1oy+4=",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.47"
+      }
+    },
+    "@types/webdriverio": {
+      "version": "4.8.6",
+      "resolved": "https://registry.npmjs.org/@types/webdriverio/-/webdriverio-4.8.6.tgz",
+      "integrity": "sha512-y8zENitnHZQzRnEkAm82wrKbRT0WD3/65IREeGhfjVkvOqYji6DNwy9OvbcSPhfklij8x8TUUshr8nn6/RiZ+g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.47"
+      }
+    },
+    "@types/webpack": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-3.0.13.tgz",
+      "integrity": "sha512-gWVIAVaGapOPHOrjUQalUqdJWdUIn8w5gpKzz2L14megpB1euvq4HxvGusp9nhtkYGjD/sIg20Zse42b7+7BDw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.47",
+        "@types/tapable": "0.2.4",
+        "@types/uglify-js": "2.6.29"
+      }
+    },
+    "@types/webpack-env": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.2.tgz",
+      "integrity": "sha512-pjbzi3A1Y4iLpNdNZNG4loIZKtYOnpCQY82bnsHi9lQXl4f3ul0TDsd1fUd10jbgCXR5bwaP4Ffy1BDLuEZpaQ==",
+      "dev": true
+    },
+    "7zip-bin": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-2.2.7.tgz",
+      "integrity": "sha512-+rr4OgeTNrLuJAf09o3USdttEYiXvZshWMkhD6wR9v1ieXH0JM1Q2yT41/cJuJcqiPpSXlM/g3aR+Y5MWQdr0Q==",
+      "dev": true,
+      "requires": {
+        "7zip-bin-mac": "1.0.1"
+      }
+    },
+    "7zip-bin-mac": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/7zip-bin-mac/-/7zip-bin-mac-1.0.1.tgz",
+      "integrity": "sha1-Pmh3i78JJq3GgVlCcHRQXUdVXAI=",
+      "dev": true,
+      "optional": true
+    },
+    "abab": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+      "dev": true
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "accepts": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+      "dev": true,
+      "requires": {
+        "mime-types": "2.1.17",
+        "negotiator": "0.6.1"
+      }
+    },
+    "accessibility-developer-tools": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
+      "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
+      "dev": true
+    },
+    "acorn": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+      "dev": true
+    },
+    "acorn-dynamic-import": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+      "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+      "dev": true,
+      "requires": {
+        "acorn": "4.0.13"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "dev": true
+        }
+      }
+    },
+    "acorn-globals": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.2"
+      }
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "adjust-sourcemap-loader": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-1.1.0.tgz",
+      "integrity": "sha1-QS2SQE62HkETY1ASy6U6M9AI4OI=",
+      "dev": true,
+      "requires": {
+        "assert": "1.4.1",
+        "camelcase": "1.2.1",
+        "loader-utils": "1.1.0",
+        "lodash.assign": "4.2.0",
+        "lodash.defaults": "3.1.2",
+        "object-path": "0.9.2",
+        "regex-parser": "2.2.8"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true
+        },
+        "lodash.defaults": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
+          "integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
+          "dev": true,
+          "requires": {
+            "lodash.assign": "3.2.0",
+            "lodash.restparam": "3.6.1"
+          },
+          "dependencies": {
+            "lodash.assign": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+              "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+              "dev": true,
+              "requires": {
+                "lodash._baseassign": "3.2.0",
+                "lodash._createassigner": "3.1.1",
+                "lodash.keys": "3.1.2"
+              }
+            }
+          }
+        }
+      }
+    },
+    "agent-base": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "dev": true,
+      "requires": {
+        "extend": "3.0.1",
+        "semver": "5.0.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
+      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
+      "dev": true
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
+      }
+    },
+    "alphanum-sort": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+      "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-align": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "dev": true,
+      "requires": {
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-html": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+      "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "dev": true,
+      "requires": {
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "1.1.0"
+          }
+        }
+      }
+    },
+    "app-package-builder": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/app-package-builder/-/app-package-builder-1.3.1.tgz",
+      "integrity": "sha512-TnKHgkO0zW1x9b1bDAJSPNx9FljH21GaG8gF7uAn134GvR4hVO98h+zQ9lDYKV4uyW+F6eKrWKAUhUupD2sNuQ==",
+      "dev": true,
+      "requires": {
+        "bluebird-lst": "1.0.5",
+        "builder-util": "3.1.0",
+        "builder-util-runtime": "2.4.0",
+        "fs-extra-p": "4.4.4",
+        "int64-buffer": "0.1.9",
+        "js-yaml": "3.10.0",
+        "rabin-bindings": "1.7.3"
+      }
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+      "dev": true
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "archiver": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
+      "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
+      "dev": true,
+      "requires": {
+        "archiver-utils": "1.3.0",
+        "async": "2.5.0",
+        "buffer-crc32": "0.2.13",
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "readable-stream": "2.3.3",
+        "tar-stream": "1.5.4",
+        "walkdir": "0.0.11",
+        "zip-stream": "1.2.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        }
+      }
+    },
+    "archiver-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lazystream": "1.0.0",
+        "lodash": "4.17.4",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "1.1.0"
+          }
+        }
+      }
+    },
+    "are-we-there-yet": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-back": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
+      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+      "requires": {
+        "typical": "2.6.1"
+      }
+    },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.9.0"
+      }
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "asar-integrity": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asar-integrity/-/asar-integrity-0.2.3.tgz",
+      "integrity": "sha512-c+oMuxlpKRDv9Kv6WdjbnkySfSYATAmW+cvy8NIdMg9twY9RMvSdvOoPssroWlTpSra1qX9vLew2ROpV4jQm7w==",
+      "dev": true,
+      "requires": {
+        "bluebird-lst": "1.0.5",
+        "fs-extra-p": "4.4.4"
+      }
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "asn1.js": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+      "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "assert": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "dev": true,
+      "requires": {
+        "util": "0.10.3"
+      }
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+    },
+    "ast-types": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+      "dev": true
+    },
+    "async-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true
+    },
+    "async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true
+    },
+    "async-foreach": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "atob": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
+      "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
+      "dev": true
+    },
+    "autoprefixer": {
+      "version": "6.7.7",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+      "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+      "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000750",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "awesome-typescript-loader": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-3.2.3.tgz",
+      "integrity": "sha512-zGGD6j6jYYtIOBtfhtnrbNB3dlDThVdgF9CQhkPqBwPUUsyJOHNxj9d2LOmVJY1PlBoNPABoDeyRfphIDeYGxA==",
+      "dev": true,
+      "requires": {
+        "colors": "1.1.2",
+        "enhanced-resolve": "3.3.0",
+        "loader-utils": "1.1.0",
+        "lodash": "4.17.4",
+        "micromatch": "3.1.3",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1",
+        "source-map-support": "0.4.18"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.4.18",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        }
+      }
+    },
+    "aws-sdk": {
+      "version": "2.140.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.140.0.tgz",
+      "integrity": "sha1-wV/Fw9t6GAXFn4V2frEGeuNPmuQ=",
+      "dev": true,
+      "requires": {
+        "buffer": "4.9.1",
+        "crypto-browserify": "1.0.9",
+        "events": "1.1.1",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.1.0",
+        "xml2js": "0.4.17",
+        "xmlbuilder": "4.2.1"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+          "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+          "dev": true
+        },
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "dev": true,
+          "requires": {
+            "base64-js": "1.2.1",
+            "ieee754": "1.1.8",
+            "isarray": "1.0.0"
+          }
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+          "dev": true
+        },
+        "xmlbuilder": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+          "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        }
+      }
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+        }
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.5",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.2.0",
+        "pascalcase": "0.1.1"
+      }
+    },
+    "base62": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base62/-/base62-1.2.0.tgz",
+      "integrity": "sha1-MeflYNyEbJ9EwaUx32UU2jVHQVc=",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+    },
+    "base64url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs=",
+      "dev": true
+    },
+    "basic-auth": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
+      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "batch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+      "dev": true
+    },
+    "bcrypt": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-1.0.3.tgz",
+      "integrity": "sha512-pRyDdo73C8Nim3jwFJ7DWe3TZCgwDfWZ6nHS5LSdU77kWbj1frruvdndP02AOavtD4y8v6Fp2dolbHgp4SDrfg==",
+      "dev": true,
+      "requires": {
+        "nan": "2.6.2",
+        "node-pre-gyp": "0.6.36"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+          "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+          "dev": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.36",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
+          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
+          "dev": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.2",
+            "rc": "1.2.2",
+            "request": "2.83.0",
+            "rimraf": "2.6.2",
+            "semver": "5.4.1",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.1"
+          }
+        }
+      }
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "big.js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
+      "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
+      "dev": true
+    },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+      "dev": true
+    },
+    "bl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
+    "bluebird-lst": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.5.tgz",
+      "integrity": "sha512-Ey0bDNys5qpYPhZ/oQ9vOEvD0TYQDTILMXWP2iGfvMg7rSDde+oV4aQQgqRH+CvBFNz2BSDQnPGMUl6LKBUUQA==",
+      "requires": {
+        "bluebird": "3.5.1"
+      }
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "dev": true
+    },
+    "body-parser": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "1.6.15"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        }
+      }
+    },
+    "bonjour": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+      "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+      "dev": true,
+      "requires": {
+        "array-flatten": "2.1.1",
+        "deep-equal": "1.0.1",
+        "dns-equal": "1.0.0",
+        "dns-txt": "2.0.2",
+        "multicast-dns": "6.1.1",
+        "multicast-dns-service-types": "1.1.0"
+      },
+      "dependencies": {
+        "array-flatten": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
+          "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
+          "dev": true
+        }
+      }
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "bootstrap": {
+      "version": "4.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0-alpha.6.tgz",
+      "integrity": "sha1-T1TdM6wN6sOyhAe8LffsYIhpycg=",
+      "dev": true,
+      "requires": {
+        "jquery": "3.2.1",
+        "tether": "1.4.0"
+      }
+    },
+    "boxen": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.2.tgz",
+      "integrity": "sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=",
+      "dev": true,
+      "requires": {
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "2.3.0",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
+        "widest-line": "1.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.0.tgz",
+      "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.2",
+        "snapdragon": "0.8.1",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.0.2",
+        "to-regex": "3.0.1"
+      }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "browserify-aes": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
+      "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+      "dev": true,
+      "requires": {
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "browserify-cipher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+      "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+      "dev": true,
+      "requires": {
+        "browserify-aes": "1.1.1",
+        "browserify-des": "1.0.0",
+        "evp_bytestokey": "1.0.3"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+      "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3"
+      }
+    },
+    "browserify-rsa": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.5"
+      }
+    },
+    "browserify-sign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.0"
+      }
+    },
+    "browserify-zlib": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+      "dev": true,
+      "requires": {
+        "pako": "0.2.9"
+      }
+    },
+    "browserslist": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+      "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+      "dev": true,
+      "requires": {
+        "caniuse-db": "1.0.30000750",
+        "electron-to-chromium": "1.3.27"
+      }
+    },
+    "buffer": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+      "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
+      "requires": {
+        "base64-js": "0.0.8",
+        "ieee754": "1.1.8",
+        "isarray": "1.0.0"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+      "dev": true
+    },
+    "buffer-indexof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
+      "dev": true
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "dev": true
+    },
+    "builder-util": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-3.1.0.tgz",
+      "integrity": "sha512-DVf9/tZqh0CGUyOGf6dHCmT34j3sd6a30tgfu89+ZcdBfYMN9Iu2piFm0BsClzhOxZE/UsJie4d9LuD1Dxm9XA==",
+      "dev": true,
+      "requires": {
+        "7zip-bin": "2.2.7",
+        "bluebird-lst": "1.0.5",
+        "builder-util-runtime": "2.4.0",
+        "chalk": "2.3.0",
+        "debug": "3.1.0",
+        "fs-extra-p": "4.4.4",
+        "ini": "1.3.4",
+        "is-ci": "1.0.10",
+        "js-yaml": "3.10.0",
+        "lazy-val": "1.0.2",
+        "node-emoji": "1.8.1",
+        "semver": "5.4.1",
+        "source-map-support": "0.5.0",
+        "stat-mode": "0.2.2",
+        "temp-file": "2.0.3",
+        "tunnel-agent": "0.6.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "builder-util-runtime": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-2.4.0.tgz",
+      "integrity": "sha512-35PskRowZnDnqJ6zbGSZ+ijndHPan2l56tF9n+FHMNmZnSQ69aw5eXWQDxyMlKKVwt/lF6dFGWhyRtsBmtDL7g==",
+      "requires": {
+        "bluebird-lst": "1.0.5",
+        "debug": "3.1.0",
+        "fs-extra-p": "4.4.4",
+        "sax": "1.2.4"
+      }
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
+      }
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      }
+    },
+    "caniuse-api": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+      "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+      "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000750",
+        "lodash.memoize": "4.1.2",
+        "lodash.uniq": "4.5.0"
+      }
+    },
+    "caniuse-db": {
+      "version": "1.0.30000750",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000750.tgz",
+      "integrity": "sha1-Px+FySyRNO3ac1aV42nX4XZ1K3U=",
+      "dev": true
+    },
+    "capture-stack-trace": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      },
+      "dependencies": {
+        "lazy-cache": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+          "dev": true
+        }
+      }
+    },
+    "chain-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
+      "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
+    },
+    "chalk": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+      "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "1.1.0",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "0.1.0",
+        "strip-ansi": "0.3.0",
+        "supports-color": "0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "0.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+          "dev": true
+        }
+      }
+    },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
+    "chokidar": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "dev": true,
+      "requires": {
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.1.2",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
+      }
+    },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+      "dev": true
+    },
+    "chromium-pickle-js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "integrity": "sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=",
+      "dev": true
+    },
+    "ci-info": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
+      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
+      "dev": true
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "circular-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/circular-buffer/-/circular-buffer-1.0.2.tgz",
+      "integrity": "sha1-+g4VLtYp92/iTd+J5y69AHhsWm4=",
+      "dev": true
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "clap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+      "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "class-utils": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.5.tgz",
+      "integrity": "sha1-F+eTEDdQ+WJ7IXbqNM/RtWWQPIA=",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "lazy-cache": "2.0.2",
+        "static-extend": "0.1.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "classnames": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+      "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "cli-spinners": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+      "dev": true
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      }
+    },
+    "clone": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+      "dev": true
+    },
+    "clone-deep": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.3.0.tgz",
+      "integrity": "sha1-NIxhrpzb4O3+BT2R/0zFIdeQ7eg=",
+      "dev": true,
+      "requires": {
+        "for-own": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "kind-of": "3.2.2",
+        "shallow-clone": "0.1.2"
+      },
+      "dependencies": {
+        "for-own": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "coa": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+      "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+      "dev": true,
+      "requires": {
+        "q": "1.5.1"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
+      }
+    },
+    "color": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+      "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+      "dev": true,
+      "requires": {
+        "clone": "1.0.2",
+        "color-convert": "1.9.0",
+        "color-string": "0.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "color-string": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "colormin": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+      "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
+      "dev": true,
+      "requires": {
+        "color": "0.11.4",
+        "css-color-names": "0.0.4",
+        "has": "1.0.1"
+      }
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "command-line-args": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
+      "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
+      "requires": {
+        "array-back": "2.0.0",
+        "find-replace": "1.0.3",
+        "typical": "2.6.1"
+      }
+    },
+    "commander": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+      "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
+    },
+    "commoner": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+      "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
+      "dev": true,
+      "requires": {
+        "commander": "2.8.1",
+        "detective": "4.5.0",
+        "glob": "5.0.15",
+        "graceful-fs": "4.1.11",
+        "iconv-lite": "0.4.19",
+        "mkdirp": "0.5.1",
+        "private": "0.1.8",
+        "q": "1.5.1",
+        "recast": "0.11.23"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "compare-version": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+      "integrity": "sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA=",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
+    },
+    "compress-commons": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "0.2.13",
+        "crc32-stream": "2.0.0",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "1.1.0"
+          }
+        }
+      }
+    },
+    "compressible": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
+      "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "compression": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
+      "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.4",
+        "bytes": "3.0.0",
+        "compressible": "2.0.12",
+        "debug": "2.6.9",
+        "on-headers": "1.0.1",
+        "safe-buffer": "5.1.1",
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
+    },
+    "concurrently": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-3.5.0.tgz",
+      "integrity": "sha1-jPG3cHppFqeKT/W3e7BN7FSzebI=",
+      "dev": true,
+      "requires": {
+        "chalk": "0.5.1",
+        "commander": "2.6.0",
+        "date-fns": "1.29.0",
+        "lodash": "4.17.4",
+        "rx": "2.3.24",
+        "spawn-command": "0.0.2-1",
+        "supports-color": "3.2.3",
+        "tree-kill": "1.2.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+          "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
+          "dev": true
+        }
+      }
+    },
+    "configstore": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.1.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
+      }
+    },
+    "connect-history-api-fallback": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.4.0.tgz",
+      "integrity": "sha1-PbJPlz9LkjsOgvYZzg3wJBHKYj0=",
+      "dev": true
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "0.1.4"
+      }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+      "dev": true
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
+    },
+    "content-type-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "cookiejar": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
+      "dev": true
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cosmiconfig": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
+      "integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "js-yaml": "3.10.0",
+        "minimist": "1.2.0",
+        "object-assign": "4.1.1",
+        "os-homedir": "1.0.2",
+        "parse-json": "2.2.0",
+        "pinkie-promise": "2.0.1",
+        "require-from-string": "1.2.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "crc": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
+      "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ=",
+      "dev": true
+    },
+    "crc32-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+      "dev": true,
+      "requires": {
+        "crc": "3.5.0",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "create-ecdh": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+      "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.0"
+      }
+    },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
+      "requires": {
+        "capture-stack-trace": "1.0.0"
+      }
+    },
+    "create-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+      "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "sha.js": "2.4.9"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+      "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.9"
+      }
+    },
+    "create-react-class": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
+      "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "requires": {
+        "boom": "2.10.1"
+      }
+    },
+    "crypto-browserify": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
+      "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA=",
+      "dev": true
+    },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
+    },
+    "css": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+      "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "source-map": "0.1.43",
+        "source-map-resolve": "0.3.1",
+        "urix": "0.1.0"
+      },
+      "dependencies": {
+        "atob": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+          "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        },
+        "source-map-resolve": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+          "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
+          "dev": true,
+          "requires": {
+            "atob": "1.1.3",
+            "resolve-url": "0.2.1",
+            "source-map-url": "0.3.0",
+            "urix": "0.1.0"
+          }
+        },
+        "source-map-url": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+          "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=",
+          "dev": true
+        }
+      }
+    },
+    "css-color-names": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+      "dev": true
+    },
+    "css-loader": {
+      "version": "0.28.7",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.7.tgz",
+      "integrity": "sha512-GxMpax8a/VgcfRrVy0gXD6yLd5ePYbXX/5zGgTVYp4wXtJklS8Z2VaUArJgc//f6/Dzil7BaJObdSv8eKKCPgg==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "css-selector-tokenizer": "0.7.0",
+        "cssnano": "3.10.0",
+        "icss-utils": "2.1.0",
+        "loader-utils": "1.1.0",
+        "lodash.camelcase": "4.3.0",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-modules-extract-imports": "1.1.0",
+        "postcss-modules-local-by-default": "1.2.0",
+        "postcss-modules-scope": "1.1.0",
+        "postcss-modules-values": "1.3.0",
+        "postcss-value-parser": "3.3.0",
+        "source-list-map": "2.0.0"
+      }
+    },
+    "css-parse": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
+      "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
+      "dev": true,
+      "requires": {
+        "css": "2.2.1"
+      }
+    },
+    "css-selector-tokenizer": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+      "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+      "dev": true,
+      "requires": {
+        "cssesc": "0.1.0",
+        "fastparse": "1.1.1",
+        "regexpu-core": "1.0.0"
+      }
+    },
+    "css-value": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
+      "integrity": "sha1-Xv1sLupeof1rasV+wEJ7GEUkJOo=",
+      "dev": true
+    },
+    "cssesc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+      "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+      "dev": true
+    },
+    "cssnano": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+      "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+      "dev": true,
+      "requires": {
+        "autoprefixer": "6.7.7",
+        "decamelize": "1.2.0",
+        "defined": "1.0.0",
+        "has": "1.0.1",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-calc": "5.3.1",
+        "postcss-colormin": "2.2.2",
+        "postcss-convert-values": "2.6.1",
+        "postcss-discard-comments": "2.0.4",
+        "postcss-discard-duplicates": "2.1.0",
+        "postcss-discard-empty": "2.1.0",
+        "postcss-discard-overridden": "0.1.1",
+        "postcss-discard-unused": "2.2.3",
+        "postcss-filter-plugins": "2.0.2",
+        "postcss-merge-idents": "2.1.7",
+        "postcss-merge-longhand": "2.0.2",
+        "postcss-merge-rules": "2.1.2",
+        "postcss-minify-font-values": "1.0.5",
+        "postcss-minify-gradients": "1.0.5",
+        "postcss-minify-params": "1.2.2",
+        "postcss-minify-selectors": "2.1.1",
+        "postcss-normalize-charset": "1.1.1",
+        "postcss-normalize-url": "3.0.8",
+        "postcss-ordered-values": "2.2.3",
+        "postcss-reduce-idents": "2.4.0",
+        "postcss-reduce-initial": "1.0.1",
+        "postcss-reduce-transforms": "1.0.4",
+        "postcss-svgo": "2.1.6",
+        "postcss-unique-selectors": "2.0.2",
+        "postcss-value-parser": "3.3.0",
+        "postcss-zindex": "2.2.0"
+      }
+    },
+    "csso": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+      "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+      "dev": true,
+      "requires": {
+        "clap": "1.2.3",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "cssom": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+      "dev": true,
+      "requires": {
+        "cssom": "0.3.2"
+      }
+    },
+    "cuint": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
+      "dev": true
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true
+    },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.35"
+      }
+    },
+    "d3": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
+      "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g=",
+      "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "decompress": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
+      "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+      "requires": {
+        "decompress-tar": "4.1.1",
+        "decompress-tarbz2": "4.1.1",
+        "decompress-targz": "4.1.1",
+        "decompress-unzip": "4.0.1",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.1.0",
+        "pify": "2.3.0",
+        "strip-dirs": "2.1.0"
+      }
+    },
+    "decompress-tar": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+      "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+      "requires": {
+        "file-type": "5.2.0",
+        "is-stream": "1.1.0",
+        "tar-stream": "1.5.4"
+      }
+    },
+    "decompress-tarbz2": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+      "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+      "requires": {
+        "decompress-tar": "4.1.1",
+        "file-type": "6.2.0",
+        "is-stream": "1.1.0",
+        "seek-bzip": "1.0.5",
+        "unbzip2-stream": "1.2.5"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
+        }
+      }
+    },
+    "decompress-targz": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+      "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+      "requires": {
+        "decompress-tar": "4.1.1",
+        "file-type": "5.2.0",
+        "is-stream": "1.1.0"
+      }
+    },
+    "decompress-tarxz": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tarxz/-/decompress-tarxz-2.1.1.tgz",
+      "integrity": "sha512-U7LniyhLTpCc07lAmNXMX4NBW60ONkpGTwo6KxIDk9zk22GYh5NKjEI09F8I1oYkGr9WGOA6OH7scqLo7Xu5lA==",
+      "requires": {
+        "decompress-tar": "4.1.1",
+        "file-type": "3.9.0",
+        "is-stream": "1.1.0",
+        "lzma-native": "3.0.1"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+        }
+      }
+    },
+    "decompress-unzip": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+      "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
+      "requires": {
+        "file-type": "3.9.0",
+        "get-stream": "2.3.1",
+        "pify": "2.3.0",
+        "yauzl": "2.8.0"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+        }
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "deep-extend": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.3.2.tgz",
+      "integrity": "sha1-FmNpFinU2/42T6EqKk8KqGqjoFA=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+          "dev": true
+        }
+      }
+    },
+    "define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "1.0.1"
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "depd": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+      "dev": true
+    },
+    "des.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "detect-node": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
+      "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
+      "dev": true
+    },
+    "detective": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+      "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
+      "dev": true,
+      "requires": {
+        "acorn": "4.0.13",
+        "defined": "1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "dev": true
+        }
+      }
+    },
+    "dev-null": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dev-null/-/dev-null-0.1.1.tgz",
+      "integrity": "sha1-WiBc48Ky73e2I41roXnrdMag6Bg=",
+      "dev": true
+    },
+    "devtron": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/devtron/-/devtron-1.4.0.tgz",
+      "integrity": "sha1-tedIvW6Vu+cL/MaKrm/mlhGUQeE=",
+      "dev": true,
+      "requires": {
+        "accessibility-developer-tools": "2.12.0",
+        "highlight.js": "9.12.0",
+        "humanize-plus": "1.8.2"
+      }
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "diffie-hellman": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+      "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.0.5"
+      }
+    },
+    "dmg-builder": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-2.1.3.tgz",
+      "integrity": "sha512-3H0BNx62NzhTX/UuEf6GHRAl6moZvECufemxqgeByKs3o4ys6SNU+HynzppPTKZ5nNwx4EqcJXtAbhfPuMwHUQ==",
+      "dev": true,
+      "requires": {
+        "bluebird-lst": "1.0.5",
+        "builder-util": "3.1.0",
+        "debug": "3.1.0",
+        "fs-extra-p": "4.4.4",
+        "iconv-lite": "0.4.19",
+        "js-yaml": "3.10.0",
+        "parse-color": "1.0.0"
+      }
+    },
+    "dns-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+      "dev": true
+    },
+    "dns-packet": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.2.tgz",
+      "integrity": "sha512-kN+DjfGF7dJGUL7nWRktL9Z18t1rWP3aQlyZdY8XlpvU3Nc6GeFTQApftcjtWKxAZfiggZSGrCEoszNgvnpwDg==",
+      "dev": true,
+      "requires": {
+        "ip": "1.1.5",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "dns-txt": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+      "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+      "dev": true,
+      "requires": {
+        "buffer-indexof": "1.1.1"
+      }
+    },
+    "doctrine": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
+    },
+    "dom-helpers": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz",
+      "integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo="
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        }
+      }
+    },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
+      "dev": true
+    },
+    "domain-browser": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+      "dev": true
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.0.tgz",
+      "integrity": "sha512-WpwuBlZ2lQRFa4H/4w49deb9rJLot9KmqrKKjMc9qBl7CID+DdC2swoa34ccRl+anL2B6bLp6TjFdIdnzekMBQ==",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domready": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/domready/-/domready-1.0.8.tgz",
+      "integrity": "sha1-kfJS5Ze2Wvd+dFriTdAYXV4m1Yw=",
+      "dev": true
+    },
+    "domutils": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz",
+      "integrity": "sha1-GVjMC0yUJuntNn+xyOhUiRsPo/8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
+    },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
+      "requires": {
+        "is-obj": "1.0.1"
+      }
+    },
+    "dotenv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
+      "dev": true
+    },
+    "dotenv-expand": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.0.1.tgz",
+      "integrity": "sha1-aP3cFWGBTgoQlkERBX/xOM7X16g=",
+      "dev": true
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
+      "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
+      "dev": true,
+      "requires": {
+        "base64url": "2.0.0",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "ejs": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
+      "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=",
+      "dev": true
+    },
+    "electron": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-1.8.1.tgz",
+      "integrity": "sha1-GbbznyAT4gSpGmC8MIbcekoH7Yg=",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.47",
+        "electron-download": "3.3.0",
+        "extract-zip": "1.6.5"
+      }
+    },
+    "electron-builder": {
+      "version": "19.41.0",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-19.41.0.tgz",
+      "integrity": "sha512-ncvGpEJEZjvJLVi9dqi6pWR4pqaw2e99dKRiXlFmsFPQXpmlEQMEmP/S9yoJkb3RgOEzVRKFMHmtwvZ73LGD+g==",
+      "dev": true,
+      "requires": {
+        "7zip-bin": "2.2.7",
+        "app-package-builder": "1.3.1",
+        "asar-integrity": "0.2.3",
+        "async-exit-hook": "2.0.1",
+        "bluebird-lst": "1.0.5",
+        "builder-util": "3.1.0",
+        "builder-util-runtime": "2.4.0",
+        "chalk": "2.3.0",
+        "chromium-pickle-js": "0.2.0",
+        "cuint": "0.2.2",
+        "debug": "3.1.0",
+        "dmg-builder": "2.1.3",
+        "ejs": "2.5.7",
+        "electron-download-tf": "4.3.4",
+        "electron-osx-sign": "0.4.7",
+        "electron-publish": "19.40.0",
+        "fs-extra-p": "4.4.4",
+        "hosted-git-info": "2.5.0",
+        "is-ci": "1.0.10",
+        "isbinaryfile": "3.0.2",
+        "js-yaml": "3.10.0",
+        "lazy-val": "1.0.2",
+        "minimatch": "3.0.4",
+        "normalize-package-data": "2.4.0",
+        "plist": "2.1.0",
+        "read-config-file": "1.2.0",
+        "sanitize-filename": "1.6.1",
+        "semver": "5.4.1",
+        "temp-file": "2.0.3",
+        "update-notifier": "2.3.0",
+        "yargs": "10.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "electron-download-tf": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/electron-download-tf/-/electron-download-tf-4.3.4.tgz",
+          "integrity": "sha512-SQYDGMLpTgty1bx3NycuDb7dNPzktVSdK2sqPZjyRocauq/uN/V4S2lcpFVLupaHhKlD8zozm9fTpm5UdohvTg==",
+          "dev": true,
+          "requires": {
+            "debug": "3.1.0",
+            "env-paths": "1.0.0",
+            "fs-extra": "4.0.2",
+            "minimist": "1.2.0",
+            "nugget": "2.0.1",
+            "path-exists": "3.0.0",
+            "rc": "1.2.2",
+            "semver": "5.4.1",
+            "sumchecker": "2.0.2"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "sumchecker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-2.0.2.tgz",
+          "integrity": "sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "electron-chromedriver": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/electron-chromedriver/-/electron-chromedriver-1.7.1.tgz",
+      "integrity": "sha1-AIyXl2AHqk6xhJHuCV6U0X7kdhA=",
+      "dev": true,
+      "requires": {
+        "electron-download": "4.1.0",
+        "extract-zip": "1.6.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "electron-download": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-4.1.0.tgz",
+          "integrity": "sha1-v5MsdG8vh//MCdHdRy8v9rkYeEU=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "env-paths": "1.0.0",
+            "fs-extra": "2.1.2",
+            "minimist": "1.2.0",
+            "nugget": "2.0.1",
+            "path-exists": "3.0.0",
+            "rc": "1.2.2",
+            "semver": "5.4.1",
+            "sumchecker": "2.0.2"
+          }
+        },
+        "fs-extra": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+          "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "sumchecker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-2.0.2.tgz",
+          "integrity": "sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9"
+          }
+        }
+      }
+    },
+    "electron-download": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
+      "integrity": "sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "fs-extra": "0.30.0",
+        "home-path": "1.0.5",
+        "minimist": "1.2.0",
+        "nugget": "2.0.1",
+        "path-exists": "2.1.0",
+        "rc": "1.2.2",
+        "semver": "5.4.1",
+        "sumchecker": "1.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "2.6.2"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "electron-is-dev": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-0.3.0.tgz",
+      "integrity": "sha1-FOb9pcaOnk7L7/nM8DfL18BcWv4="
+    },
+    "electron-osx-sign": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.7.tgz",
+      "integrity": "sha1-HXVkeoJ0jqzUi+pwYW7IP/rePuU=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "compare-version": "0.1.2",
+        "debug": "2.6.9",
+        "isbinaryfile": "3.0.2",
+        "minimist": "1.2.0",
+        "plist": "2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "electron-publish": {
+      "version": "19.40.0",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-19.40.0.tgz",
+      "integrity": "sha512-8SZOp+V3o65IYfKjOgkqis16uL3S6gQLK08MYs9ceGelQ5IEvC69lJslk0hCTAxwfczH6eL7QlGS3A/zAyWsbQ==",
+      "dev": true,
+      "requires": {
+        "bluebird-lst": "1.0.5",
+        "builder-util": "3.1.0",
+        "builder-util-runtime": "2.4.0",
+        "chalk": "2.1.0",
+        "fs-extra-p": "4.4.4",
+        "mime": "2.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "electron-publisher-s3": {
+      "version": "19.40.0",
+      "resolved": "https://registry.npmjs.org/electron-publisher-s3/-/electron-publisher-s3-19.40.0.tgz",
+      "integrity": "sha512-I4KBEcPAkAchat0uoB/7eP1FNok900XMkGZvRLag+B1io7AVJLGvvNPTkA0oKI1ZC/eYlUSGrDdDF27uFmejKQ==",
+      "dev": true,
+      "requires": {
+        "aws-sdk": "2.140.0",
+        "bluebird-lst": "1.0.5",
+        "builder-util": "3.1.0",
+        "electron-publish": "19.40.0",
+        "fs-extra-p": "4.4.4",
+        "mime": "2.0.3"
+      }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.27",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
+      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
+      "dev": true
+    },
+    "electron-updater": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-2.15.0.tgz",
+      "integrity": "sha512-xHGUPJav7EOKrEs/Tdlv6HFhtzkDfemLKew+S4iIjXyGPuV8hg7bFnbrHdOXid1iQF6ZE2QiNa1iT1Or2gnZsQ==",
+      "requires": {
+        "bluebird-lst": "1.0.5",
+        "builder-util-runtime": "2.4.0",
+        "electron-is-dev": "0.3.0",
+        "fs-extra-p": "4.4.4",
+        "js-yaml": "3.10.0",
+        "lazy-val": "1.0.2",
+        "lodash.isequal": "4.5.0",
+        "semver": "5.4.1",
+        "source-map-support": "0.5.0"
+      }
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
+    },
+    "elliptic": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.3",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
+      "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
+    "enhanced-resolve": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz",
+      "integrity": "sha512-2qbxE7ek3YxPJ1ML6V+satHkzHpJQKWkRHmRx6mfAoW59yP8YH8BFplbegSP+u2hBd6B6KCOpvJQ3dZAP+hkpg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.4.1",
+        "object-assign": "4.1.1",
+        "tapable": "0.2.8"
+      }
+    },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+      "dev": true
+    },
+    "env-paths": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
+      "integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=",
+      "dev": true
+    },
+    "envify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
+      "integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
+      "dev": true,
+      "requires": {
+        "jstransform": "11.0.3",
+        "through": "2.3.8"
+      }
+    },
+    "errno": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "dev": true,
+      "requires": {
+        "prr": "0.0.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
+      "integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
+      "dev": true,
+      "requires": {
+        "stackframe": "0.3.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
+      "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.35",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
+      "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
+    },
+    "es6-promise": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
+      "dev": true
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
+      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "dev": true,
+      "requires": {
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "escope": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
+    },
+    "eslint": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+      "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "es6-map": "0.1.5",
+        "escope": "3.6.0",
+        "espree": "3.5.1",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "1.3.1",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.6",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.16.1",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.10.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "optionator": "0.8.2",
+        "path-is-absolute": "1.0.1",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.6.1",
+        "strip-json-comments": "1.0.4",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "progress": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.3.1.tgz",
+      "integrity": "sha512-AV8shBlGN9tRZffj5v/f4uiQWlP3qiQ+lh+BhTqRLuKSyczx+HRWVkVZaf7dOmguxghAH1wftnou/JUEEChhGg==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
+      }
+    },
+    "espree": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
+      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.2",
+        "acorn-jsx": "3.0.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+    },
+    "esrecurse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.35"
+      }
+    },
+    "eventemitter3": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
+      "dev": true
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
+    },
+    "eventsource": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+      "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+      "dev": true,
+      "requires": {
+        "original": "1.0.0"
+      }
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "requires": {
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        }
+      }
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "2.2.3"
+      },
+      "dependencies": {
+        "fill-range": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+          "dev": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.7",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
+      }
+    },
+    "expand-template": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
+      "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ==",
+      "dev": true
+    },
+    "express": {
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.4",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "2.0.2",
+        "qs": "6.5.1",
+        "range-parser": "1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.3.1",
+        "type-is": "1.6.15",
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "requires": {
+        "is-extendable": "0.1.1"
+      }
+    },
+    "external-editor": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
+      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.19",
+        "jschardet": "1.5.1",
+        "tmp": "0.0.33"
+      }
+    },
+    "extglob": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.2.tgz",
+      "integrity": "sha512-I0+eZBH+jFGL8F5BnIz2ON2nKCjTS3AS3H/5PeSmCp7UVC70Ym8IhdRiQly2juKYQ//f7z1aj1BRpQniFJoU1w==",
+      "dev": true,
+      "requires": {
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
+      }
+    },
+    "extract-zip": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
+      "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.0",
+        "debug": "2.2.0",
+        "mkdirp": "0.5.0",
+        "yauzl": "2.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        },
+        "yauzl": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+          "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+          "dev": true,
+          "requires": {
+            "fd-slicer": "1.0.1"
+          }
+        }
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "dev": true
+    },
+    "faker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fastparse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+      "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
+      "dev": true
+    },
+    "faye-websocket": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+      "dev": true,
+      "requires": {
+        "websocket-driver": "0.7.0"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "requires": {
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.17"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "requires": {
+        "pend": "1.2.0"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
+    },
+    "file-entry-cache": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+      "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "file-loader": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.5.tgz",
+      "integrity": "sha512-RzGHDatcVNpGISTvCpfUfOGpYuSR7HSsSg87ki+wF6rw1Hm0RALPTiAdsxAq1UwLf0RRhbe22/eHK6nhXspiOQ==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "schema-utils": "0.3.0"
+      }
+    },
+    "file-type": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+      "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
+        }
+      }
+    },
+    "find-replace": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
+      "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
+      "requires": {
+        "array-back": "1.0.4",
+        "test-value": "2.1.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "requires": {
+            "typical": "2.6.1"
+          }
+        }
+      }
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
+    },
+    "flatten": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+      "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
+      "dev": true
+    },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2"
+      }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
+    },
+    "formidable": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
+      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak=",
+      "dev": true
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "0.2.2"
+      }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "front-matter": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-2.1.2.tgz",
+      "integrity": "sha1-91mDufL0E75ljJPf172M5AePXNs=",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.10.0"
+      }
+    },
+    "fs-extra": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
+      "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
+      }
+    },
+    "fs-extra-p": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.4.4.tgz",
+      "integrity": "sha512-zHsMNJWhXD184QfHKEIFSQSgAFNV7v9J+Nt2XpaLZp2nTz6WxZNV+R4G2uYeGeLTMaKvUZiqGKrH/4iFCupcUA==",
+      "requires": {
+        "bluebird-lst": "1.0.5",
+        "fs-extra": "4.0.2"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.7.0",
+        "node-pre-gyp": "0.6.36"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.36",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "fstream-ignore": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+      "requires": {
+        "fstream": "1.0.11",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
+      }
+    },
+    "gaze": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+      "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+      "dev": true,
+      "requires": {
+        "globule": "1.2.0"
+      }
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+      "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "dev": true,
+      "requires": {
+        "is-glob": "2.0.1"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
+      }
+    },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "dev": true,
+      "requires": {
+        "min-document": "2.19.0",
+        "process": "0.5.2"
+      }
+    },
+    "global-dirs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.0.tgz",
+      "integrity": "sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=",
+      "dev": true,
+      "requires": {
+        "ini": "1.3.4"
+      }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globby": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "globule": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
+      "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4"
+      }
+    },
+    "gonzales-pe-sl": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/gonzales-pe-sl/-/gonzales-pe-sl-4.2.3.tgz",
+      "integrity": "sha1-aoaLw4BkXxQf7rBCxvl/zHG1n+Y=",
+      "dev": true,
+      "requires": {
+        "minimist": "1.1.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
+          "dev": true
+        }
+      }
+    },
+    "got": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "dev": true,
+      "requires": {
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.0",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "unzip-response": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+          "dev": true
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "handle-thing": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+      "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+    },
+    "har-validator": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+      "requires": {
+        "ajv": "4.11.8",
+        "har-schema": "1.0.5"
+      }
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+      "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "0.2.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+          "dev": true
+        }
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
+      }
+    },
+    "hash-base": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "hash.js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "highlight.js": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
+      "dev": true
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
+      "requires": {
+        "hash.js": "1.1.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "home-path": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz",
+      "integrity": "sha1-eIspgVsS1Tus9XVkhHbm+QQdEz8=",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "dev": true
+    },
+    "hpack.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "obuf": "1.1.1",
+        "readable-stream": "2.3.3",
+        "wbuf": "1.7.2"
+      }
+    },
+    "html-comment-regex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
+      "integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
+      "dev": true
+    },
+    "html-encoding-sniffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "1.0.2"
+      }
+    },
+    "html-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.1",
+        "domutils": "1.6.2",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "http-basic": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
+      "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
+      "requires": {
+        "caseless": "0.11.0",
+        "concat-stream": "1.6.0",
+        "http-response-object": "1.1.0"
+      },
+      "dependencies": {
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+        }
+      }
+    },
+    "http-deceiver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+      "dev": true
+    },
+    "http-errors": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "dev": true,
+      "requires": {
+        "depd": "1.1.1",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.4.0"
+      }
+    },
+    "http-parser-js": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
+      "integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE=",
+      "dev": true
+    },
+    "http-proxy": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+      "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
+      }
+    },
+    "http-proxy-middleware": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+      "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+      "dev": true,
+      "requires": {
+        "http-proxy": "1.16.2",
+        "is-glob": "3.1.0",
+        "lodash": "4.17.4",
+        "micromatch": "2.3.11"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          },
+          "dependencies": {
+            "is-extglob": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+              "dev": true
+            }
+          }
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          },
+          "dependencies": {
+            "is-extglob": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+              "dev": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            }
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "1.1.0"
+          }
+        }
+      }
+    },
+    "http-response-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
+      "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM="
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
+    },
+    "https-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+      "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
+      "dev": true
+    },
+    "https-proxy-agent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "dev": true,
+      "requires": {
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "humanize-plus": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/humanize-plus/-/humanize-plus-1.8.2.tgz",
+      "integrity": "sha1-pls0RZrWNnrbs3B6gqPJ+RYWcDA=",
+      "dev": true
+    },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        }
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "icss-replace-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+      "dev": true
+    },
+    "icss-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
+      "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+      "dev": true,
+      "requires": {
+        "postcss": "6.0.13"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
+          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "source-map": "0.6.1",
+            "supports-color": "4.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+    },
+    "ignore": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
+      "integrity": "sha512-HrxmNxKTGZ9a3uAl/FNG66Sdt0G9L4TtMbbUQjP1WhGmSj0FOyHvSgx7623aGJvXfPOur8MwmarlHT+37jmzlw==",
+      "dev": true
+    },
+    "image-size": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+      "dev": true
+    },
+    "import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
+    },
+    "import-local": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
+      "integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "in-publish": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+    },
+    "inquirer": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.2.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "int64-buffer": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.9.tgz",
+      "integrity": "sha1-ngOdoEOyT3ixlrKD4EZT716ZD2E=",
+      "dev": true
+    },
+    "internal-ip": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
+      "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
+      "dev": true,
+      "requires": {
+        "meow": "3.7.0"
+      }
+    },
+    "interpret": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
+      "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
+      "dev": true
+    },
+    "invariant": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
+      "dev": true
+    },
+    "is-absolute-url": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "1.10.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.1"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-descriptor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz",
+      "integrity": "sha512-G3fFVFTqfaqu7r4YuSBHKBAuOaLz8Sy7ekklUpFEliaLMP1Y2ZjoN9jS62YWCAPQrQpMUQSitRlrzibbuCZjdA==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true,
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-glob": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "2.1.1"
+      }
+    },
+    "is-installed-globally": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
+      "requires": {
+        "global-dirs": "0.1.0",
+        "is-path-inside": "1.0.0"
+      }
+    },
+    "is-my-json-valid": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "is-natural-number": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+      "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
+    },
+    "is-npm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
+      }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-odd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
+      "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0"
+      }
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-svg": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+      "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+      "dev": true,
+      "requires": {
+        "html-comment-regex": "1.1.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isbinaryfile": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz",
+      "integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE=",
+      "dev": true
+    },
+    "isemail": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+      "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
+      }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
+    },
+    "jest-validate": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-get-type": "21.2.0",
+        "leven": "2.1.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
+    },
+    "joi": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
+      "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3",
+        "isemail": "1.2.0",
+        "moment": "2.19.1",
+        "topo": "1.1.0"
+      }
+    },
+    "jquery": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
+      "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c=",
+      "dev": true
+    },
+    "js-base64": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
+      "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "js-yaml": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "jschardet": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
+      "dev": true
+    },
+    "jsdom": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.3.0.tgz",
+      "integrity": "sha512-aPZTDl4MplzQhx5bLztk6nzjbEslmO3Q3+z0WpCMutL1XJDhZIRzir6R1Y8S84LgeT/7jhQvgtUMkY6oPwvlUw==",
+      "dev": true,
+      "requires": {
+        "abab": "1.0.4",
+        "acorn": "5.1.2",
+        "acorn-globals": "4.1.0",
+        "array-equal": "1.0.0",
+        "content-type-parser": "1.0.2",
+        "cssom": "0.3.2",
+        "cssstyle": "0.2.37",
+        "domexception": "1.0.0",
+        "escodegen": "1.9.0",
+        "html-encoding-sniffer": "1.0.2",
+        "nwmatcher": "1.4.3",
+        "parse5": "3.0.2",
+        "pn": "1.0.0",
+        "request": "2.83.0",
+        "request-promise-native": "1.0.5",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.3.3",
+        "webidl-conversions": "4.0.2",
+        "whatwg-encoding": "1.0.2",
+        "whatwg-url": "6.3.0",
+        "xml-name-validator": "2.0.1"
+      }
+    },
+    "jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+      "dev": true
+    },
+    "json-loader": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
+    "jsonwebtoken": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
+      "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
+      "dev": true,
+      "requires": {
+        "joi": "6.10.1",
+        "jws": "3.1.4",
+        "lodash.once": "4.1.1",
+        "ms": "2.0.0",
+        "xtend": "4.0.1"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "jstransform": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
+      "integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
+      "dev": true,
+      "requires": {
+        "base62": "1.2.0",
+        "commoner": "0.10.8",
+        "esprima-fb": "15001.1.0-dev-harmony-fb",
+        "object-assign": "2.1.1",
+        "source-map": "0.4.4"
+      },
+      "dependencies": {
+        "esprima-fb": {
+          "version": "15001.1.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "jwa": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
+      "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
+      "dev": true,
+      "requires": {
+        "base64url": "2.0.0",
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.9",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "jws": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
+      "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
+      "dev": true,
+      "requires": {
+        "base64url": "2.0.0",
+        "jwa": "1.1.5",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "kind-of": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.0.tgz",
+      "integrity": "sha512-sUd5AnFyOPh+RW+ZIHd1FHuwM4OFvhKCPVxxhamLxWLpmv1xQ394lzRMmhLQOiMpXvnB64YRLezWaJi5xGk7Dg==",
+      "dev": true
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "known-css-properties": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.3.0.tgz",
+      "integrity": "sha512-QMQcnKAiQccfQTqtBh/qwquGZ2XK/DXND1jrcN9M8gMMy99Gwla7GQjndVUsEqIaRyP6bsFRuhwRj5poafBGJQ==",
+      "dev": true
+    },
+    "latest-version": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "dev": true,
+      "requires": {
+        "package-json": "4.0.1"
+      }
+    },
+    "lazy-cache": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+      "dev": true,
+      "requires": {
+        "set-getter": "0.1.0"
+      }
+    },
+    "lazy-val": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.2.tgz",
+      "integrity": "sha512-2BaSu6qVnicKdWQPysrffZVFAKcPcZQ/q2YyeSjAxWaJlvCvKSrkcvsSHlleeIfA//fW2goTcYDTy2cBLN7+PQ=="
+    },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
+    },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "lint-staged": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-4.3.0.tgz",
+      "integrity": "sha512-C/Zxslg0VRbsxwmCu977iIs+QyrmW2cyRCPUV5NDFYOH/jtRFHH8ch7ua2fH0voI/nVC3Tpg7DykfgMZySliKw==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "chalk": "2.3.0",
+        "commander": "2.11.0",
+        "cosmiconfig": "1.1.0",
+        "execa": "0.8.0",
+        "is-glob": "4.0.0",
+        "jest-validate": "21.2.1",
+        "listr": "0.12.0",
+        "lodash": "4.17.4",
+        "log-symbols": "2.1.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "staged-git-files": "0.0.4",
+        "stringify-object": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "listr": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.12.0.tgz",
+      "integrity": "sha1-a84sD1YD+klYDqF81qAMwOX6RRo=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.2.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.1",
+        "stream-to-observable": "0.1.0",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz",
+      "integrity": "sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      }
+    },
+    "loader-runner": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
+      "integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
+      "dev": true
+    },
+    "loader-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+      "dev": true,
+      "requires": {
+        "big.js": "3.2.0",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "dev": true
+    },
+    "lodash._createassigner": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+      "dev": true,
+      "requires": {
+        "lodash._bindcallback": "3.0.1",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash.restparam": "3.6.1"
+      }
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
+    "lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+      "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lodash.isfunction": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz",
+      "integrity": "sha1-TbcJ/IG8So/XEnpFilNGxc3OLGs="
+    },
+    "lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
+    },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
+      "dev": true
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+      "dev": true
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "lodash.tail": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
+      "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
+      "dev": true
+    },
+    "lodash.toarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+      "dev": true
+    },
+    "lodash.tonumber": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
+      "integrity": "sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk="
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
+      "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
+      }
+    },
+    "loglevel": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.5.1.tgz",
+      "integrity": "sha1-GJB4yUq5BT7iFaCs2/JCROoPZQI=",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "lowercase-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "lzma-native": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-3.0.1.tgz",
+      "integrity": "sha512-RZsLWwvuCpkaXEt2p2pmx7dI20UUfXK9OTyG8KGxSiZA79i67TWLnhlNtCMGGZ0xP3NaWjkq4W5+gol7l7RyPQ==",
+      "requires": {
+        "nan": "2.5.1",
+        "node-pre-gyp": "0.6.36",
+        "readable-stream": "2.2.11",
+        "rimraf": "2.6.1"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.11"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.1.2",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "nan": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
+          "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI="
+        },
+        "node-pre-gyp": {
+          "version": "0.6.36",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.11",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.0.1",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.11",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        }
+      }
+    },
+    "macaddress": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
+      "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
+      "dev": true
+    },
+    "make-dir": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
+      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+      "requires": {
+        "pify": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "1.0.1"
+      }
+    },
+    "math-expression-evaluator": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+      "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
+      "dev": true
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "dev": true,
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "1.1.5"
+      }
+    },
+    "md5.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+      "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+      "dev": true,
+      "requires": {
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "hash-base": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+          "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
+    "mem": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
+    },
+    "memory-fs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+      "dev": true,
+      "requires": {
+        "errno": "0.1.4",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "merge": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "dev": true
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "merge-options": {
+      "version": "0.0.64",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-0.0.64.tgz",
+      "integrity": "sha1-y+BPWUppheryf3+PCyo6z2+dVi0=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.3.tgz",
+      "integrity": "sha512-gVCSW2StFfuHZYfh/p/HJpdTyB/YX/mr/EATvmw9zMQa6BSUioG4hg4duKEKc47OaXioikzhgFYS/m4EyLmXXg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.0",
+        "define-property": "1.0.0",
+        "extend-shallow": "2.0.1",
+        "extglob": "2.0.2",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.0",
+        "nanomatch": "1.2.5",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
+      }
+    },
+    "miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
+      }
+    },
+    "mime": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.0.3.tgz",
+      "integrity": "sha512-TrpAd/vX3xaLPDgVRm6JkZwLR0KHfukMdU2wTEbqMDdCnY6Yo3mE+mjs9YE6oMNw2QRfXVeBEYpmpO94BIqiug==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "dev": true
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
+      "requires": {
+        "dom-walk": "0.1.1"
+      }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
+      "dev": true
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mitt": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.1.2.tgz",
+      "integrity": "sha1-OA5hSA1qYVtmDwertg1R4KTkvtY=",
+      "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+      "integrity": "sha1-0CuMb4ttS49ZgtP9AJxJGYUcP+I=",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "0.1.1"
+      }
+    },
+    "mixin-object": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+      "dev": true,
+      "requires": {
+        "for-in": "0.1.8",
+        "is-extendable": "0.1.1"
+      },
+      "dependencies": {
+        "for-in": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
+          "dev": true
+        }
+      }
+    },
+    "mixpanel": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/mixpanel/-/mixpanel-0.7.0.tgz",
+      "integrity": "sha1-KXGqbhmmJi98hfwi4RVPT14vYW8=",
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "1.0.0"
+      }
+    },
+    "mixpanel-browser": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.13.0.tgz",
+      "integrity": "sha1-61JsjTT4FnWV36oPOJT8ZZU0Gu8="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
+      }
+    },
+    "mocha-junit-reporter": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-1.15.0.tgz",
+      "integrity": "sha1-MJ9LeiD82ibQrWnJt9CAjXcjAsI=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "md5": "2.2.1",
+        "mkdirp": "0.5.1",
+        "xml": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "mocha-webpack": {
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/mocha-webpack/-/mocha-webpack-1.0.0-rc.1.tgz",
+      "integrity": "sha512-9e0whjKF+NpmT1qM5nQ+iUkS314Sw8UJcxFUr3iMP2epTG/JJj/kscQWGgf8V1BK9kvxuePw3jU6db+M5r82Uw==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "chalk": "1.1.3",
+        "chokidar": "1.7.0",
+        "glob-parent": "2.0.0",
+        "globby": "6.1.0",
+        "interpret": "1.0.4",
+        "is-glob": "2.0.1",
+        "loader-utils": "1.1.0",
+        "lodash": "4.17.4",
+        "memory-fs": "0.4.1",
+        "nodent-runtime": "3.0.4",
+        "normalize-path": "2.1.1",
+        "progress": "1.1.8",
+        "source-map-support": "0.4.18",
+        "toposort": "1.0.6",
+        "yargs": "4.8.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "1.1.0"
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "progress": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.4.18",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+          "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+          "dev": true,
+          "requires": {
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "lodash.assign": "4.2.0",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
+          }
+        }
+      }
+    },
+    "moment": {
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz",
+      "integrity": "sha1-VtoaLRy/AdOLfhr8McELz6GSkWc="
+    },
+    "morgan": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
+      "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
+      "dev": true,
+      "requires": {
+        "basic-auth": "2.0.0",
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multicast-dns": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.1.tgz",
+      "integrity": "sha1-bn3oalcIcqsXBYrepxYLvsqBTd4=",
+      "dev": true,
+      "requires": {
+        "dns-packet": "1.2.2",
+        "thunky": "0.1.0"
+      }
+    },
+    "multicast-dns-service-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+      "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
+    },
+    "nanomatch": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.5.tgz",
+      "integrity": "sha512-ZHJamn1utzcUvW8Bais+Kk7pobp6dKmUEKOSQ/HI2glGwOMA/GvjRRKlLyORBUrdRXnwTU/6LIBcW7jYSlutgg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "is-odd": "1.0.0",
+        "kind-of": "5.1.0",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
+    },
+    "node-abi": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz",
+      "integrity": "sha512-6oxV13poCOv7TfGvhsSz6XZWpXeKkdGVh72++cs33OfMh3KAX8lN84dCvmqSETyDXAFcUHtV7eJrgFBoOqZbNQ==",
+      "dev": true
+    },
+    "node-emoji": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
+      "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
+      "dev": true,
+      "requires": {
+        "lodash.toarray": "4.4.0"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
+    },
+    "node-forge": {
+      "version": "0.6.33",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.33.tgz",
+      "integrity": "sha1-RjgRh59XPUUVWtap9D3ClujoXrw=",
+      "dev": true
+    },
+    "node-gyp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+      "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
+      "dev": true,
+      "requires": {
+        "fstream": "1.0.11",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "npmlog": "4.1.2",
+        "osenv": "0.1.4",
+        "request": "2.83.0",
+        "rimraf": "2.6.2",
+        "semver": "5.3.0",
+        "tar": "2.2.1",
+        "which": "1.3.0"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.1.1"
+          }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        }
+      }
+    },
+    "node-libs-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
+      "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+      "dev": true,
+      "requires": {
+        "assert": "1.4.1",
+        "browserify-zlib": "0.1.4",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.11.1",
+        "domain-browser": "1.1.7",
+        "events": "1.1.1",
+        "https-browserify": "0.0.1",
+        "os-browserify": "0.2.1",
+        "path-browserify": "0.0.0",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.3",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.7.2",
+        "string_decoder": "0.10.31",
+        "timers-browserify": "2.0.4",
+        "tty-browserify": "0.0.0",
+        "url": "0.11.0",
+        "util": "0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+          "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+          "dev": true
+        },
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "dev": true,
+          "requires": {
+            "base64-js": "1.2.1",
+            "ieee754": "1.1.8",
+            "isarray": "1.0.0"
+          }
+        },
+        "crypto-browserify": {
+          "version": "3.11.1",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+          "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+          "dev": true,
+          "requires": {
+            "browserify-cipher": "1.0.0",
+            "browserify-sign": "4.0.4",
+            "create-ecdh": "4.0.0",
+            "create-hash": "1.1.3",
+            "create-hmac": "1.1.6",
+            "diffie-hellman": "5.0.2",
+            "inherits": "2.0.3",
+            "pbkdf2": "3.0.14",
+            "public-encrypt": "4.0.0",
+            "randombytes": "2.0.5"
+          }
+        },
+        "process": {
+          "version": "0.11.10",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "url": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+          "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+          "dev": true,
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+              "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "node-pre-gyp": {
+      "version": "0.6.38",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.38.tgz",
+      "integrity": "sha1-6Sog+DQWQVu0CG9tH7eLPac9ET0=",
+      "requires": {
+        "hawk": "3.1.3",
+        "mkdirp": "0.5.1",
+        "nopt": "4.0.1",
+        "npmlog": "4.1.2",
+        "rc": "1.2.2",
+        "request": "2.81.0",
+        "rimraf": "2.6.2",
+        "semver": "5.4.1",
+        "tar": "2.2.1",
+        "tar-pack": "3.4.1"
+      },
+      "dependencies": {
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          }
+        }
+      }
+    },
+    "node-sass": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
+      "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
+      "dev": true,
+      "requires": {
+        "async-foreach": "0.1.3",
+        "chalk": "1.1.3",
+        "cross-spawn": "3.0.1",
+        "gaze": "1.1.2",
+        "get-stdin": "4.0.1",
+        "glob": "7.1.2",
+        "in-publish": "2.0.0",
+        "lodash.assign": "4.2.0",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.mergewith": "4.6.0",
+        "meow": "3.7.0",
+        "mkdirp": "0.5.1",
+        "nan": "2.7.0",
+        "node-gyp": "3.6.2",
+        "npmlog": "4.1.2",
+        "request": "2.83.0",
+        "sass-graph": "2.2.4",
+        "stdout-stream": "1.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "nodent-runtime": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/nodent-runtime/-/nodent-runtime-3.0.4.tgz",
+      "integrity": "sha1-qAHst7sPbDmmmyTML6Nwz6i0kto=",
+      "dev": true
+    },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
+      "dev": true
+    },
+    "nopt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+      "requires": {
+        "abbrev": "1.1.1",
+        "osenv": "0.1.4"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.4.1",
+        "validate-npm-package-license": "3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+      "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+      "dev": true
+    },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true
+    },
+    "normalize-url": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "prepend-http": "1.0.4",
+        "query-string": "4.3.4",
+        "sort-keys": "1.1.2"
+      }
+    },
+    "npm-install-package": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/npm-install-package/-/npm-install-package-2.1.0.tgz",
+      "integrity": "sha1-1+/jz816sAYUuJbqUxGdyaslkSU=",
+      "dev": true
+    },
+    "npm-path": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
+      "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
+      "dev": true,
+      "requires": {
+        "which": "1.3.0"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "2.0.1"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "2.11.0",
+        "npm-path": "2.0.3",
+        "which": "1.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        }
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
+    },
+    "nugget": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
+      "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "minimist": "1.2.0",
+        "pretty-bytes": "1.0.4",
+        "progress-stream": "1.2.0",
+        "request": "2.83.0",
+        "single-line-log": "1.1.2",
+        "throttleit": "0.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "null-loader": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/null-loader/-/null-loader-0.1.1.tgz",
+      "integrity": "sha1-F76av80/8OFRL2/Er8sfUDk3j64=",
+      "dev": true
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "nwmatcher": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
+      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
+      }
+    },
+    "object-keys": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+      "dev": true
+    },
+    "object-path": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
+      "integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU=",
+      "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "obuf": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
+      "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4=",
+      "dev": true
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
+    "opn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
+      "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
+      "dev": true,
+      "requires": {
+        "is-wsl": "1.1.0"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "ora": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "original": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
+      "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
+      "dev": true,
+      "requires": {
+        "url-parse": "1.0.5"
+      },
+      "dependencies": {
+        "querystringify": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+          "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw=",
+          "dev": true
+        },
+        "url-parse": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+          "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
+          "dev": true,
+          "requires": {
+            "querystringify": "0.0.4",
+            "requires-port": "1.0.0"
+          }
+        }
+      }
+    },
+    "os-browserify": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+      "integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=",
+      "dev": true
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-locale": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "dev": true,
+      "requires": {
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+      "dev": true
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.1.0"
+      }
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
+    "package-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "dev": true,
+      "requires": {
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.1",
+        "registry-url": "3.1.0",
+        "semver": "5.4.1"
+      }
+    },
+    "pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+      "dev": true
+    },
+    "parse-asn1": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+      "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+      "dev": true,
+      "requires": {
+        "asn1.js": "4.9.1",
+        "browserify-aes": "1.1.1",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.14"
+      }
+    },
+    "parse-color": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
+      "integrity": "sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=",
+      "dev": true,
+      "requires": {
+        "color-convert": "0.5.3"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
+          "dev": true
+        }
+      }
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true,
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        }
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
+    "parse5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.2.tgz",
+      "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA=",
+      "dev": true,
+      "requires": {
+        "@types/node": "6.0.90"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "6.0.90",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.90.tgz",
+          "integrity": "sha512-tXoGRVdi7wZX7P1VWoV9Wfk0uYDOAHdEYXAttuWgSrN76Q32wQlSrMX0Rgyv3RTEaQY2ZLQrzYHVM2e8rfo8sA==",
+          "dev": true
+        }
+      }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.1.0.tgz",
+      "integrity": "sha512-dZY7QPCPp5r9cnNuQ955mOv4ZFVDXY/yvqeV7Y1W2PJA3PEFcuow9xKFfJxbBj1pIjOAP+M2B4/7xubmykLrXw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "pbkdf2": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
+      "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+      "dev": true,
+      "requires": {
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.9"
+      }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
+    "performance-now": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
+    },
+    "plist": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
+      "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
+      "dev": true,
+      "requires": {
+        "base64-js": "1.2.0",
+        "xmlbuilder": "8.2.2",
+        "xmldom": "0.1.27"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+          "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
+          "dev": true
+        }
+      }
+    },
+    "pluralize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "dev": true
+    },
+    "pn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.0.0.tgz",
+      "integrity": "sha1-HPWjCw2AbNGPiPxBprXUrWFbO6k=",
+      "dev": true
+    },
+    "portfinder": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
+      "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "postcss": {
+      "version": "5.2.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+      "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "js-base64": "2.3.2",
+        "source-map": "0.5.7",
+        "supports-color": "3.2.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-calc": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+      "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-css-calc": "1.3.0"
+      }
+    },
+    "postcss-colormin": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+      "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+      "dev": true,
+      "requires": {
+        "colormin": "1.1.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-convert-values": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+      "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-discard-comments": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+      "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-discard-duplicates": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+      "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-discard-empty": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+      "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-discard-overridden": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+      "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-discard-unused": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+      "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
+      }
+    },
+    "postcss-filter-plugins": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+      "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "uniqid": "4.1.1"
+      }
+    },
+    "postcss-merge-idents": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+      "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-merge-longhand": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+      "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-merge-rules": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+      "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+      "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-api": "1.6.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3",
+        "vendors": "1.0.1"
+      }
+    },
+    "postcss-message-helpers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+      "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
+      "dev": true
+    },
+    "postcss-minify-font-values": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+      "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-minify-gradients": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+      "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-minify-params": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+      "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "uniqs": "2.0.0"
+      }
+    },
+    "postcss-minify-selectors": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+      "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3"
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
+      "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
+      "dev": true,
+      "requires": {
+        "postcss": "6.0.13"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
+          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "source-map": "0.6.1",
+            "supports-color": "4.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+      "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.13"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
+          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "source-map": "0.6.1",
+            "supports-color": "4.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+      "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.13"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
+          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "source-map": "0.6.1",
+            "supports-color": "4.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-values": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+      "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+      "dev": true,
+      "requires": {
+        "icss-replace-symbols": "1.1.0",
+        "postcss": "6.0.13"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
+          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "source-map": "0.6.1",
+            "supports-color": "4.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "postcss-normalize-charset": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+      "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-normalize-url": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+      "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+      "dev": true,
+      "requires": {
+        "is-absolute-url": "2.1.0",
+        "normalize-url": "1.9.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-ordered-values": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+      "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-prefix-selector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.6.0.tgz",
+      "integrity": "sha1-tJWUnWOcYxRxRWSDJoUyFvPBCQA=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-reduce-idents": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+      "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-reduce-initial": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+      "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-reduce-transforms": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+      "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+      "dev": true,
+      "requires": {
+        "flatten": "1.0.2",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
+      }
+    },
+    "postcss-svgo": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+      "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+      "dev": true,
+      "requires": {
+        "is-svg": "2.1.0",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "svgo": "0.7.2"
+      }
+    },
+    "postcss-unique-selectors": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+      "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+      "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
+      "dev": true
+    },
+    "postcss-zindex": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+      "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
+      }
+    },
+    "posthtml": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.9.2.tgz",
+      "integrity": "sha1-9MBtufZ7Yf0XxOJW5+PZUVv3Jv0=",
+      "dev": true,
+      "requires": {
+        "posthtml-parser": "0.2.1",
+        "posthtml-render": "1.0.6"
+      }
+    },
+    "posthtml-parser": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.2.1.tgz",
+      "integrity": "sha1-NdUw3jhnQMK6JP8usvrznM3ycd0=",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "3.9.2",
+        "isobject": "2.1.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        }
+      }
+    },
+    "posthtml-rename-id": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/posthtml-rename-id/-/posthtml-rename-id-1.0.3.tgz",
+      "integrity": "sha512-zaaHJSTihw1fsx2L81npO6gmDYu4yZuHfRX89IsJDhcRIV1P8SKJY5m1xDRZQh542flidwNS+70/pVAK8yMYOA==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
+    },
+    "posthtml-render": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.0.6.tgz",
+      "integrity": "sha1-G4i454YKjr3+LyoTEKRkKlXPW9o=",
+      "dev": true
+    },
+    "posthtml-svg-mode": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/posthtml-svg-mode/-/posthtml-svg-mode-1.0.2.tgz",
+      "integrity": "sha512-yH4w0CULTg6v3YW5hVUY2z14R+11XWvtxMRqk30FDgxg0JWv+BhS9FLtKNIu858/1mrO1NcIC4heb6IezLAfHw==",
+      "dev": true,
+      "requires": {
+        "merge-options": "0.0.64",
+        "posthtml": "0.9.2",
+        "posthtml-parser": "0.2.1",
+        "posthtml-render": "1.0.6"
+      }
+    },
+    "prebuild-install": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.3.0.tgz",
+      "integrity": "sha512-gzjq2oHB8oMbzJSsSh9MQ64zrXZGt092/uT4TLZlz2qnrPxpWqp4vYB7LZrDxnlxf5RfbCjkgDI/z0EIVuYzAw==",
+      "dev": true,
+      "requires": {
+        "expand-template": "1.1.0",
+        "github-from-package": "0.0.0",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "node-abi": "2.1.1",
+        "noop-logger": "0.1.1",
+        "npmlog": "4.1.2",
+        "os-homedir": "1.0.2",
+        "pump": "1.0.2",
+        "rc": "1.2.2",
+        "simple-get": "1.4.3",
+        "tar-fs": "1.16.0",
+        "tunnel-agent": "0.6.0",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.7.4.tgz",
+      "integrity": "sha1-XoYkrpNjyA+V7GRFhOzfVddPk/o=",
+      "dev": true
+    },
+    "pretty-bytes": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+      "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0"
+      }
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        }
+      }
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
+    "process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+    },
+    "progress-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
+      "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
+      "dev": true,
+      "requires": {
+        "speedometer": "0.1.4",
+        "through2": "0.2.3"
+      }
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "promptly": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/promptly/-/promptly-2.2.0.tgz",
+      "integrity": "sha1-KhP6BjaIoqWYOxYf/wEIoH0m/HQ=",
+      "dev": true,
+      "requires": {
+        "read": "1.0.7"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
+    },
+    "proxy-addr": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+      "dev": true,
+      "requires": {
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.5.2"
+      }
+    },
+    "prr": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "public-encrypt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+      "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "parse-asn1": "5.1.0",
+        "randombytes": "2.0.5"
+      }
+    },
+    "pump": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
+      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.0",
+        "once": "1.4.0"
+      }
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
+      }
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
+    "querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+      "dev": true
+    },
+    "querystringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+      "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
+    },
+    "rabin-bindings": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/rabin-bindings/-/rabin-bindings-1.7.3.tgz",
+      "integrity": "sha512-zeVdstq+EWdwQ5JCyuuvOsP2fmGc6993laN+v8eEQsahHwZCy8bt5TefohUpgsetiwQhMMk/o+m/2sYng13Txw==",
+      "dev": true,
+      "requires": {
+        "bindings": "1.3.0",
+        "nan": "2.7.0",
+        "prebuild-install": "2.3.0"
+      }
+    },
+    "randomatic": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
+      }
+    },
+    "randombytes": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
+      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      }
+    },
+    "rc": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
+      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "react": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
+      "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+      "requires": {
+        "create-react-class": "15.6.2",
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
+      }
+    },
+    "react-addons-css-transition-group": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react-addons-css-transition-group/-/react-addons-css-transition-group-15.6.2.tgz",
+      "integrity": "sha1-nkN2vPQLUhfRTsaFUwgc7ksIptY=",
+      "requires": {
+        "react-transition-group": "1.2.1"
+      }
+    },
+    "react-addons-transition-group": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react-addons-transition-group/-/react-addons-transition-group-15.6.2.tgz",
+      "integrity": "sha1-i668Kukczb8kX+Kcn9PTb4tHGSM=",
+      "requires": {
+        "react-transition-group": "1.2.1"
+      }
+    },
+    "react-deep-force-update": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz",
+      "integrity": "sha1-jqQmPNZFWgULN0RbPwj9g52G6Qk=",
+      "dev": true
+    },
+    "react-dom": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
+      "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+      "dev": true,
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
+      }
+    },
+    "react-draggable": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-3.0.3.tgz",
+      "integrity": "sha512-ekb3dKvZFC6QaBNBpAWwGk9aoaDPkSVkrZl/LEU92THoX72Pv6uQ2ZpfYjmBrbrTQcAYmuUAkp9pHJ7j8FUYJA==",
+      "requires": {
+        "classnames": "2.2.5",
+        "prop-types": "15.6.0"
+      }
+    },
+    "react-hot-loader": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-3.1.1.tgz",
+      "integrity": "sha512-TxvSs1KN+YZxdXIX5sq0AKEy8dBdyiUE9nK9ML4Op6S06tkvNAg51V8OSvlQemCQkOfk8gTc5O8azUCvV4vTUw==",
+      "dev": true,
+      "requires": {
+        "global": "4.3.2",
+        "react-deep-force-update": "2.1.1",
+        "react-proxy": "3.0.0-alpha.1",
+        "redbox-react": "1.5.0",
+        "source-map": "0.6.1"
+      }
+    },
+    "react-proxy": {
+      "version": "3.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz",
+      "integrity": "sha1-RABCa8+oDKpnJMd1VpUxUgn6Swc=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "react-sortable-hoc": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-0.6.8.tgz",
+      "integrity": "sha512-sUUAtNdV84AKZ2o+F5lVOOFWcyWG6aGDkNFgHoieB1zFLeWLWENkix06asPS4/GhigfuRh06aZix1j3Qx8+NSQ==",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4",
+        "prop-types": "15.6.0"
+      }
+    },
+    "react-transition-group": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
+      "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
+      "requires": {
+        "chain-function": "1.0.0",
+        "dom-helpers": "3.2.1",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.0",
+        "warning": "3.0.0"
+      }
+    },
+    "react-virtualized": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.12.0.tgz",
+      "integrity": "sha512-QxqGUq7vktRsPnV/FclAGQ943rIYizTe9RIuyJGE75/3BA/7KJPXwXCQ9XW/3pnPKix+Jar0CCo3uTqoA4hFOg==",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "classnames": "2.2.5",
+        "dom-helpers": "3.2.1",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.0"
+      }
+    },
+    "reactstrap": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-4.8.0.tgz",
+      "integrity": "sha1-6zUGQqYoLHnH4b2Nb3XGJxMaQvY=",
+      "requires": {
+        "classnames": "2.2.5",
+        "lodash.isfunction": "3.0.8",
+        "lodash.isobject": "3.0.2",
+        "lodash.tonumber": "4.0.3",
+        "prop-types": "15.6.0",
+        "reactstrap-tether": "1.3.4"
+      }
+    },
+    "reactstrap-tether": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/reactstrap-tether/-/reactstrap-tether-1.3.4.tgz",
+      "integrity": "sha1-htlNMCFv+jTOssYm9LmRLA0ZOJQ="
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "requires": {
+        "mute-stream": "0.0.7"
+      }
+    },
+    "read-config-file": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-1.2.0.tgz",
+      "integrity": "sha512-A1MNfKNIfYV7vXMOQ/CPCuVpCdWoPULu8whmrkKxwN8FUsv6EjwU2SPSNueeTKR6tZPl7+Qeondyb4/pAcoozQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.3.0",
+        "ajv-keywords": "2.1.0",
+        "bluebird-lst": "1.0.5",
+        "dotenv": "4.0.0",
+        "dotenv-expand": "4.0.1",
+        "fs-extra-p": "4.4.4",
+        "js-yaml": "3.10.0",
+        "json5": "0.5.1",
+        "lazy-val": "1.0.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+          "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "readdirp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.3",
+        "set-immediate-shim": "1.0.1"
+      }
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      },
+      "dependencies": {
+        "mute-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+          "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+          "dev": true
+        }
+      }
+    },
+    "realm": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-2.0.0.tgz",
+      "integrity": "sha1-IhCqXFgxtGgS/8w1gpTwSFsnvrc=",
+      "requires": {
+        "command-line-args": "4.0.7",
+        "decompress": "4.2.0",
+        "decompress-tarxz": "2.1.1",
+        "fs-extra": "4.0.2",
+        "ini": "1.3.4",
+        "nan": "2.7.0",
+        "node-fetch": "1.7.3",
+        "node-pre-gyp": "0.6.38",
+        "progress": "2.0.0",
+        "prop-types": "15.6.0",
+        "request": "2.83.0",
+        "stream-counter": "1.0.0",
+        "sync-request": "3.0.1",
+        "url-parse": "1.1.9"
+      }
+    },
+    "realm-object-server": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/realm-object-server/-/realm-object-server-2.0.6.tgz",
+      "integrity": "sha1-Y/nlxRZFV9veKI359oFuFbV7yjo=",
+      "dev": true,
+      "requires": {
+        "@types/bcrypt": "1.0.0",
+        "@types/body-parser": "1.16.6",
+        "@types/colors": "1.1.3",
+        "@types/commander": "2.11.0",
+        "@types/del": "3.0.0",
+        "@types/express": "4.0.37",
+        "@types/faker": "4.1.1",
+        "@types/fs-extra": "4.0.3",
+        "@types/http-proxy": "1.12.2",
+        "@types/jsonwebtoken": "7.2.3",
+        "@types/lodash": "4.14.79",
+        "@types/morgan": "1.7.34",
+        "@types/promptly": "1.1.28",
+        "@types/proxyquire": "1.3.28",
+        "@types/superagent": "3.5.6",
+        "@types/tmp": "0.0.33",
+        "@types/urijs": "1.15.34",
+        "@types/uuid": "3.4.3",
+        "@types/uws": "0.13.0",
+        "bcrypt": "1.0.3",
+        "body-parser": "1.18.2",
+        "circular-buffer": "1.0.2",
+        "colors": "1.1.2",
+        "commander": "2.11.0",
+        "express": "4.16.2",
+        "fs-extra": "4.0.2",
+        "http-proxy": "1.16.2",
+        "JSONStream": "1.3.1",
+        "jsonwebtoken": "7.4.3",
+        "lodash": "4.17.4",
+        "minimist": "1.2.0",
+        "mixpanel": "0.7.0",
+        "moment": "2.19.1",
+        "morgan": "1.9.0",
+        "npm-which": "3.0.1",
+        "path-to-regexp": "2.1.0",
+        "promptly": "2.2.0",
+        "realm": "2.0.1",
+        "realm-one": "1.12.0",
+        "realm-sync-server": "https://s3.amazonaws.com/static.realm.io/downloads/node/realm-sync-server-2.1.0.tgz",
+        "semver": "5.4.1",
+        "superagent": "3.8.0",
+        "tmp": "0.0.33",
+        "urijs": "1.19.0",
+        "ursa": "0.9.4",
+        "uuid": "3.1.0",
+        "uws": "8.14.1",
+        "winston": "2.4.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ajv": {
+          "version": "5.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "json-schema-traverse": "0.3.1",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.3"
+          }
+        },
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "bundled": true,
+          "dev": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-stream": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.3",
+            "typedarray": "0.0.6"
+          }
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "iconv-lite": "0.4.19"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "extract-zip": {
+          "version": "1.6.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "concat-stream": "1.6.0",
+            "debug": "2.2.0",
+            "mkdirp": "0.5.0",
+            "yauzl": "2.4.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ms": "0.7.1"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "0.7.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fbjs": {
+          "version": "0.8.16",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.17"
+          }
+        },
+        "fd-slicer": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pend": "1.2.0"
+          }
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ajv": "5.2.4",
+            "har-schema": "2.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-basic": {
+          "version": "2.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "caseless": "0.11.0",
+            "concat-stream": "1.6.0",
+            "http-response-object": "1.1.0"
+          }
+        },
+        "http-response-object": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "node-fetch": "1.7.3",
+            "whatwg-fetch": "2.0.3"
+          }
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "mime-db": {
+          "version": "1.30.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.30.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "nan": {
+          "version": "2.7.0",
+          "bundled": true,
+          "dev": true
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "encoding": "0.1.12",
+            "is-stream": "1.1.0"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.6.38",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.2",
+            "rc": "1.2.2",
+            "request": "2.81.0",
+            "rimraf": "2.6.2",
+            "semver": "5.4.1",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "4.11.8",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
+              }
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true,
+              "dev": true
+            },
+            "har-schema": {
+              "version": "1.0.5",
+              "bundled": true,
+              "dev": true
+            },
+            "har-validator": {
+              "version": "4.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ajv": "4.11.8",
+                "har-schema": "1.0.5"
+              }
+            },
+            "performance-now": {
+              "version": "0.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "qs": {
+              "version": "6.4.0",
+              "bundled": true,
+              "dev": true
+            },
+            "request": {
+              "version": "2.81.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.1.0"
+              }
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+              }
+            }
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "pend": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "promise": {
+          "version": "7.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asap": "2.0.6"
+          }
+        },
+        "prop-types": {
+          "version": "15.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "querystringify": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "rc": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "realm": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/realm/-/realm-2.0.1.tgz",
+          "integrity": "sha1-/pcAq4c3V8BpaMgIobnJozX7a6M=",
+          "dev": true,
+          "requires": {
+            "command-line-args": "4.0.7",
+            "decompress": "4.2.0",
+            "decompress-tarxz": "2.1.1",
+            "fs-extra": "4.0.2",
+            "ini": "1.3.4",
+            "nan": "2.7.0",
+            "node-fetch": "1.7.3",
+            "node-pre-gyp": "0.6.38",
+            "progress": "2.0.0",
+            "prop-types": "15.6.0",
+            "request": "2.83.0",
+            "stream-counter": "1.0.0",
+            "sync-request": "3.0.1",
+            "url-parse": "1.1.9"
+          }
+        },
+        "realm-one": {
+          "version": "1.12.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "realm": "1.12.0"
+          },
+          "dependencies": {
+            "realm": {
+              "version": "1.12.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "extract-zip": "1.6.5",
+                "ini": "1.3.4",
+                "nan": "2.7.0",
+                "node-fetch": "1.7.3",
+                "node-pre-gyp": "0.6.38",
+                "prop-types": "15.6.0",
+                "request": "2.83.0",
+                "sync-request": "3.0.1",
+                "url-parse": "1.1.9"
+              }
+            }
+          }
+        },
+        "realm-sync-server": {
+          "version": "https://s3.amazonaws.com/static.realm.io/downloads/node/realm-sync-server-2.1.0.tgz",
+          "integrity": "sha1-7k8OCdNu/GsXNuc1svO06+BLs6g=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.83.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.1",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          },
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.7.0",
+              "bundled": true,
+              "dev": true
+            },
+            "boom": {
+              "version": "4.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true,
+              "dev": true
+            },
+            "cryptiles": {
+              "version": "3.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "boom": "5.2.0"
+              },
+              "dependencies": {
+                "boom": {
+                  "version": "5.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "hoek": "4.2.0"
+                  }
+                }
+              }
+            },
+            "form-data": {
+              "version": "2.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
+              }
+            },
+            "hawk": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.0",
+                "sntp": "2.0.2"
+              }
+            },
+            "hoek": {
+              "version": "4.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "http-signature": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+              }
+            },
+            "sntp": {
+              "version": "2.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            }
+          }
+        },
+        "requires-port": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "sync-request": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "concat-stream": "1.6.0",
+            "http-response-object": "1.1.0",
+            "then-request": "2.2.0"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.3.3",
+            "rimraf": "2.6.2",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          },
+          "dependencies": {
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+              }
+            }
+          }
+        },
+        "then-request": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "caseless": "0.11.0",
+            "concat-stream": "1.6.0",
+            "http-basic": "2.5.1",
+            "http-response-object": "1.1.0",
+            "promise": "7.3.1",
+            "qs": "6.5.1"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "ua-parser-js": {
+          "version": "0.7.17",
+          "bundled": true,
+          "dev": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "url-parse": {
+          "version": "1.1.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "querystringify": "1.0.0",
+            "requires-port": "1.0.0"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "1.3.0"
+          }
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yauzl": {
+          "version": "2.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fd-slicer": "1.0.1"
+          }
+        }
+      }
+    },
+    "recast": {
+      "version": "0.11.23",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+      "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+      "dev": true,
+      "requires": {
+        "ast-types": "0.9.6",
+        "esprima": "3.1.3",
+        "private": "0.1.8",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "redbox-react": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/redbox-react/-/redbox-react-1.5.0.tgz",
+      "integrity": "sha512-mdxArOI3sF8K5Nay5NG+lv/VW516TbXjjd4h1wcV1Iy4IMDQPnCayjoQXBAycAFSME4nyXRUXCjHxsw2rYpVRw==",
+      "dev": true,
+      "requires": {
+        "error-stack-parser": "1.3.6",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0",
+        "sourcemapped-stacktrace": "1.1.7"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
+      }
+    },
+    "reduce-css-calc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "0.4.2",
+        "math-expression-evaluator": "1.2.17",
+        "reduce-function-call": "1.0.2"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "dev": true
+        }
+      }
+    },
+    "reduce-function-call": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+      "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "0.4.2"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "dev": true
+        }
+      }
+    },
+    "regenerate": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+      "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "0.1.3"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
+      "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1"
+      }
+    },
+    "regex-parser": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.8.tgz",
+      "integrity": "sha1-2kwM2lqChVkJQWiTD0VfUytv+6w=",
+      "dev": true
+    },
+    "regexpu-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+      "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+      "dev": true,
+      "requires": {
+        "regenerate": "1.3.3",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      }
+    },
+    "registry-auth-token": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+      "dev": true,
+      "requires": {
+        "rc": "1.2.2",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
+      "requires": {
+        "rc": "1.2.2"
+      }
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
+      "requires": {
+        "jsesc": "0.5.0"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
+    "request": {
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+          "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "boom": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            }
+          }
+        },
+        "form-data": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "5.3.0",
+            "har-schema": "2.0.0"
+          }
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.0",
+            "sntp": "2.0.2"
+          }
+        },
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+        },
+        "sntp": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
+          "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.3"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "resolve-url-loader": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-2.1.1.tgz",
+      "integrity": "sha512-ZrMHMPJ8boX5peNuuHfw/waNpWAgvEj8+f8mEE/W61tC9L4NcyEBnruK7LsKamnNTbf0gUoJdPmV1okjSUVJgA==",
+      "dev": true,
+      "requires": {
+        "adjust-sourcemap-loader": "1.1.0",
+        "camelcase": "4.1.0",
+        "convert-source-map": "1.5.0",
+        "loader-utils": "1.1.0",
+        "lodash.defaults": "4.2.0",
+        "rework": "1.0.1",
+        "rework-visit": "1.0.0",
+        "source-map": "0.5.7",
+        "urix": "0.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
+    },
+    "rework": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rework/-/rework-1.0.1.tgz",
+      "integrity": "sha1-MIBqhBNCtUUQqkEQhQzUhTQUSqc=",
+      "dev": true,
+      "requires": {
+        "convert-source-map": "0.3.5",
+        "css": "2.2.1"
+      },
+      "dependencies": {
+        "convert-source-map": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+          "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA=",
+          "dev": true
+        }
+      }
+    },
+    "rework-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rework-visit/-/rework-visit-1.0.0.tgz",
+      "integrity": "sha1-mUWygD8hni96ygCtuLyfZA+ELJo=",
+      "dev": true
+    },
+    "rgb2hex": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.0.tgz",
+      "integrity": "sha1-zNVfhgrgxcTqN1BLlY5ELY0SMls=",
+      "dev": true
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "ripemd160": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+      "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+      "dev": true,
+      "requires": {
+        "hash-base": "2.0.2",
+        "inherits": "2.0.3"
+      }
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
+    "rx": {
+      "version": "2.3.24",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-2.3.24.tgz",
+      "integrity": "sha1-FPlQpCF9fjXapxu8vljv9o6ksrc=",
+      "dev": true
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "rxjs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.1.tgz",
+      "integrity": "sha512-LmsJqk/i5D3e9eD7WR0v1XkHos2Rjo6qJkmVK7k6r74UZnesqcyVl6xTado4FxdjuNKWexnJJF6U8rCCz8BaFw==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.4"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sanitize-filename": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
+      "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
+      "dev": true,
+      "requires": {
+        "truncate-utf8-bytes": "1.0.2"
+      }
+    },
+    "sass-graph": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "scss-tokenizer": "0.2.3",
+        "yargs": "7.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          }
+        }
+      }
+    },
+    "sass-lint": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/sass-lint/-/sass-lint-1.12.1.tgz",
+      "integrity": "sha1-Yw9pwhaqIGuCMvsqqQe98zNrbYM=",
+      "dev": true,
+      "requires": {
+        "commander": "2.8.1",
+        "eslint": "2.13.1",
+        "front-matter": "2.1.2",
+        "fs-extra": "3.0.1",
+        "glob": "7.1.2",
+        "globule": "1.2.0",
+        "gonzales-pe-sl": "4.2.3",
+        "js-yaml": "3.10.0",
+        "known-css-properties": "0.3.0",
+        "lodash.capitalize": "4.2.1",
+        "lodash.kebabcase": "4.1.1",
+        "merge": "1.2.0",
+        "path-is-absolute": "1.0.1",
+        "util": "0.10.3"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+          "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "3.0.1",
+            "universalify": "0.1.1"
+          }
+        },
+        "jsonfile": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        }
+      }
+    },
+    "sass-loader": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.6.tgz",
+      "integrity": "sha512-c3/Zc+iW+qqDip6kXPYLEgsAu2lf4xz0EZDplB7EmSUMda12U1sGJPetH55B/j9eu0bTtKzKlNPWWyYC7wFNyQ==",
+      "dev": true,
+      "requires": {
+        "async": "2.5.0",
+        "clone-deep": "0.3.0",
+        "loader-utils": "1.1.0",
+        "lodash.tail": "4.1.1",
+        "pify": "3.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "schema-utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+      "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+      "dev": true,
+      "requires": {
+        "ajv": "5.3.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+          "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
+      }
+    },
+    "scss-tokenizer": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+      "dev": true,
+      "requires": {
+        "js-base64": "2.3.2",
+        "source-map": "0.4.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "seek-bzip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+      "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+      "requires": {
+        "commander": "2.8.1"
+      }
+    },
+    "select-hose": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+      "dev": true
+    },
+    "selfsigned": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.1.tgz",
+      "integrity": "sha1-v4y3uDJWxFUeMTR8YxF3jbme7FI=",
+      "dev": true,
+      "requires": {
+        "node-forge": "0.6.33"
+      }
+    },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+    },
+    "semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
+      "requires": {
+        "semver": "5.4.1"
+      }
+    },
+    "send": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "dev": true
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
+        }
+      }
+    },
+    "serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.2",
+        "mime-types": "2.1.17",
+        "parseurl": "1.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.16.1"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-getter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+      "dev": true,
+      "requires": {
+        "to-object-path": "0.3.0"
+      }
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "dev": true
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.0.2"
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "setprototypeof": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+      "dev": true
+    },
+    "sha.js": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
+      "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "shallow-clone": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+      "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+      "dev": true,
+      "requires": {
+        "is-extendable": "0.1.1",
+        "kind-of": "2.0.1",
+        "lazy-cache": "0.2.7",
+        "mixin-object": "2.0.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        },
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+          "dev": true
+        }
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-get": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
+      "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "unzip-response": "1.0.2",
+        "xtend": "4.0.1"
+      }
+    },
+    "simple-git": {
+      "version": "1.80.1",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.80.1.tgz",
+      "integrity": "sha1-SBBMtKxyV2k3hT4a/R7v/cl6yyk=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "single-line-log": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
+      "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
+    "snapdragon": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
+      "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+      "dev": true,
+      "requires": {
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
+      }
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "sockjs": {
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
+      "integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
+      "dev": true,
+      "requires": {
+        "faye-websocket": "0.10.0",
+        "uuid": "2.0.3"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+          "dev": true
+        }
+      }
+    },
+    "sockjs-client": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+      "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "eventsource": "0.1.6",
+        "faye-websocket": "0.11.1",
+        "inherits": "2.0.3",
+        "json3": "3.3.2",
+        "url-parse": "1.1.9"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "faye-websocket": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+          "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+          "dev": true,
+          "requires": {
+            "websocket-driver": "0.7.0"
+          }
+        }
+      }
+    },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
+    },
+    "source-list-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+      "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-resolve": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+      "dev": true,
+      "requires": {
+        "atob": "2.0.3",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
+      "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+      "requires": {
+        "source-map": "0.6.1"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sourcemapped-stacktrace": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.7.tgz",
+      "integrity": "sha512-pgHNUACbafkQ+M5zR00NSOtSKBc/i40prgN+SY07J/pghClwVNWNTTMa0JuXj4lriR2TvMKcPAHw5KN9tVFRhA==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.6"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true
+        }
+      }
+    },
+    "spawn-command": {
+      "version": "0.0.2-1",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
+      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+      "dev": true
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
+    },
+    "spdy": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
+      "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "handle-thing": "1.2.5",
+        "http-deceiver": "1.2.7",
+        "safe-buffer": "5.1.1",
+        "select-hose": "2.0.0",
+        "spdy-transport": "2.0.20"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "spdy-transport": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
+      "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "detect-node": "2.0.3",
+        "hpack.js": "2.1.6",
+        "obuf": "1.1.1",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1",
+        "wbuf": "1.7.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "spectron": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/spectron/-/spectron-3.7.2.tgz",
+      "integrity": "sha1-hvQTBqm3DtbuFQD399Otw4mvtEY=",
+      "dev": true,
+      "requires": {
+        "dev-null": "0.1.1",
+        "electron-chromedriver": "1.7.1",
+        "request": "2.83.0",
+        "split": "1.0.1",
+        "webdriverio": "4.8.0"
+      }
+    },
+    "speedometer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
+      "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0=",
+      "dev": true
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "split-string": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.0.2.tgz",
+      "integrity": "sha512-d6myUSfwmBz1izkY4r7r7I0PL41rh21qUDYK1OgclmGHeoqQoujduGxMbzw6BlF3HKmJR4sMpbWVo7/Xzg4YBQ==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
+    },
+    "stackframe": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
+      "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=",
+      "dev": true
+    },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true
+    },
+    "stat-mode": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+      "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
+      "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+      "dev": true
+    },
+    "stdout-stream": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
+      "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
+    "stream-browserify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "stream-counter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-1.0.0.tgz",
+      "integrity": "sha1-kc8lac5NxQYf6816yyY5SloRR1E="
+    },
+    "stream-http": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+      "dev": true,
+      "requires": {
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "stream-to-observable": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz",
+      "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
+      "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "stringify-object": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
+      "integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
+    },
+    "strip-dirs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+      "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+      "requires": {
+        "is-natural-number": "4.0.1"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "style-loader": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.19.0.tgz",
+      "integrity": "sha512-9mx9sC9nX1dgP96MZOODpGC6l1RzQBITI2D5WJhu+wnbrSYVKLGuy14XJSLVQih/0GFrPpjelt+s//VcZQ2Evw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "schema-utils": "0.3.0"
+      }
+    },
+    "sumchecker": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz",
+      "integrity": "sha1-ebs7RFbdBPGOvbwNcDodHa7FEF0=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "es6-promise": "4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "superagent": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.0.tgz",
+      "integrity": "sha512-71XGWgtn70TNwgmgYa69dPOYg55aU9FCahjUNY03rOrKvaTCaU3b9MeZmqonmf9Od96SCxr3vGfEAnhM7dtxCw==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "cookiejar": "2.1.1",
+        "debug": "3.1.0",
+        "extend": "3.0.1",
+        "form-data": "2.3.1",
+        "formidable": "1.1.1",
+        "methods": "1.1.2",
+        "mime": "1.4.1",
+        "qs": "6.5.1",
+        "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        }
+      }
+    },
+    "supports-color": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+      "dev": true,
+      "requires": {
+        "has-flag": "1.0.0"
+      }
+    },
+    "svg-baker": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/svg-baker/-/svg-baker-1.2.16.tgz",
+      "integrity": "sha512-L8ftwzm9ig4TjWrzp1/fZ9j8qo6oDD+COUHmNhhhvb5/FjIT+X0f+1Id9BsQ7eCAmRimFWI72Nzk5etnuLc5hg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "clone": "2.1.1",
+        "he": "1.1.1",
+        "image-size": "0.5.5",
+        "loader-utils": "1.1.0",
+        "merge-options": "0.0.64",
+        "micromatch": "3.1.0",
+        "postcss": "5.2.18",
+        "postcss-prefix-selector": "1.6.0",
+        "posthtml-rename-id": "1.0.3",
+        "posthtml-svg-mode": "1.0.2",
+        "query-string": "4.3.4",
+        "traverse": "0.6.6"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.0.tgz",
+          "integrity": "sha512-3StSelAE+hnRvMs8IdVW7Uhk8CVed5tp+kLLGlBP6WiRAXS21GPGu/Nat4WNPXj2Eoc24B02SaeoyozPMfj0/g==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.0",
+            "define-property": "1.0.0",
+            "extend-shallow": "2.0.1",
+            "extglob": "2.0.2",
+            "fragment-cache": "0.2.1",
+            "kind-of": "5.1.0",
+            "nanomatch": "1.2.5",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.1"
+          }
+        }
+      }
+    },
+    "svg-baker-runtime": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/svg-baker-runtime/-/svg-baker-runtime-1.3.3.tgz",
+      "integrity": "sha512-yDnHhVM+nGxLu+Oj/zG07yUPXmJ7XLmekU2XQqL0jaLUazLjxj61uO8IMyww2roUjdMQo4x+J+KIlAp37qIbZQ==",
+      "dev": true,
+      "requires": {
+        "deepmerge": "1.3.2",
+        "mitt": "1.1.2",
+        "svg-baker": "1.2.16"
+      }
+    },
+    "svg-sprite-loader": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/svg-sprite-loader/-/svg-sprite-loader-3.4.1.tgz",
+      "integrity": "sha512-M6d2JVOXo6eUEpOCF8A4ZDHZRdfiitXiGFJYxXX6F/1f0TE7pedAsZ9NAY+mLnGFrMYn5qc/DqAk2l5ed+rz2A==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "deepmerge": "1.3.2",
+        "domready": "1.0.8",
+        "escape-string-regexp": "1.0.5",
+        "loader-utils": "1.1.0",
+        "svg-baker": "1.2.16",
+        "svg-baker-runtime": "1.3.3",
+        "url-slug": "2.0.0"
+      }
+    },
+    "svgo": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+      "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+      "dev": true,
+      "requires": {
+        "coa": "1.0.4",
+        "colors": "1.1.2",
+        "csso": "2.3.2",
+        "js-yaml": "3.7.0",
+        "mkdirp": "0.5.1",
+        "sax": "1.2.4",
+        "whet.extend": "0.9.9"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+          "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "2.7.3"
+          }
+        }
+      }
+    },
+    "symbol-observable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
+      "dev": true
+    },
+    "symbol-tree": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "dev": true
+    },
+    "sync-request": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-3.0.1.tgz",
+      "integrity": "sha1-yqEjWq+Im6UBB2oYNMQ2gwqC+3M=",
+      "requires": {
+        "concat-stream": "1.6.0",
+        "http-response-object": "1.1.0",
+        "then-request": "2.2.0"
+      }
+    },
+    "table": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ajv-keywords": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+          "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "tapable": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+      "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
+      "dev": true
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
+      }
+    },
+    "tar-fs": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
+      "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
+      "dev": true,
+      "requires": {
+        "chownr": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pump": "1.0.2",
+        "tar-stream": "1.5.4"
+      }
+    },
+    "tar-pack": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
+      "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
+      "requires": {
+        "debug": "2.6.9",
+        "fstream": "1.0.11",
+        "fstream-ignore": "1.0.5",
+        "once": "1.4.0",
+        "readable-stream": "2.3.3",
+        "rimraf": "2.6.2",
+        "tar": "2.2.1",
+        "uid-number": "0.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "tar-stream": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
+      "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+      "requires": {
+        "bl": "1.2.1",
+        "end-of-stream": "1.4.0",
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "temp-file": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-2.0.3.tgz",
+      "integrity": "sha512-qN0iNW0DFNmog1BFS8J3rQK4sZRIqqUZJ/zFlFo+0PwE7adUTEpPrQ3toWxwTcDjtGL9HjsQWe8CqMKq1kM7Gw==",
+      "dev": true,
+      "requires": {
+        "async-exit-hook": "2.0.1",
+        "bluebird-lst": "1.0.5",
+        "fs-extra-p": "4.4.4",
+        "lazy-val": "1.0.2"
+      }
+    },
+    "term-size": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
+      "requires": {
+        "execa": "0.7.0"
+      }
+    },
+    "test-value": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
+      "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+      "requires": {
+        "array-back": "1.0.4",
+        "typical": "2.6.1"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "requires": {
+            "typical": "2.6.1"
+          }
+        }
+      }
+    },
+    "tether": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.0.tgz",
+      "integrity": "sha1-D5+hcfdb9YSF2BSelHmdeudNHBo=",
+      "dev": true
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "then-request": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
+      "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
+      "requires": {
+        "caseless": "0.11.0",
+        "concat-stream": "1.6.0",
+        "http-basic": "2.5.1",
+        "http-response-object": "1.1.0",
+        "promise": "7.3.1",
+        "qs": "6.4.0"
+      },
+      "dependencies": {
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+        }
+      }
+    },
+    "throttleit": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+      "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.1.14",
+        "xtend": "2.1.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "dev": true,
+          "requires": {
+            "object-keys": "0.4.0"
+          }
+        }
+      }
+    },
+    "thunky": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
+      "integrity": "sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4=",
+      "dev": true
+    },
+    "time-stamp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
+      "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=",
+      "dev": true
+    },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
+    },
+    "timers-browserify": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
+      "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+      "dev": true,
+      "requires": {
+        "setimmediate": "1.0.5"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
+      "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "regex-not": "1.0.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "topo": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+      "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "toposort": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.6.tgz",
+      "integrity": "sha1-wxdI5V0hDv/AD9zcfW5o19e7nOw=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "dev": true
+        }
+      }
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
+    "tree-kill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
+      "integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg==",
+      "dev": true
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "dev": true,
+      "requires": {
+        "utf8-byte-length": "1.0.4"
+      }
+    },
+    "tryit": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+      "dev": true
+    },
+    "tslib": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
+      "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg==",
+      "dev": true
+    },
+    "tslint": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz",
+      "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.3.0",
+        "commander": "2.11.0",
+        "diff": "3.2.0",
+        "glob": "7.1.2",
+        "minimatch": "3.0.4",
+        "resolve": "1.5.0",
+        "semver": "5.4.1",
+        "tslib": "1.8.0",
+        "tsutils": "2.12.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "tslint-config-prettier": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.6.0.tgz",
+      "integrity": "sha512-39xsbQGnv20r0iraRNR/tlIaW4Fk2rj6mTk+V1r0TV1NztFfP0WTFKYP7JDq91w+wsfEfMNqWG4GPA6FjpDZEA==",
+      "dev": true
+    },
+    "tslint-eslint-rules": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-4.1.1.tgz",
+      "integrity": "sha1-fDDniC8mvCdr/5HSOEl1xp2viLo=",
+      "dev": true,
+      "requires": {
+        "doctrine": "0.7.2",
+        "tslib": "1.8.0",
+        "tsutils": "1.9.1"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+          "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+          "dev": true,
+          "requires": {
+            "esutils": "1.1.6",
+            "isarray": "0.0.1"
+          }
+        },
+        "esutils": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "tsutils": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-1.9.1.tgz",
+          "integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA=",
+          "dev": true
+        }
+      }
+    },
+    "tslint-plugin-prettier": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
+      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-prettier": "2.3.1",
+        "tslib": "1.8.0"
+      }
+    },
+    "tslint-react": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tslint-react/-/tslint-react-3.2.0.tgz",
+      "integrity": "sha1-hR+1BSAcY9A0PFFybmNk9+mtLpk=",
+      "dev": true,
+      "requires": {
+        "tsutils": "2.12.1"
+      }
+    },
+    "tsutils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.1.tgz",
+      "integrity": "sha1-9Nlc4zkciXHkblTEzw7bCiHdWyQ=",
+      "dev": true,
+      "requires": {
+        "tslib": "1.8.0"
+      }
+    },
+    "tty-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "type-is": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.17"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typescript": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
+      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
+      "dev": true
+    },
+    "typical": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
+    },
+    "ua-parser-js": {
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "uglifyjs-webpack-plugin": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+      "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-js": "2.8.29",
+        "webpack-sources": "1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "uid-number": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
+    },
+    "unbzip2-stream": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
+      "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
+      "requires": {
+        "buffer": "3.6.0",
+        "through": "2.3.8"
+      }
+    },
+    "unidecode": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/unidecode/-/unidecode-0.1.8.tgz",
+      "integrity": "sha1-77swFTi8RSRqmsjFWdcvAVMFBT4=",
+      "dev": true
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
+      },
+      "dependencies": {
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
+      }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
+    "uniqid": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+      "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
+      "dev": true,
+      "requires": {
+        "macaddress": "0.2.8"
+      }
+    },
+    "uniqs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+      "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+      "dev": true
+    },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "1.0.0"
+      }
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "unzip-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
+      "dev": true
+    },
+    "update-notifier": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
+      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+      "dev": true,
+      "requires": {
+        "boxen": "1.2.2",
+        "chalk": "2.3.0",
+        "configstore": "3.1.1",
+        "import-lazy": "2.1.0",
+        "is-installed-globally": "0.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "urijs": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.0.tgz",
+      "integrity": "sha512-Qs2odXn0hST5VSPVjpi73CMqtbAoanahaqWBujGU+IyMrMqpWcIhDewxQRhCkmqYxuyvICDcSuLdv2O7ncWBGw==",
+      "dev": true
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        }
+      }
+    },
+    "url-loader": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz",
+      "integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "mime": "1.4.1",
+        "schema-utils": "0.3.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "dev": true
+        }
+      }
+    },
+    "url-parse": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
+      "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
+      "requires": {
+        "querystringify": "1.0.0",
+        "requires-port": "1.0.0"
+      }
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "1.0.4"
+      }
+    },
+    "url-slug": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/url-slug/-/url-slug-2.0.0.tgz",
+      "integrity": "sha1-p4nVrtSZXA2VrzM3etHVxo1NcCc=",
+      "dev": true,
+      "requires": {
+        "unidecode": "0.1.8"
+      }
+    },
+    "ursa": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/ursa/-/ursa-0.9.4.tgz",
+      "integrity": "sha1-Ciq/t9xCZ/czsPjy/H8siV1ApBM=",
+      "dev": true,
+      "requires": {
+        "bindings": "1.3.0",
+        "nan": "2.7.0"
+      }
+    },
+    "use": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
+      "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "lazy-cache": "2.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
+      "dev": true
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+    },
+    "uws": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/uws/-/uws-8.14.1.tgz",
+      "integrity": "sha1-3glhnzBfYXTVUWqcaULLEgkEsgs=",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
+    },
+    "validator": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-7.0.0.tgz",
+      "integrity": "sha1-x03rgGNRL6w1VHk45vCxUEooL9I=",
+      "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
+    },
+    "vendors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
+      "integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "vm-browserify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+      "dev": true,
+      "requires": {
+        "indexof": "0.0.1"
+      }
+    },
+    "walkdir": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+      "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
+      "dev": true
+    },
+    "warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
+    },
+    "watchpack": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
+      "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
+      "dev": true,
+      "requires": {
+        "async": "2.5.0",
+        "chokidar": "1.7.0",
+        "graceful-fs": "4.1.11"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        }
+      }
+    },
+    "wbuf": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
+      "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
+      "dev": true,
+      "requires": {
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "wdio-dot-reporter": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/wdio-dot-reporter/-/wdio-dot-reporter-0.0.9.tgz",
+      "integrity": "sha1-kpsq2v1J1rBTT9oGjocxm0fjj+U=",
+      "dev": true
+    },
+    "webdriverio": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-4.8.0.tgz",
+      "integrity": "sha1-1Skpt0kID4mWf24WFAUcvIFy0TI=",
+      "dev": true,
+      "requires": {
+        "archiver": "1.3.0",
+        "babel-runtime": "6.23.0",
+        "css-parse": "2.0.0",
+        "css-value": "0.0.1",
+        "deepmerge": "1.3.2",
+        "ejs": "2.5.7",
+        "gaze": "1.1.2",
+        "glob": "7.1.2",
+        "inquirer": "3.0.6",
+        "json-stringify-safe": "5.0.1",
+        "mkdirp": "0.5.1",
+        "npm-install-package": "2.1.0",
+        "optimist": "0.6.1",
+        "q": "1.5.1",
+        "request": "2.81.0",
+        "rgb2hex": "0.1.0",
+        "safe-buffer": "5.0.1",
+        "supports-color": "3.2.3",
+        "url": "0.11.0",
+        "validator": "7.0.0",
+        "wdio-dot-reporter": "0.0.9",
+        "wgxpath": "1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "babel-runtime": {
+          "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+          "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.5.1",
+            "regenerator-runtime": "0.10.5"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "2.0.0"
+          }
+        },
+        "core-js": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "inquirer": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
+          "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "chalk": "1.1.3",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "2.0.5",
+            "figures": "2.0.0",
+            "lodash": "4.17.4",
+            "mute-stream": "0.0.7",
+            "run-async": "2.3.0",
+            "rx": "4.1.0",
+            "string-width": "2.1.1",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.1.0"
+          }
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "2.0.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+          "dev": true,
+          "requires": {
+            "is-promise": "2.1.0"
+          }
+        },
+        "rx": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+          "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "url": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+          "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+          "dev": true,
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        }
+      }
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "webpack": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
+      "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.2",
+        "acorn-dynamic-import": "2.0.2",
+        "ajv": "5.3.0",
+        "ajv-keywords": "2.1.0",
+        "async": "2.5.0",
+        "enhanced-resolve": "3.4.1",
+        "escope": "3.6.0",
+        "interpret": "1.0.4",
+        "json-loader": "0.5.7",
+        "json5": "0.5.1",
+        "loader-runner": "2.3.0",
+        "loader-utils": "1.1.0",
+        "memory-fs": "0.4.1",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "2.0.0",
+        "source-map": "0.5.7",
+        "supports-color": "4.5.0",
+        "tapable": "0.2.8",
+        "uglifyjs-webpack-plugin": "0.4.6",
+        "watchpack": "1.4.0",
+        "webpack-sources": "1.0.1",
+        "yargs": "8.0.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+          "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "async": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "enhanced-resolve": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+          "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "memory-fs": "0.4.1",
+            "object-assign": "4.1.1",
+            "tapable": "0.2.8"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          }
+        }
+      }
+    },
+    "webpack-dev-middleware": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz",
+      "integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
+      "dev": true,
+      "requires": {
+        "memory-fs": "0.4.1",
+        "mime": "1.4.1",
+        "path-is-absolute": "1.0.1",
+        "range-parser": "1.2.0",
+        "time-stamp": "2.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "dev": true
+        }
+      }
+    },
+    "webpack-dev-server": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.3.tgz",
+      "integrity": "sha512-bwq7sj452FRH+oVfgOA8xXKkLYPTNsYB4dQ0Jhz3ydjNJ9MvhpGJtehFW8Z0cEcwNkRRiF4aYbReiSGQ4pbS1w==",
+      "dev": true,
+      "requires": {
+        "ansi-html": "0.0.7",
+        "array-includes": "3.0.3",
+        "bonjour": "3.5.0",
+        "chokidar": "1.7.0",
+        "compression": "1.7.1",
+        "connect-history-api-fallback": "1.4.0",
+        "debug": "3.1.0",
+        "del": "3.0.0",
+        "express": "4.16.2",
+        "html-entities": "1.2.1",
+        "http-proxy-middleware": "0.17.4",
+        "import-local": "0.1.1",
+        "internal-ip": "1.2.0",
+        "ip": "1.1.5",
+        "loglevel": "1.5.1",
+        "opn": "5.1.0",
+        "portfinder": "1.0.13",
+        "selfsigned": "1.10.1",
+        "serve-index": "1.9.1",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "3.4.7",
+        "strip-ansi": "3.0.1",
+        "supports-color": "4.5.0",
+        "webpack-dev-middleware": "1.12.0",
+        "yargs": "6.6.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "del": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+          "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+          "dev": true,
+          "requires": {
+            "globby": "6.1.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.0",
+            "p-map": "1.2.0",
+            "pify": "3.0.0",
+            "rimraf": "2.6.2"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          }
+        }
+      }
+    },
+    "webpack-node-externals": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.6.0.tgz",
+      "integrity": "sha1-Iyxi7GCSsQBjWj0p2DwXRxKN+b0=",
+      "dev": true
+    },
+    "webpack-sources": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
+      "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+      "dev": true,
+      "requires": {
+        "source-list-map": "2.0.0",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "webpack-visualizer-plugin": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/webpack-visualizer-plugin/-/webpack-visualizer-plugin-0.1.11.tgz",
+      "integrity": "sha1-uHcK2GtPZSYSxosbeCJT+vn4o04=",
+      "dev": true,
+      "requires": {
+        "d3": "3.5.17",
+        "mkdirp": "0.5.1",
+        "react": "0.14.9",
+        "react-dom": "0.14.9"
+      },
+      "dependencies": {
+        "fbjs": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.6.1.tgz",
+          "integrity": "sha1-lja3cF9bqWhNRLcveDISVK/IYPc=",
+          "dev": true,
+          "requires": {
+            "core-js": "1.2.7",
+            "loose-envify": "1.3.1",
+            "promise": "7.3.1",
+            "ua-parser-js": "0.7.17",
+            "whatwg-fetch": "0.9.0"
+          }
+        },
+        "react": {
+          "version": "0.14.9",
+          "resolved": "https://registry.npmjs.org/react/-/react-0.14.9.tgz",
+          "integrity": "sha1-kRCmSXxJ1EuhwO3TF67CnC4NkdE=",
+          "dev": true,
+          "requires": {
+            "envify": "3.4.1",
+            "fbjs": "0.6.1"
+          }
+        },
+        "react-dom": {
+          "version": "0.14.9",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.9.tgz",
+          "integrity": "sha1-BQZKPc8PsYgKOyv8nVjFXY2fYpM=",
+          "dev": true
+        },
+        "whatwg-fetch": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
+          "integrity": "sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA=",
+          "dev": true
+        }
+      }
+    },
+    "websocket-driver": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "dev": true,
+      "requires": {
+        "http-parser-js": "0.4.9",
+        "websocket-extensions": "0.1.2"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
+      "integrity": "sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0=",
+      "dev": true
+    },
+    "wgxpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wgxpath/-/wgxpath-1.0.0.tgz",
+      "integrity": "sha1-7vikudVYzEla06mit1FZfs2a9pA=",
+      "dev": true
+    },
+    "whatwg-encoding": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.2.tgz",
+      "integrity": "sha512-9WQ+6BvuD7A1vaGMqMjyR5zhHnR/VXKrs2WHobV/YCfeKXKEk0SJbgwg4kjdpRRrenEQbYwZ/P9vQAVUEVAzUg==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.13"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.13",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
+          "dev": true
+        }
+      }
+    },
+    "whatwg-fetch": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+    },
+    "whatwg-url": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.3.0.tgz",
+      "integrity": "sha512-rM+hE5iYKGPAOu05mIdJR47pYSR2vDzfrTEFRc/S8D3L60yW8BuXmUJ7Kog7x/DrokFN7JNaHKadpzjouKRRAw==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
+      }
+    },
+    "whet.extend": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+      "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
+    "widest-line": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
+    "window-size": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+      "dev": true
+    },
+    "winston": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+      "dev": true,
+      "requires": {
+        "async": "1.0.0",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "stack-trace": "0.0.10"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        }
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
+    },
+    "write-file-atomic": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "xdg-basedir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
+    },
+    "xml-name-validator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "dev": true,
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "4.2.1"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+          "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        }
+      }
+    },
+    "xmlbuilder": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+      "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+      "dev": true
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "xvfb-maybe": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/xvfb-maybe/-/xvfb-maybe-0.2.1.tgz",
+      "integrity": "sha1-7YyxMpV7eEi0OZhMZvAQ6n8kNhs=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "which": "1.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+      "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+      "dev": true,
+      "requires": {
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "find-up": "2.1.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "2.1.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "8.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+      "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+      "dev": true,
+      "requires": {
+        "camelcase": "4.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
+      }
+    },
+    "yauzl": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
+      "integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
+      "requires": {
+        "buffer-crc32": "0.2.13",
+        "fd-slicer": "1.0.1"
+      }
+    },
+    "zip-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+      "dev": true,
+      "requires": {
+        "archiver-utils": "1.3.0",
+        "compress-commons": "1.2.2",
+        "lodash": "4.17.4",
+        "readable-stream": "2.3.3"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "prettier": "^1.7.4",
     "react-dom": "^15.6.2",
     "react-hot-loader": "^3.1.1",
-    "realm-object-server": "2.0.4",
+    "realm-object-server": "2.0.6",
     "resolve-url-loader": "^2.1.1",
     "sass-lint": "^1.12.1",
     "sass-loader": "^6.0.6",

--- a/src/ui/server-administration/logs/Log.tsx
+++ b/src/ui/server-administration/logs/Log.tsx
@@ -4,6 +4,7 @@ import {
   Column,
   Dimensions as IAutoSizerDimensions,
   List,
+  ScrollSync,
 } from 'react-virtualized';
 
 import { Entry, ILogEntry } from './Entry';
@@ -27,20 +28,33 @@ export const Log = ({
   return (
     <div className="Log">
       <div className="Log__Table">
-        <AutoSizer>
-          {({ width, height }: IAutoSizerDimensions) => (
-            <List
-              width={width}
-              height={height}
-              rowCount={entries.length}
-              rowHeight={20}
-              rowRenderer={({ key, style, index, isScrolling }) => {
-                const entry = entries[index] as ILogEntry;
-                return <Entry key={key} style={style} {...entry} />;
-              }}
-            />
-          )}
-        </AutoSizer>
+        <ScrollSync>
+          {({ clientHeight, onScroll, scrollTop, scrollHeight }) => {
+            // Measure the distance from the bottom scroll - initially 0.
+            const scrollBottom = scrollHeight - (scrollTop + clientHeight);
+            // If we're close to the bottom - stick to the bottom when new entries arrive
+            const scrollToIndex =
+              scrollBottom < 10 ? entries.length - 1 : undefined;
+            return (
+              <AutoSizer>
+                {({ width, height }: IAutoSizerDimensions) => (
+                  <List
+                    width={width}
+                    height={height}
+                    onScroll={onScroll}
+                    rowCount={entries.length}
+                    rowHeight={20}
+                    rowRenderer={({ key, style, index, isScrolling }) => {
+                      const entry = entries[index] as ILogEntry;
+                      return <Entry key={key} style={style} {...entry} />;
+                    }}
+                    scrollToIndex={scrollToIndex}
+                  />
+                )}
+              </AutoSizer>
+            );
+          }}
+        </ScrollSync>
       </div>
       <div className="Log__Controls">
         <div className="Log__Status">Showing {entries.length} log entries</div>

--- a/src/ui/server-administration/logs/LogContainer.tsx
+++ b/src/ui/server-administration/logs/LogContainer.tsx
@@ -111,8 +111,9 @@ export class LogContainer extends React.Component<
 
   private onLogMessage = (e: MessageEvent) => {
     const newEntries = JSON.parse(e.data);
+    const entries: ILogEntry[] = [];
     this.setState({
-      entries: newEntries.concat(this.state.entries),
+      entries: entries.concat(this.state.entries, newEntries),
     });
   };
 }

--- a/src/ui/server-administration/logs/LogContainer.tsx
+++ b/src/ui/server-administration/logs/LogContainer.tsx
@@ -110,10 +110,9 @@ export class LogContainer extends React.Component<
   }
 
   private onLogMessage = (e: MessageEvent) => {
-    const newEntries = JSON.parse(e.data);
-    const entries: ILogEntry[] = [];
+    const newEntries = JSON.parse(e.data).reverse();
     this.setState({
-      entries: entries.concat(this.state.entries, newEntries),
+      entries: this.state.entries.concat(newEntries),
     });
   };
 }

--- a/src/ui/server-administration/logs/LogContainer.tsx
+++ b/src/ui/server-administration/logs/LogContainer.tsx
@@ -80,6 +80,16 @@ export class LogContainer extends React.Component<
     const url = this.generateLogUrl();
     const userRefreshToken = this.props.user.token;
     this.socket = new WebSocket(url);
+    this.socket.addEventListener('open', e => {
+      if (this.socket) {
+        this.socket.send(
+          JSON.stringify({
+            action: 'authenticate',
+            token: this.props.user.token,
+          }),
+        );
+      }
+    });
     this.socket.addEventListener('message', this.onLogMessage);
   }
 

--- a/src/ui/server-administration/logs/LogContainer.tsx
+++ b/src/ui/server-administration/logs/LogContainer.tsx
@@ -92,9 +92,6 @@ export class LogContainer extends React.Component<
 
   private generateLogUrl() {
     const url = new URL(this.props.user.server);
-    // Add in the users identity and token
-    url.username = this.props.user.identity;
-    url.password = this.props.user.token;
     // Use ws instead of http
     url.protocol = url.protocol.replace('http', 'ws');
     // Replace the path


### PR DESCRIPTION
The browser now sends a token when opening the WebSocket connection for logs: fixing https://github.com/realm/realm-object-server-private/issues/546
The log entries are reversed (newest at bottom) - fixing #206
And if your scrolling to the bottom - stick there and see the newest entries come in.