### PR TITLE
Fix creating synced properties

### DIFF
--- a/src/services/ros/realms.ts
+++ b/src/services/ros/realms.ts
@@ -47,14 +47,12 @@ export const open = async (
   ssl: ISslConfiguration = { validateCertificates: true },
   progressCallback?: Realm.Sync.ProgressNotificationCallback,
   schema?: Realm.ObjectSchema[],
-  schemaVersion?: number,
 ): Promise<Realm> => {
   const url = getUrl(user, realmPath);
 
   const realm = Realm.open({
     encryptionKey,
     schema,
-    schemaVersion,
     sync: {
       url,
       user,

--- a/src/ui/realm-browser/RealmBrowserContainer.tsx
+++ b/src/ui/realm-browser/RealmBrowserContainer.tsx
@@ -168,6 +168,7 @@ export class RealmBrowserContainer extends RealmLoadingComponent<
   public onAddClass = async (name: string) => {
     if (this.realm) {
       try {
+        // The schema version needs to be bumped for local realms
         const nextSchemaVersion = this.realm.schemaVersion + 1;
         // Close the current Realm
         this.realm.close();

--- a/src/ui/reusable/realm-loading-component/RealmLoadingComponent.tsx
+++ b/src/ui/reusable/realm-loading-component/RealmLoadingComponent.tsx
@@ -42,6 +42,7 @@ export abstract class RealmLoadingComponent<
       // Deleting indicates we've closed it
       delete this.realm;
     }
+    this.closeRealm();
     this.cancelLoadingRealms();
   }
 
@@ -55,11 +56,11 @@ export abstract class RealmLoadingComponent<
     schema?: Realm.ObjectSchema[],
     schemaVersion?: number,
   ) {
-    // Remove any existing a change listeners
-    if (this.realm) {
-      this.realm.removeListener('change', this.onRealmChanged);
-    }
+    console.log('loadRealm called with', schemaVersion);
+    // Close the realm - if open
+    this.closeRealm();
 
+    // Should certificates get validated?
     const validateCertificates =
       realm.mode === 'synced' && realm.validateCertificates;
 
@@ -114,6 +115,15 @@ export abstract class RealmLoadingComponent<
           }
         }
       }
+    }
+  }
+
+  protected closeRealm() {
+    // Remove any existing a change listeners
+    if (this.realm) {
+      this.realm.removeListener('change', this.onRealmChanged);
+      this.realm.close();
+      delete this.realm;
     }
   }
 

--- a/src/ui/reusable/realm-loading-component/RealmLoadingComponent.tsx
+++ b/src/ui/reusable/realm-loading-component/RealmLoadingComponent.tsx
@@ -56,7 +56,6 @@ export abstract class RealmLoadingComponent<
     schema?: Realm.ObjectSchema[],
     schemaVersion?: number,
   ) {
-    console.log('loadRealm called with', schemaVersion);
     // Close the realm - if open
     this.closeRealm();
 
@@ -174,7 +173,6 @@ export abstract class RealmLoadingComponent<
         ssl,
         this.progressChanged,
         schema,
-        schemaVersion,
       );
       // Save a wrapping promise so this can be cancelled
       return new Promise<Realm>((resolve, reject) => {


### PR DESCRIPTION
This fixes https://github.com/realm/realm-studio/issues/528 by not passing a schemaVersion to the Realm.open.