### PR TITLE
Allow ssl verification bypass

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "build": "webpack --env.NODE_ENV=production",
     "check:package-lock": "node ./scripts/check-package-lock.js",
     "dev:ros": "ros start",
+    "dev:ros-https": "ros start --https --https-key ./data/keys/server.key --https-cert ./data/keys/server.crt",
     "dev": "rm -rf ./build && concurrently --names \"WEBPACK:M,WEBPACK:R,ELECTRON\" \"npm run webpack:main\" \"npm run webpack:renderer\" \"npm run wait-for-bundle && electron .\"",
     "prepackage": "rm -rf ./build && npm run build",
     "package": "electron-builder --publish=never",

--- a/src/services/ros/index.ts
+++ b/src/services/ros/index.ts
@@ -96,10 +96,21 @@ export const timeoutPromise = (
   });
 };
 
+export interface ISslConfiguration {
+  validateCertificates: boolean;
+  errorCallback?: Realm.Sync.ErrorCallback;
+  certificatePath?: string;
+}
+
+export const defaultSyncErrorCallback = (sender: any, err: any) => {
+  showError('Error while synchronizing Realm', err);
+};
+
 export const getRealm = async (
   user: Realm.Sync.User,
   realmPath: string,
   encryptionKey?: Uint8Array,
+  ssl: ISslConfiguration = { validateCertificates: true },
   progressCallback?: Realm.Sync.ProgressNotificationCallback,
 ): Promise<Realm> => {
   const url = getRealmUrl(user, realmPath);
@@ -108,9 +119,9 @@ export const getRealm = async (
     sync: {
       url,
       user,
-      error: (err: any) => {
-        showError('Error while synchronizing Realm', err);
-      },
+      error: ssl.errorCallback || defaultSyncErrorCallback,
+      validate_ssl: ssl.validateCertificates,
+      ssl_trust_certificate_path: ssl.certificatePath,
     },
   });
 

