### PR TITLE
Custom authentication + "Connect to server" UI update

### DIFF
--- a/src/services/ros/ros-authentication.ts
+++ b/src/services/ros/ros-authentication.ts
@@ -1,14 +1,25 @@
-export interface IUsernamePasswordCredentials {
+interface ICredentials {
+  kind: string;
   url: string;
+}
+
+export interface IUsernamePasswordCredentials extends ICredentials {
+  kind: 'password';
   username: string;
   password: string;
 }
 
-export interface IAdminTokenCredentials {
-  url: string;
+export interface IAdminTokenCredentials extends ICredentials {
+  kind: 'token';
   token: string;
+}
+
+export interface IOtherCredentials extends ICredentials {
+  kind: 'other';
+  options: object;
 }
 
 export type IServerCredentials =
   | IUsernamePasswordCredentials
-  | IAdminTokenCredentials;
+  | IAdminTokenCredentials
+  | IOtherCredentials;

--- a/src/ui/connect-to-server/AuthenticationForm.tsx
+++ b/src/ui/connect-to-server/AuthenticationForm.tsx
@@ -3,11 +3,13 @@ import { Col, FormGroup, Input, Label, Row } from 'reactstrap';
 
 import { AdminTokenForm } from './AdminTokenForm';
 import { AuthenticationMethodSelector } from './AuthenticationMethodSelector';
+import { OtherForm } from './OtherForm';
 import { UsernamePasswordForm } from './UsernamePasswordForm';
 
 export enum AuthenticationMethod {
   usernamePassword,
   adminToken,
+  other,
 }
 
 export const AuthenticationForm = ({
@@ -15,19 +17,23 @@ export const AuthenticationForm = ({
   username,
   password,
   token,
+  otherOptions,
   onMethodChanged,
   onUsernameChanged,
   onPasswordChanged,
   onTokenChanged,
+  onOtherOptionsChanged,
 }: {
   method: AuthenticationMethod;
   username: string;
   password: string;
   token: string;
+  otherOptions: string;
   onMethodChanged: (method: AuthenticationMethod) => void;
   onUsernameChanged: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onPasswordChanged: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onTokenChanged: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onOtherOptionsChanged: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }) => {
   let form;
   if (method === AuthenticationMethod.usernamePassword) {
@@ -46,6 +52,13 @@ export const AuthenticationForm = ({
         token={token}
         onTokenChanged={onTokenChanged}
         isRequired={!username}
+      />
+    );
+  } else if (method === AuthenticationMethod.other) {
+    form = (
+      <OtherForm
+        options={otherOptions}
+        onOptionsChanged={onOtherOptionsChanged}
       />
     );
   }

--- a/src/ui/connect-to-server/AuthenticationMethodSelector.tsx
+++ b/src/ui/connect-to-server/AuthenticationMethodSelector.tsx
@@ -3,35 +3,60 @@ import { Button } from 'reactstrap';
 
 import { AuthenticationMethod } from './AuthenticationForm';
 
+export type MethodChangedHandler = (method: AuthenticationMethod) => void;
+
+const AuthenticationMethodButton = ({
+  activeMethod,
+  children,
+  method,
+  onMethodChanged,
+}: {
+  activeMethod: AuthenticationMethod;
+  children: React.ReactNode;
+  method: AuthenticationMethod;
+  onMethodChanged: MethodChangedHandler;
+}) => (
+  <Button
+    className="ConnectToServer__AuthenticationMethodSelector__Btn"
+    size="sm"
+    color={method === activeMethod ? 'primary' : 'secondary'}
+    onClick={e => {
+      e.preventDefault();
+      onMethodChanged(method);
+    }}
+  >
+    {children}
+  </Button>
+);
+
 export const AuthenticationMethodSelector = ({
   method,
   onMethodChanged,
 }: {
   method: AuthenticationMethod;
-  onMethodChanged: (method: AuthenticationMethod) => void;
+  onMethodChanged: MethodChangedHandler;
 }) => (
   <div className="ConnectToServer__AuthenticationMethodSelector">
-    <Button
-      className="ConnectToServer__AuthenticationMethodSelector__Btn"
-      size="sm"
-      active={method === AuthenticationMethod.usernamePassword}
-      onClick={e => {
-        e.preventDefault();
-        onMethodChanged(AuthenticationMethod.usernamePassword);
-      }}
+    <AuthenticationMethodButton
+      activeMethod={method}
+      method={AuthenticationMethod.usernamePassword}
+      onMethodChanged={onMethodChanged}
     >
       Username / password
-    </Button>
-    <Button
-      className="ConnectToServer__AuthenticationMethodSelector__Btn"
-      size="sm"
-      active={method === AuthenticationMethod.adminToken}
-      onClick={e => {
-        e.preventDefault();
-        onMethodChanged(AuthenticationMethod.adminToken);
-      }}
+    </AuthenticationMethodButton>
+    <AuthenticationMethodButton
+      activeMethod={method}
+      method={AuthenticationMethod.adminToken}
+      onMethodChanged={onMethodChanged}
     >
       Admin token
-    </Button>
+    </AuthenticationMethodButton>
+    <AuthenticationMethodButton
+      activeMethod={method}
+      method={AuthenticationMethod.other}
+      onMethodChanged={onMethodChanged}
+    >
+      Other
+    </AuthenticationMethodButton>
   </div>
 );

--- a/src/ui/connect-to-server/ConnectToServer.scss
+++ b/src/ui/connect-to-server/ConnectToServer.scss
@@ -27,21 +27,29 @@
   }
 
   &__AuthenticationForm {
-    background: $color-dove;
+    background: $white;
     display: flex;
     flex-basis: 110px;
     flex-direction: column;
     justify-content: space-around;
-    margin-top: $spacer;
+    margin-top: 2 * $spacer;
+    padding: $spacer;
     position: relative;
+
+    &__Payload {
+      font-family: monospace;
+      height: 4 * 1.5em;
+      resize: none;
+    }
   }
 
   &__AuthenticationMethodSelector {
     display: flex;
     justify-content: center;
+    left: 0;
     position: absolute;
+    right: 0;
     top: -$spacer;
-    width: 100%;
 
     &__Btn {
       margin: 0 ($spacer / 4);

--- a/src/ui/connect-to-server/ConnectToServer.tsx
+++ b/src/ui/connect-to-server/ConnectToServer.tsx
@@ -15,10 +15,12 @@ export const ConnectToServer = ({
   onUsernameChanged,
   onPasswordChanged,
   onTokenChanged,
+  onOtherOptionsChanged,
   url,
   username,
   password,
   token,
+  otherOptions,
   isConnecting,
 }: {
   method: AuthenticationMethod;
@@ -29,10 +31,12 @@ export const ConnectToServer = ({
   onUsernameChanged: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onPasswordChanged: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onTokenChanged: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onOtherOptionsChanged: (e: React.ChangeEvent<HTMLInputElement>) => void;
   url: string;
   username: string;
   password: string;
   token: string;
+  otherOptions: string;
   isConnecting: boolean;
 }) => {
   return (
@@ -61,9 +65,11 @@ export const ConnectToServer = ({
         onMethodChanged={onMethodChanged}
         username={username}
         password={password}
+        token={token}
+        otherOptions={otherOptions}
         onUsernameChanged={onUsernameChanged}
         onPasswordChanged={onPasswordChanged}
-        token={token}
+        onOtherOptionsChanged={onOtherOptionsChanged}
         onTokenChanged={onTokenChanged}
       />
       <div className="ConnectToServer__Controls">

--- a/src/ui/connect-to-server/ConnectToServerContainer.tsx
+++ b/src/ui/connect-to-server/ConnectToServerContainer.tsx
@@ -3,10 +3,14 @@ import * as React from 'react';
 import * as Realm from 'realm';
 
 import { main } from '../../actions/main';
+import * as ros from '../../services/ros';
 import { showError } from '../reusable/errors';
 
 import { AuthenticationMethod } from './AuthenticationForm';
 import { ConnectToServer } from './ConnectToServer';
+
+const MISSING_PARAMS_MESSAGE =
+  'Your request did not validate because of missing parameters.';
 
 export class ConnectToServerContainer extends React.Component<
   {},
@@ -17,6 +21,7 @@ export class ConnectToServerContainer extends React.Component<
     username: string;
     password: string;
     token: string;
+    otherOptions: string;
   }
 > {
   constructor() {
@@ -28,6 +33,7 @@ export class ConnectToServerContainer extends React.Component<
       username: '',
       password: '',
       token: '',
+      otherOptions: '',
     };
   }
 
@@ -40,55 +46,39 @@ export class ConnectToServerContainer extends React.Component<
   };
 
   public onSubmit = async () => {
-    const { url, username, password, token } = this.state;
-
-    const preparedUrl = this.prepareUrl(url);
-    const preparedUsername = this.prepareUsername(username);
-
     this.setState({
       isConnecting: true,
     });
 
-    if (token) {
+    try {
+      const credentials = this.prepareCredentials();
+      const user = await ros.authenticate(credentials);
+      if (!user.isAdmin) {
+        throw new Error('You must be an administrator');
+      }
       await main.showServerAdministration({
-        credentials: {
-          url: preparedUrl,
-          token,
-        },
+        credentials,
       });
+      electron.remote.getCurrentWindow().close();
+    } catch (err) {
+      if (err.message === MISSING_PARAMS_MESSAGE) {
+        const missingParams = (err.invalid_params || [])
+          .filter((params: any) => params.reason)
+          .map((param: any) => {
+            return ` • ${param.reason}`;
+          })
+          .join('\n');
+        // Replace the error, with a more elaborate one
+        err = new Error(`${err.message}\n\n${missingParams}`);
+      }
+      showError(`Couldn't connect to Realm Object Server`, err, {
+        'Failed to fetch':
+          'Could not reach the server.\nNote: SSL certificates must be signed by a trusted CA.',
+      });
+    } finally {
       this.setState({
         isConnecting: false,
       });
-    } else {
-      try {
-        const user = await Realm.Sync.User.login(
-          preparedUrl,
-          preparedUsername,
-          password,
-        );
-        // Show the server administration
-        await main.showServerAdministration({
-          credentials: {
-            url: user.server,
-            username: preparedUsername,
-            password,
-          },
-        });
-        // and close this window
-        electron.remote.getCurrentWindow().close();
-      } catch (err) {
-        const sslWarning =
-          preparedUrl.indexOf('https:') === 0
-            ? '\nNote: SSL certificates should be signed by a trusted CA.'
-            : '';
-        showError(`Couldn't connect to Realm Object Server`, err, {
-          'Failed to fetch': 'Could not reach the server.' + sslWarning,
-        });
-      } finally {
-        this.setState({
-          isConnecting: false,
-        });
-      }
     }
   };
 
@@ -122,6 +112,12 @@ export class ConnectToServerContainer extends React.Component<
     });
   };
 
+  public onOtherOptionsChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({
+      otherOptions: e.target.value,
+    });
+  };
+
   private prepareUrl(urlString: string) {
     if (urlString === '') {
       return 'http://localhost:9080';
@@ -147,6 +143,45 @@ export class ConnectToServerContainer extends React.Component<
       return 'realm-admin';
     } else {
       return username;
+    }
+  }
+
+  private prepareCredentials(): ros.IServerCredentials {
+    const { url, method } = this.state;
+    const preparedUrl = this.prepareUrl(url);
+    if (method === AuthenticationMethod.usernamePassword) {
+      const username = this.prepareUsername(this.state.username);
+      const password = this.state.password;
+      return {
+        kind: 'password',
+        url: preparedUrl,
+        username,
+        password,
+      };
+    } else if (method === AuthenticationMethod.adminToken) {
+      const token = this.state.token;
+      return {
+        kind: 'token',
+        url: preparedUrl,
+        token,
+      };
+    } else if (method === AuthenticationMethod.other) {
+      try {
+        const options = JSON.parse(this.state.otherOptions);
+        return {
+          kind: 'other',
+          url: preparedUrl,
+          options,
+        };
+      } catch (err) {
+        if (err instanceof SyntaxError) {
+          throw new SyntaxError(`Please provide valid JSON: ${err.message}`);
+        } else {
+          throw err;
+        }
+      }
+    } else {
+      throw new Error(`The method is not supported: ${method}`);
     }
   }
 }

--- a/src/ui/connect-to-server/OtherForm.tsx
+++ b/src/ui/connect-to-server/OtherForm.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { Input } from 'reactstrap';
+
+import { CredentialsFormGroup } from './CredentialsFormGroup';
+
+const placeholder = `{
+  "provider": "...",
+  "data": { ... }
+}
+`;
+
+/*
+Test this with the debug authentication provider,
+
+npm run dev:ros -- --auth debug
+
+and this payload:
+
+{
+  "provider": "debug",
+  "data": "admin"
+}
+*/
+
+export const OtherForm = ({
+  options,
+  onOptionsChanged,
+}: {
+  options: string;
+  onOptionsChanged: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}) => (
+  <div>
+    <Input
+      type="textarea"
+      placeholder={placeholder}
+      className="ConnectToServer__AuthenticationForm__Payload"
+      value={options}
+      onChange={onOptionsChanged}
+      size="sm"
+    />
+  </div>
+);

--- a/src/ui/reusable/realm-loading-component/RealmLoadingComponent.tsx
+++ b/src/ui/reusable/realm-loading-component/RealmLoadingComponent.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import {
+  authenticate,
   createUser,
   getRealm,
   IAdminTokenCredentials,
@@ -90,7 +91,7 @@ export abstract class RealmLoadingComponent<
       const user =
         props.authentication instanceof Realm.Sync.User
           ? props.authentication
-          : await this.getRealmLoadingUser(props.authentication);
+          : await authenticate(props.authentication);
       const realmPromise = getRealm(
         user,
         realm.path,

--- a/src/ui/server-administration/ServerAdministrationContainer.tsx
+++ b/src/ui/server-administration/ServerAdministrationContainer.tsx
@@ -4,6 +4,7 @@ import * as Realm from 'realm';
 
 import { main } from '../../actions/main';
 import {
+  authenticate,
   IAdminTokenCredentials,
   ISyncedRealmToLoad,
   IUsernamePasswordCredentials,
@@ -35,30 +36,10 @@ export class ServerAdministrationContainer extends React.Component<
   }
 
   public async componentDidMount() {
-    const serverUrl = this.props.credentials.url;
-    if ('token' in this.props.credentials) {
-      const credentials = this.props.credentials as IAdminTokenCredentials;
-      const user = Realm.Sync.User.adminUser(credentials.token, serverUrl);
-      this.setState({ user });
-    } else if (
-      'username' in this.props.credentials &&
-      'password' in this.props.credentials
-    ) {
-      const credentials = this.props
-        .credentials as IUsernamePasswordCredentials;
-      try {
-        const user = await Realm.Sync.User.login(
-          serverUrl,
-          credentials.username,
-          credentials.password,
-        );
-        this.setState({ user });
-      } catch (err) {
-        showError(`Couldn't connect to Realm Object Server`, err, {
-          'Failed to fetch': 'Could not reach the server',
-        });
-      }
-    }
+    const user = await authenticate(this.props.credentials);
+    this.setState({
+      user,
+    });
   }
 
   public render() {


### PR DESCRIPTION
This adds a way for users to login to ROS using a custom authentication provider (fixing #54 and #51) and updates the UI to incorporate a fix for https://github.com/realm/realm-studio/issues/298.

![skaermbillede 2017-11-01 kl 14 11 41](https://user-images.githubusercontent.com/1243959/32276376-41aec5ec-bf0f-11e7-9895-0d961161a85d.png)

![skaermbillede 2017-11-01 kl 14 11 51](https://user-images.githubusercontent.com/1243959/32276380-443fca54-bf0f-11e7-9b61-06ffe872ca60.png)

![skaermbillede 2017-11-01 kl 14 11 55](https://user-images.githubusercontent.com/1243959/32276381-465d81d2-bf0f-11e7-8c20-3f6404921be7.png)