### PR TITLE
Table of realms revisited

### DIFF
--- a/src/services/ros/index.ts
+++ b/src/services/ros/index.ts
@@ -30,8 +30,9 @@ export interface IUserMetadataRow {
 
 export interface IRealmFile {
   path: string;
-  creatorId: string;
-  creationDate: Date;
+  syncLabel: string;
+  owner: IUser;
+  createdAt: Date;
   permissions: IPermission[];
 }
 

--- a/src/ui/server-administration/realms/RealmSidebar/PermissionsBadge.tsx
+++ b/src/ui/server-administration/realms/RealmSidebar/PermissionsBadge.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { Badge } from 'reactstrap';
+
+interface IPermissionsBadgeProps {
+  isVisible: boolean;
+  label: string;
+  title: string;
+}
+
+export const PermissionsBadge = ({
+  isVisible,
+  label,
+  title,
+}: IPermissionsBadgeProps) =>
+  isVisible ? (
+    <Badge className="PermissionsTable__PermissionsCell__Badge">
+      <span title={title}>{label}</span>
+    </Badge>
+  ) : null;

--- a/src/ui/server-administration/realms/RealmSidebar/PermissionsTable.scss
+++ b/src/ui/server-administration/realms/RealmSidebar/PermissionsTable.scss
@@ -1,0 +1,11 @@
+@import "~realm-studio-styles/variables";
+
+.PermissionsTable {
+  &__PermissionsCell {
+    width: 80px;
+
+    &__Badge {
+      margin: 0 ($spacer / 8);
+    }
+  }
+}

--- a/src/ui/server-administration/realms/RealmSidebar/PermissionsTable.tsx
+++ b/src/ui/server-administration/realms/RealmSidebar/PermissionsTable.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { Badge, Table } from 'reactstrap';
+import * as Realm from 'realm';
+
+import * as ros from '../../../../services/ros';
+import { displayUser } from '../../utils';
+
+import '../../sidebar/SidebarTable.scss';
+import { PermissionsBadge } from './PermissionsBadge';
+import './PermissionsTable.scss';
+
+export const PermissionsTable = ({
+  permissions,
+}: {
+  permissions: Realm.Results<ros.IPermission>;
+}) => (
+  <Table size="sm" className="SidebarTable">
+    <thead>
+      <tr>
+        <th>User permissions</th>
+        <th className="PermissionsTable__PermissionsCell" />
+      </tr>
+    </thead>
+    <tbody>
+      {permissions.length === 0 ? (
+        <tr>
+          <td colSpan={2} className="SidebarTable__EmptyExplanation">
+            This realm has no permissions
+          </td>
+        </tr>
+      ) : (
+        permissions.map((permission, index) => (
+          <tr key={index}>
+            <td>{displayUser(permission.user)}</td>
+            <td>
+              <PermissionsBadge
+                isVisible={permission.mayRead}
+                label="R"
+                title="May read"
+              />
+              <PermissionsBadge
+                isVisible={permission.mayWrite}
+                label="W"
+                title="May write"
+              />
+              <PermissionsBadge
+                isVisible={permission.mayManage}
+                label="M"
+                title="May manage"
+              />
+            </td>
+          </tr>
+        ))
+      )}
+    </tbody>
+  </Table>
+);

--- a/src/ui/server-administration/realms/RealmSidebar/RealmSidebar.tsx
+++ b/src/ui/server-administration/realms/RealmSidebar/RealmSidebar.tsx
@@ -1,19 +1,26 @@
 import * as React from 'react';
 import { Button, Card, CardBlock, CardTitle } from 'reactstrap';
 
-import { Sidebar } from '../../sidebar';
-
 import * as ros from '../../../../services/ros';
 
+import { Sidebar } from '../../sidebar';
+import { displayUser } from '../../utils';
+import { PermissionsTable } from './PermissionsTable';
+
 export const RealmSidebar = ({
+  getRealmPermissions,
   isOpen,
-  realm,
   onRealmDeletion,
+  onRealmOpened,
+  realm,
 }: {
+  getRealmPermissions: (path: string) => Realm.Results<ros.IPermission>;
   isOpen: boolean;
-  realm: ros.IRealmFile | null;
   onRealmDeletion: (path: string) => void;
+  onRealmOpened: (path: string) => void;
+  realm: ros.IRealmFile | null;
 }) => {
+  const permissions = realm ? getRealmPermissions(realm.path) : null;
   return (
     <Sidebar isOpen={isOpen}>
       {realm && (
@@ -22,9 +29,21 @@ export const RealmSidebar = ({
             <CardTitle className="Sidebar__Title">
               <span title={realm.path}>{realm.path}</span>
             </CardTitle>
+            <p>Owned by {displayUser(realm.owner)}</p>
           </CardBlock>
-          <CardBlock className="Sidebar__Tables" />
+          <CardBlock className="Sidebar__Tables">
+            {permissions ? (
+              <PermissionsTable permissions={permissions} />
+            ) : null}
+          </CardBlock>
           <CardBlock className="Sidebar__Controls">
+            <Button
+              size="sm"
+              color="primary"
+              onClick={() => onRealmOpened(realm.path)}
+            >
+              Open
+            </Button>
             <Button
               size="sm"
               color="danger"

--- a/src/ui/server-administration/realms/RealmSidebar/RealmSidebarContainer.tsx
+++ b/src/ui/server-administration/realms/RealmSidebar/RealmSidebarContainer.tsx
@@ -5,9 +5,11 @@ import { RealmSidebar } from './RealmSidebar';
 import * as ros from '../../../../services/ros';
 
 export interface IRealmSidebarContainerProps {
+  getRealmPermissions: (path: string) => Realm.Results<ros.IPermission>;
   isOpen: boolean;
-  realm: ros.IRealmFile | null;
   onRealmDeletion: (path: string) => void;
+  onRealmOpened: (path: string) => void;
+  realm: ros.IRealmFile | null;
 }
 
 export class RealmSidebarContainer extends React.Component<

--- a/src/ui/server-administration/realms/RealmsTable.scss
+++ b/src/ui/server-administration/realms/RealmsTable.scss
@@ -6,16 +6,14 @@ $sidebar-shadow: rgba($color-dove, .66);
   display: flex;
   flex-grow: 1;
 
-  &__selected-row {
-    background: $color-dove;
+  &__row {
+    &--selected {
+      background: $color-dove;
+    }
   }
 
   &__table {
     flex: 1 0;
-  }
-
-  &__row {
-    cursor: pointer;
   }
 
   @import "../../reusable/ReactVirtualized";

--- a/src/ui/server-administration/realms/RealmsTable.tsx
+++ b/src/ui/server-administration/realms/RealmsTable.tsx
@@ -7,7 +7,7 @@ import {
   Table,
 } from 'react-virtualized';
 
-import { IRealmFile } from '../../../services/ros';
+import { IPermission, IRealmFile } from '../../../services/ros';
 import {
   ILoadingProgress,
   LoadingOverlay,
@@ -19,6 +19,7 @@ import './RealmsTable.scss';
 export const RealmsTable = ({
   getRealm,
   getRealmFromId,
+  getRealmPermissions,
   onRealmDeletion,
   onRealmOpened,
   onRealmSelected,
@@ -28,6 +29,7 @@ export const RealmsTable = ({
 }: {
   getRealm: (index: number) => IRealmFile | null;
   getRealmFromId: (path: string) => IRealmFile | null;
+  getRealmPermissions: (path: string) => Realm.Results<IPermission>;
   onRealmDeletion: (path: string) => void;
   onRealmOpened: (path: string) => void;
   onRealmSelected: (path: string | null) => void;
@@ -82,10 +84,12 @@ export const RealmsTable = ({
 
       <RealmSidebar
         isOpen={selectedRealmPath !== null}
+        getRealmPermissions={getRealmPermissions}
+        onRealmDeletion={onRealmDeletion}
+        onRealmOpened={onRealmOpened}
         realm={
           selectedRealmPath !== null ? getRealmFromId(selectedRealmPath) : null
         }
-        onRealmDeletion={onRealmDeletion}
       />
 
       <LoadingOverlay progress={progress} fade={true} />

--- a/src/ui/server-administration/realms/RealmsTable.tsx
+++ b/src/ui/server-administration/realms/RealmsTable.tsx
@@ -62,18 +62,18 @@ export const RealmsTable = ({
               rowCount={realmCount}
               rowGetter={({ index }) => getRealm(index)}
               onRowClick={({ event, index }) => {
+                event.stopPropagation();
                 const realm = getRealm(index);
                 onRealmSelected(
                   realm && realm.path !== selectedRealmPath ? realm.path : null,
                 );
-                event.stopPropagation();
               }}
               onRowDoubleClick={({ event, index }) => {
+                event.stopPropagation();
                 const realm = getRealm(index);
                 if (realm) {
                   onRealmOpened(realm.path);
                 }
-                event.stopPropagation();
               }}
             >
               <Column label="Path" dataKey="path" width={width} />

--- a/src/ui/server-administration/realms/RealmsTableContainer.tsx
+++ b/src/ui/server-administration/realms/RealmsTableContainer.tsx
@@ -101,6 +101,8 @@ export class RealmsTableContainer extends RealmLoadingComponent<
 
   public onRealmOpened = (path: string) => {
     this.props.onRealmOpened(path);
+    // Make sure the Realm that just got opened, is selected
+    this.onRealmSelected(path);
   };
 
   public onRealmSelected = (path: string | null) => {

--- a/src/ui/server-administration/realms/RealmsTableContainer.tsx
+++ b/src/ui/server-administration/realms/RealmsTableContainer.tsx
@@ -76,6 +76,15 @@ export class RealmsTableContainer extends RealmLoadingComponent<
     return this.realm.objectForPrimaryKey<ros.IRealmFile>('RealmFile', path);
   };
 
+  public getRealmPermissions = (
+    path: string,
+  ): Realm.Results<ros.IPermission> => {
+    const realmFile = this.getRealmFromId(path);
+    return this.realm
+      .objects<ros.IPermission>('Permission')
+      .filtered('realmFile == $0', realmFile);
+  };
+
   public onRealmDeletion = async (path: string) => {
     const confirmed = await this.confirmRealmDeletion(path);
     if (confirmed) {

--- a/src/ui/server-administration/sidebar/SidebarTable.scss
+++ b/src/ui/server-administration/sidebar/SidebarTable.scss
@@ -3,6 +3,10 @@
 .SidebarTable {
   table-layout: fixed;
 
+  &--non-fixed {
+    table-layout: auto;
+  }
+
   th {
     border-top: 0;
   }

--- a/src/ui/server-administration/users/UsersTable.scss
+++ b/src/ui/server-administration/users/UsersTable.scss
@@ -5,8 +5,10 @@
   display: flex;
   flex-grow: 1;
 
-  &__selected-row {
-    background: $color-dove;
+  &__row {
+    &--selected {
+      background: $color-dove;
+    }
   }
 
   &__table {

--- a/src/ui/server-administration/users/UsersTable.tsx
+++ b/src/ui/server-administration/users/UsersTable.tsx
@@ -84,7 +84,7 @@ export const UsersTable = ({
               rowClassName={({ index }) => {
                 const user = getUser(index);
                 return classnames('UsersTable__row', {
-                  'UsersTable__selected-row':
+                  'UsersTable__row--selected':
                     user && user.userId === selectedUserId,
                 });
               }}

--- a/src/ui/server-administration/utils.tsx
+++ b/src/ui/server-administration/utils.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import * as ros from '../../services/ros';
+
+export const displayUser = (user: ros.IUser | null) =>
+  user ? (
+    <span title={`ID: ${user.userId}`}>
+      {user.accounts.map(account => (
+        <span title={account.provider}>{account.providerId}</span>
+      ))}
+    </span>
+  ) : (
+    <span>nobody</span>
+  );


### PR DESCRIPTION
This fixes an issue reported by @nirinchev:

> With 1.9.0 it seems you have to double click on a realm to open the browser - this is very counter-intuitive, especially considering the cursor is a hand (which implies a single-click interaction).
> Took me quite a while to figure it out - at some point I was frustrated and just clicking randomly until the browser opened, which is when I figured it out.

This also fixes #134 to fill up the the Realm sidebar with a little more content.