--- a/src/services/ros/ros-realms.ts
+++ b/src/services/ros/ros-realms.ts
@@ -9,11 +9,13 @@ export enum RealmLoadingMode {
 export interface IRealmToLoad {
   mode: RealmLoadingMode;
   path: string;
+  encryptionKey?: Uint8Array;
 }
 
 export interface ISyncedRealmToLoad extends IRealmToLoad {
   mode: RealmLoadingMode.Synced;
   authentication: IServerCredentials | Realm.Sync.User;
+  validateCertificates: boolean;
 }
 
 export interface ILocalRealmToLoad extends IRealmToLoad {

--- a/src/services/ros/ros-realms.ts
+++ b/src/services/ros/ros-realms.ts
@@ -12,8 +12,10 @@ export interface IRealmToLoad {
 }
 
 export interface ISyncedRealmToLoad extends IRealmToLoad {
+  mode: RealmLoadingMode.Synced;
   authentication: IServerCredentials | Realm.Sync.User;
 }
 
-// tslint:disable-next-line:no-empty-interface
-export interface ILocalRealmToLoad extends IRealmToLoad {}
+export interface ILocalRealmToLoad extends IRealmToLoad {
+  mode: RealmLoadingMode.Local;
+}

--- a/src/ui/connect-to-server/ConnectToServerContainer.tsx
+++ b/src/ui/connect-to-server/ConnectToServerContainer.tsx
@@ -83,6 +83,7 @@ export class ConnectToServerContainer extends React.Component<
       this.setLatestUrl(credentials.url);
       await main.showServerAdministration({
         credentials,
+        validateCertificates: true,
       });
       electron.remote.getCurrentWindow().close();
     } catch (err) {

--- a/src/ui/realm-browser/RealmBrowserContainer.tsx
+++ b/src/ui/realm-browser/RealmBrowserContainer.tsx
@@ -301,8 +301,11 @@ export class RealmBrowserContainer extends RealmLoadingComponent<
 
   public onOpenWithEncryption = (key: string) => {
     this.setState({ encryptionKey: key });
-    const keyBuffer = Buffer.from(key, 'hex');
-    this.loadRealm(this.props.realm, keyBuffer);
+    const encryptionKey = Buffer.from(key, 'hex');
+    this.loadRealm({
+      ...this.props.realm,
+      encryptionKey,
+    });
   };
 
   protected generateHighlight(object?: Realm.Object): IHighlight | undefined {

--- a/src/ui/reusable/realm-loading-component/RealmLoadingComponent.tsx
+++ b/src/ui/reusable/realm-loading-component/RealmLoadingComponent.tsx
@@ -72,8 +72,9 @@ export abstract class RealmLoadingComponent<
           errorCallback: this.onSyncError,
           validateCertificates,
           // Uncomment the line below to test failing certificate validation
-          certificatePath:
-            '/Users/kraenhansen/Repositories/realm-studio/data/keys/server.crt',
+          /*
+          certificatePath: '... some path of a valid but failing certificate',
+          */
         });
         // Register change listeners
         this.realm.addListener('change', this.onRealmChanged);

--- a/src/ui/reusable/realm-loading-component/RealmLoadingComponent.tsx
+++ b/src/ui/reusable/realm-loading-component/RealmLoadingComponent.tsx
@@ -1,3 +1,4 @@
+import * as electron from 'electron';
 import * as React from 'react';
 
 import {
@@ -8,6 +9,7 @@ import {
   ILocalRealmToLoad,
   IRealmFile,
   IServerCredentials,
+  ISslConfiguration,
   ISyncedRealmToLoad,
   IUser,
   IUserMetadataRow,
@@ -24,6 +26,9 @@ export interface IRealmLoadingComponentState {
   realm?: ISyncedRealmToLoad | ILocalRealmToLoad;
 }
 
+const TRUST_DIALOG_MESSAGE =
+  'The servers SSL certificate failed validation:\n\nDo you want to retry without validating the certificate?';
+
 export abstract class RealmLoadingComponent<
   P,
   S extends IRealmLoadingComponentState
@@ -33,6 +38,8 @@ export abstract class RealmLoadingComponent<
 
   protected realm: Realm;
   protected cancellations: Array<() => void> = [];
+  protected validateCertificates: boolean = true;
+  protected certificateWasRejected: boolean;
 
   public componentWillUnmount() {
     // Remove any existing a change listeners
@@ -59,16 +66,46 @@ export abstract class RealmLoadingComponent<
     if (realm) {
       try {
         this.setState({ progress: { done: false } });
+        // Reset the state that captures rejected certificates
+        this.certificateWasRejected = false;
         // Get the realms from the ROS interface
-        this.realm = await this.openRealm(realm, encryptionKey);
+        this.realm = await this.openRealm(realm, encryptionKey, {
+          errorCallback: this.onSyncError,
+          validateCertificates: this.validateCertificates,
+          // Uncomment the line below to test failing certificate validation
+          /*
+          certificatePath:
+            '/Users/kraenhansen/Repositories/realm-studio/data/keys/server.crt',
+          */
+        });
         // Register change listeners
         this.realm.addListener('change', this.onRealmChanged);
         this.onRealmLoaded();
         // Update the state, to indicate we're done loading
         this.setState({ progress: { done: true } });
       } catch (err) {
+        // Ignore an error that originates from the load being cancelled
         if (!err.wasCancelled) {
-          this.loadingRealmFailed(err);
+          // Could this error originate from an untrusted SSL certificate?
+          if (this.validateCertificates && this.certificateWasRejected) {
+            // Ask the user if they want to trust the certificate
+            const result = electron.remote.dialog.showMessageBox(
+              electron.remote.getCurrentWindow(),
+              {
+                type: 'warning',
+                message: TRUST_DIALOG_MESSAGE,
+                buttons: ['Retry, without validating certificate', 'Cancel'],
+              },
+            );
+            if (result === 0) {
+              this.validateCertificates = false;
+              this.loadRealm(realm, encryptionKey);
+            } else {
+              this.loadingRealmFailed(err);
+            }
+          } else {
+            this.loadingRealmFailed(err);
+          }
         }
       }
     }
@@ -80,9 +117,25 @@ export abstract class RealmLoadingComponent<
     this.setState({ progress: { failure, done: true } });
   }
 
+  protected isSslCertificateRelated(err: Error) {
+    return err && err.message === 'SSL server certificate rejected';
+  }
+
+  protected onSyncError = (
+    session: Realm.Sync.Session,
+    error: Realm.Sync.SyncError,
+  ) => {
+    if (error.message === 'SSL server certificate rejected') {
+      this.certificateWasRejected = true;
+    } else {
+      showError('Failed while synchronizing Realm', error);
+    }
+  };
+
   private async openRealm(
     realm: ISyncedRealmToLoad | ILocalRealmToLoad | undefined,
     encryptionKey?: Uint8Array,
+    ssl: ISslConfiguration = { validateCertificates: true },
   ): Promise<Realm> {
     if (realm && realm.mode === RealmLoadingMode.Local) {
       return new Realm({ path: realm.path, encryptionKey });
@@ -96,6 +149,7 @@ export abstract class RealmLoadingComponent<
         user,
         realm.path,
         encryptionKey,
+        ssl,
         this.progressChanged,
       );
       // Save a wrapping promise so this can be cancelled
@@ -106,7 +160,7 @@ export abstract class RealmLoadingComponent<
     } else if (!realm) {
       throw new Error(`Called without a realm to load`);
     } else {
-      throw new Error(`Unexpected mode ${realm.mode}`);
+      throw new Error('Unexpected mode');
     }
   }
 
@@ -144,7 +198,6 @@ export abstract class RealmLoadingComponent<
   }
 
   private progressChanged = (transferred: number, transferable: number) => {
-    // console.log('progressChanged', transferred, transferable);
     this.setState({
       progress: {
         done: transferred >= transferable,

--- a/src/ui/server-administration/ServerAdministration.tsx
+++ b/src/ui/server-administration/ServerAdministration.tsx
@@ -6,7 +6,10 @@ import realmLogo from '../../../static/svgs/realm-logo.svg';
 
 import { LoadingOverlay } from '../reusable/loading-overlay';
 import { LogContainer } from './logs/LogContainer';
-import { RealmsTableContainer } from './realms/RealmsTableContainer';
+import {
+  RealmsTableContainer,
+  ValidateCertificatesChangeHandler,
+} from './realms/RealmsTableContainer';
 import { ToolsContainer } from './tools/ToolsContainer';
 import { UsersTableContainer } from './users/UsersTableContainer';
 
@@ -25,17 +28,26 @@ export const ServerAdministration = ({
   onRealmOpened,
   onTabChanged,
   user,
+  validateCertificates,
+  onValidateCertificatesChange,
 }: {
   activeTab: Tab;
   isRealmOpening: boolean;
   onRealmOpened: (path: string) => void;
   onTabChanged: (tab: Tab) => void;
   user: Realm.Sync.User | null;
+  validateCertificates: boolean;
+  onValidateCertificatesChange: ValidateCertificatesChangeHandler;
 }) => {
   let content = null;
   if (user && activeTab === Tab.Realms) {
     content = (
-      <RealmsTableContainer user={user} onRealmOpened={onRealmOpened} />
+      <RealmsTableContainer
+        user={user}
+        onRealmOpened={onRealmOpened}
+        validateCertificates={validateCertificates}
+        onValidateCertificatesChange={onValidateCertificatesChange}
+      />
     );
   } else if (user && activeTab === Tab.Users) {
     content = <UsersTableContainer user={user} />;

--- a/src/ui/server-administration/ServerAdministrationContainer.tsx
+++ b/src/ui/server-administration/ServerAdministrationContainer.tsx
@@ -70,8 +70,11 @@ export class ServerAdministrationContainer extends React.Component<
         authentication: this.props.credentials,
         mode: RealmLoadingMode.Synced,
         path,
+        validateCertificates: this.props.validateCertificates,
       };
-      await main.showRealmBrowser({ realm });
+      await main.showRealmBrowser({
+        realm,
+      });
       this.setState({ isRealmOpening: false });
     }
   };

--- a/src/ui/server-administration/ServerAdministrationContainer.tsx
+++ b/src/ui/server-administration/ServerAdministrationContainer.tsx
@@ -16,15 +16,23 @@ import {
 } from '../../windows/WindowType';
 import { showError } from '../reusable/errors';
 
+import { ValidateCertificatesChangeHandler } from './realms/RealmsTableContainer';
 import { ServerAdministration, Tab } from './ServerAdministration';
 
+export interface IServerAdministrationContainerProps
+  extends IServerAdministrationOptions {
+  onValidateCertificatesChange: ValidateCertificatesChangeHandler;
+}
+
+export interface IServerAdministrationContainerState {
+  activeTab: Tab;
+  isRealmOpening: boolean;
+  user: Realm.Sync.User | null;
+}
+
 export class ServerAdministrationContainer extends React.Component<
-  IServerAdministrationOptions,
-  {
-    activeTab: Tab;
-    isRealmOpening: boolean;
-    user: Realm.Sync.User | null;
-  }
+  IServerAdministrationContainerProps,
+  IServerAdministrationContainerState
 > {
   constructor() {
     super();
@@ -43,7 +51,14 @@ export class ServerAdministrationContainer extends React.Component<
   }
 
   public render() {
-    return <ServerAdministration {...this.state} {...this} />;
+    return (
+      <ServerAdministration
+        {...this.state}
+        {...this}
+        validateCertificates={this.props.validateCertificates}
+        onValidateCertificatesChange={this.props.onValidateCertificatesChange}
+      />
+    );
   }
 
   // TODO: Once the user serializes better, this method should be moved to the ./realms/RealmsTableContainer.tsx

--- a/src/ui/server-administration/realms/RealmsTableContainer.tsx
+++ b/src/ui/server-administration/realms/RealmsTableContainer.tsx
@@ -4,7 +4,9 @@ import * as Realm from 'realm';
 
 import {
   deleteRealm,
+  ILocalRealmToLoad,
   IRealmFile,
+  ISyncedRealmToLoad,
   RealmLoadingMode,
 } from '../../../services/ros';
 import { showError } from '../../reusable/errors';
@@ -15,9 +17,15 @@ import {
 
 import { RealmsTable } from './RealmsTable';
 
+export type ValidateCertificatesChangeHandler = (
+  validateCertificates: boolean,
+) => void;
+
 export interface IRealmTableContainerProps {
-  user: Realm.Sync.User;
   onRealmOpened: (path: string) => void;
+  user: Realm.Sync.User;
+  validateCertificates: boolean;
+  onValidateCertificatesChange: ValidateCertificatesChangeHandler;
 }
 
 export interface IRealmTableContainerState extends IRealmLoadingComponentState {
@@ -41,6 +49,8 @@ export class RealmsTableContainer extends RealmLoadingComponent<
   }
 
   public componentDidMount() {
+    // Tell the RealmLoadingComponent to not validate certificates based on the property
+    this.validateCertificates = this.props.validateCertificates;
     if (this.props.user) {
       this.gotUser(this.props.user);
     }
@@ -97,6 +107,19 @@ export class RealmsTableContainer extends RealmLoadingComponent<
       mode: RealmLoadingMode.Synced,
       path: '__admin',
     });
+  }
+
+  protected async loadRealm(
+    realm: ISyncedRealmToLoad | ILocalRealmToLoad,
+    encryptionKey?: Uint8Array,
+  ) {
+    if (this.certificateWasRejected && !this.validateCertificates) {
+      // TODO: Remove this hack once this Realm JS issue has resolved:
+      // https://github.com/realm/realm-js/issues/1469
+      this.props.onValidateCertificatesChange(this.validateCertificates);
+    } else {
+      return super.loadRealm(realm, encryptionKey);
+    }
   }
 
   protected onRealmChanged = () => {

--- a/src/ui/server-administration/realms/RealmsTableContainer.tsx
+++ b/src/ui/server-administration/realms/RealmsTableContainer.tsx
@@ -49,8 +49,6 @@ export class RealmsTableContainer extends RealmLoadingComponent<
   }
 
   public componentDidMount() {
-    // Tell the RealmLoadingComponent to not validate certificates based on the property
-    this.validateCertificates = this.props.validateCertificates;
     if (this.props.user) {
       this.gotUser(this.props.user);
     }
@@ -106,19 +104,21 @@ export class RealmsTableContainer extends RealmLoadingComponent<
       authentication: this.props.user,
       mode: RealmLoadingMode.Synced,
       path: '__admin',
+      validateCertificates: this.props.validateCertificates,
     });
   }
 
-  protected async loadRealm(
-    realm: ISyncedRealmToLoad | ILocalRealmToLoad,
-    encryptionKey?: Uint8Array,
-  ) {
-    if (this.certificateWasRejected && !this.validateCertificates) {
+  protected async loadRealm(realm: ISyncedRealmToLoad | ILocalRealmToLoad) {
+    if (
+      this.certificateWasRejected &&
+      realm.mode === 'synced' &&
+      !realm.validateCertificates
+    ) {
       // TODO: Remove this hack once this Realm JS issue has resolved:
       // https://github.com/realm/realm-js/issues/1469
-      this.props.onValidateCertificatesChange(this.validateCertificates);
+      this.props.onValidateCertificatesChange(realm.validateCertificates);
     } else {
-      return super.loadRealm(realm, encryptionKey);
+      return super.loadRealm(realm);
     }
   }
 

--- a/src/ui/server-administration/users/UsersTableContainer.tsx
+++ b/src/ui/server-administration/users/UsersTableContainer.tsx
@@ -212,6 +212,7 @@ export class UsersTableContainer extends RealmLoadingComponent<
       authentication: this.props.user,
       mode: RealmLoadingMode.Synced,
       path: '__admin',
+      validateCertificates: true,
     });
   }
 

--- a/src/windows/ServerAdministrationWindow.tsx
+++ b/src/windows/ServerAdministrationWindow.tsx
@@ -13,12 +13,25 @@ export class ServerAdministrationWindow extends Window<
   {}
 > {
   public render() {
-    return <ServerAdministrationContainer {...this.props.options} />;
+    return (
+      <ServerAdministrationContainer
+        {...this.props.options}
+        onValidateCertificatesChange={this.onValidateCertificatesChange}
+      />
+    );
   }
 
-  public getTrackedProperties() {
+  protected getTrackedProperties() {
     return {
       url: this.props.options.credentials.url,
     };
   }
+
+  protected onValidateCertificatesChange = (validateCertificates: boolean) => {
+    const url = new URL(location.href);
+    const options = { ...this.props.options };
+    options.validateCertificates = validateCertificates;
+    url.searchParams.set('options', JSON.stringify(options));
+    location.replace(url.toString());
+  };
 }

--- a/src/windows/Window.ts
+++ b/src/windows/Window.ts
@@ -7,15 +7,15 @@ import { IServerAdministrationOptions } from './WindowType';
 // TODO: Consider if we can have the window not show before a connection has been established.
 
 export abstract class Window<P, S> extends React.Component<P, S> {
-  public getTrackedProperties(): { [n: string]: any } {
-    return {};
-  }
-
   public componentDidMount() {
     const trackedProperties = this.getTrackedProperties();
     mixpanel.track('Window opened', {
       ...trackedProperties,
       type: this.constructor.name,
     });
+  }
+
+  protected getTrackedProperties(): { [n: string]: any } {
+    return {};
   }
 }

--- a/src/windows/WindowType.ts
+++ b/src/windows/WindowType.ts
@@ -16,6 +16,7 @@ export enum WindowType {
 
 export interface IServerAdministrationOptions {
   credentials: IServerCredentials;
+  validateCertificates: boolean;
 }
 
 export interface IRealmBrowserOptions {

--- a/src/windows/WindowType.ts
+++ b/src/windows/WindowType.ts
@@ -1,7 +1,11 @@
 // These enums and interfaces are not in index.tsx to enable the main process to import this without importing
 // React components.
 
-import { IRealmToLoad, IServerCredentials } from '../services/ros';
+import {
+  ILocalRealmToLoad,
+  IServerCredentials,
+  ISyncedRealmToLoad,
+} from '../services/ros';
 
 export enum WindowType {
   ConnectToServer = 'connect-to-server',
@@ -15,7 +19,7 @@ export interface IServerAdministrationOptions {
 }
 
 export interface IRealmBrowserOptions {
-  realm: IRealmToLoad;
+  realm: ISyncedRealmToLoad | ILocalRealmToLoad;
 }
 
 export function getWindowOptions(


### PR DESCRIPTION
This fixes #364 with a message dialog that asks the user if they want to retry with certificate validation disabled.

<img width="1044" alt="skaermbillede 2017-11-06 kl 16 18 59" src="https://user-images.githubusercontent.com/1243959/32448104-4f8a8d7e-c30e-11e7-85b0-d9d495a57a97.png">

![retry-on-windows](https://user-images.githubusercontent.com/1243959/32448285-d1b596d6-c30e-11e7-8ae0-c880d6c09390.png)

Needs to be revisited once we've fixed this issue https://github.com/realm/realm-js/issues/1469.