### PR TITLE
Allow create primary key column when creating a new class in schema

### DIFF
--- a/src/ui/realm-browser/AddClassModal/View.tsx
+++ b/src/ui/realm-browser/AddClassModal/View.tsx
@@ -82,18 +82,6 @@ export const View = ({
                 <Input
                   type="radio"
                   name="primaryKey"
-                  value={PRIMARY_KEY_OPTIONS.auto.key}
-                  checked={primaryKey === PRIMARY_KEY_OPTIONS.auto.key}
-                  onChange={onPKChange}
-                />
-                <span>{PRIMARY_KEY_OPTIONS.auto.label}</span>
-              </Label>
-            </FormGroup>
-            <FormGroup check>
-              <Label check>
-                <Input
-                  type="radio"
-                  name="primaryKey"
                   value={PRIMARY_KEY_OPTIONS.custom.key}
                   checked={primaryKey === PRIMARY_KEY_OPTIONS.custom.key}
                   onChange={onPKChange}
@@ -109,9 +97,9 @@ export const View = ({
                 <FormGroup>
                   <Label for="primaryKeyName">Name</Label>
                   <Input
+                    placeholder="uuid"
                     name="primaryKeyName"
                     type="text"
-                    required={true}
                     value={primaryKeyName}
                     onChange={onPKNameChange}
                   />

--- a/src/ui/realm-browser/AddClassModal/View.tsx
+++ b/src/ui/realm-browser/AddClassModal/View.tsx
@@ -1,19 +1,18 @@
 import * as React from 'react';
 import {
   Button,
-  Col,
   Form,
   FormFeedback,
   FormGroup,
   Input,
+  InputGroup,
+  InputGroupAddon,
   Label,
   Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
-  Row,
 } from 'reactstrap';
-import { PRIMARY_KEY_OPTIONS } from './';
 
 export const View = ({
   isOpen,
@@ -32,13 +31,13 @@ export const View = ({
   isOpen: boolean;
   toggle: () => void;
   onNameChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onPKChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onPKChange: () => void;
   onPKNameChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onPKTypeChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   name: string;
   nameIsValid: boolean;
-  primaryKey: string;
+  primaryKey: boolean;
   primaryKeyName: string;
   primaryKeyType: string;
 }) => {
@@ -63,79 +62,55 @@ export const View = ({
               </FormFeedback>
             )}
           </FormGroup>
-          <FormGroup>
-            <Label for="name">Primary key</Label>
-            <FormGroup check>
-              <Label check>
+          <FormGroup className={nameIsValid ? '' : 'has-danger'}>
+            <Label for="primaryKey">Primary key</Label>
+            <InputGroup>
+              <InputGroupAddon>
                 <Input
-                  type="radio"
+                  addon
+                  type="checkbox"
+                  id="primaryKey"
                   name="primaryKey"
-                  value={PRIMARY_KEY_OPTIONS.none.key}
-                  checked={primaryKey === PRIMARY_KEY_OPTIONS.none.key}
+                  checked={primaryKey}
                   onChange={onPKChange}
                 />
-                <span>{PRIMARY_KEY_OPTIONS.none.label}</span>
-              </Label>
-            </FormGroup>
-            <FormGroup check>
-              <Label check>
-                <Input
-                  type="radio"
-                  name="primaryKey"
-                  value={PRIMARY_KEY_OPTIONS.custom.key}
-                  checked={primaryKey === PRIMARY_KEY_OPTIONS.custom.key}
-                  onChange={onPKChange}
-                />
-                <span>{PRIMARY_KEY_OPTIONS.custom.label}</span>
-              </Label>
-            </FormGroup>
-          </FormGroup>
-          {primaryKey === PRIMARY_KEY_OPTIONS.custom.key && (
-            <Row>
-              <Col sm={1} />
-              <Col sm={11}>
-                <FormGroup>
-                  <Label for="primaryKeyName">Name</Label>
+              </InputGroupAddon>
+              <Input
+                placeholder="uuid"
+                name="primaryKeyName"
+                type="text"
+                value={primaryKeyName}
+                onChange={onPKNameChange}
+                disabled={!primaryKey}
+              />
+              <InputGroupAddon>
+                <Label check>
                   <Input
-                    placeholder="uuid"
-                    name="primaryKeyName"
-                    type="text"
-                    value={primaryKeyName}
-                    onChange={onPKNameChange}
-                  />
-                </FormGroup>
-                <FormGroup row>
-                  <Col sm={2}>
-                    <Label for="name">Type:</Label>
-                  </Col>
-                  <Col sm={2}>
-                    <Label>
-                      <Input
-                        type="radio"
-                        name="primaryKeyType"
-                        value="int"
-                        checked={primaryKeyType === 'int'}
-                        onChange={onPKTypeChange}
-                      />
-                      <span>int</span>
-                    </Label>
-                  </Col>
-                  <Col sm={2}>
-                    <Label>
-                      <Input
-                        type="radio"
-                        name="primaryKeyType"
-                        value="string"
-                        checked={primaryKeyType === 'string'}
-                        onChange={onPKTypeChange}
-                      />
-                      <span>string</span>
-                    </Label>
-                  </Col>
-                </FormGroup>
-              </Col>
-            </Row>
-          )}
+                    type="radio"
+                    name="primaryKeyType"
+                    value="int"
+                    checked={primaryKeyType === 'int'}
+                    onChange={onPKTypeChange}
+                    disabled={!primaryKey}
+                  />{' '}
+                  int
+                </Label>
+              </InputGroupAddon>
+              <InputGroupAddon>
+                <Label check>
+                  <Input
+                    type="radio"
+                    name="primaryKeyType"
+                    value="string"
+                    checked={primaryKeyType === 'string'}
+                    onChange={onPKTypeChange}
+                    disabled={!primaryKey}
+                  />{' '}
+                  string
+                </Label>
+              </InputGroupAddon>
+            </InputGroup>
+          </FormGroup>
         </ModalBody>
         <ModalFooter>
           <Button color="primary" disabled={!nameIsValid}>

--- a/src/ui/realm-browser/AddClassModal/View.tsx
+++ b/src/ui/realm-browser/AddClassModal/View.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   Button,
+  Col,
   Form,
   FormFeedback,
   FormGroup,
@@ -10,22 +11,36 @@ import {
   ModalBody,
   ModalFooter,
   ModalHeader,
+  Row,
 } from 'reactstrap';
+import { PRIMARY_KEY_OPTIONS } from './';
 
 export const View = ({
   isOpen,
   toggle,
   onNameChange,
+  onPKChange,
+  onPKNameChange,
+  onPKTypeChange,
   onSubmit,
   name,
   nameIsValid,
+  primaryKey,
+  primaryKeyName,
+  primaryKeyType,
 }: {
   isOpen: boolean;
   toggle: () => void;
   onNameChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onPKChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onPKNameChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onPKTypeChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   name: string;
   nameIsValid: boolean;
+  primaryKey: string;
+  primaryKeyName: string;
+  primaryKeyType: string;
 }) => {
   return (
     <Modal isOpen={isOpen} toggle={toggle}>
@@ -48,6 +63,91 @@ export const View = ({
               </FormFeedback>
             )}
           </FormGroup>
+          <FormGroup>
+            <Label for="name">Primary key</Label>
+            <FormGroup check>
+              <Label check>
+                <Input
+                  type="radio"
+                  name="primaryKey"
+                  value={PRIMARY_KEY_OPTIONS.none.key}
+                  checked={primaryKey === PRIMARY_KEY_OPTIONS.none.key}
+                  onChange={onPKChange}
+                />
+                <span>{PRIMARY_KEY_OPTIONS.none.label}</span>
+              </Label>
+            </FormGroup>
+            <FormGroup check>
+              <Label check>
+                <Input
+                  type="radio"
+                  name="primaryKey"
+                  value={PRIMARY_KEY_OPTIONS.auto.key}
+                  checked={primaryKey === PRIMARY_KEY_OPTIONS.auto.key}
+                  onChange={onPKChange}
+                />
+                <span>{PRIMARY_KEY_OPTIONS.auto.label}</span>
+              </Label>
+            </FormGroup>
+            <FormGroup check>
+              <Label check>
+                <Input
+                  type="radio"
+                  name="primaryKey"
+                  value={PRIMARY_KEY_OPTIONS.custom.key}
+                  checked={primaryKey === PRIMARY_KEY_OPTIONS.custom.key}
+                  onChange={onPKChange}
+                />
+                <span>{PRIMARY_KEY_OPTIONS.custom.label}</span>
+              </Label>
+            </FormGroup>
+          </FormGroup>
+          {primaryKey === PRIMARY_KEY_OPTIONS.custom.key && (
+            <Row>
+              <Col sm={1} />
+              <Col sm={11}>
+                <FormGroup>
+                  <Label for="primaryKeyName">Name</Label>
+                  <Input
+                    name="primaryKeyName"
+                    type="text"
+                    required={true}
+                    value={primaryKeyName}
+                    onChange={onPKNameChange}
+                  />
+                </FormGroup>
+                <FormGroup row>
+                  <Col sm={2}>
+                    <Label for="name">Type:</Label>
+                  </Col>
+                  <Col sm={2}>
+                    <Label>
+                      <Input
+                        type="radio"
+                        name="primaryKeyType"
+                        value="int"
+                        checked={primaryKeyType === 'int'}
+                        onChange={onPKTypeChange}
+                      />
+                      <span>int</span>
+                    </Label>
+                  </Col>
+                  <Col sm={2}>
+                    <Label>
+                      <Input
+                        type="radio"
+                        name="primaryKeyType"
+                        value="string"
+                        checked={primaryKeyType === 'string'}
+                        onChange={onPKTypeChange}
+                      />
+                      <span>string</span>
+                    </Label>
+                  </Col>
+                </FormGroup>
+              </Col>
+            </Row>
+          )}
         </ModalBody>
         <ModalFooter>
           <Button color="primary" disabled={!nameIsValid}>

--- a/src/ui/realm-browser/AddClassModal/index.tsx
+++ b/src/ui/realm-browser/AddClassModal/index.tsx
@@ -2,17 +2,6 @@ import * as React from 'react';
 
 import { View } from './View';
 
-export const PRIMARY_KEY_OPTIONS = {
-  none: {
-    key: 'none',
-    label: 'None',
-  },
-  custom: {
-    key: 'custom',
-    label: 'Customized',
-  },
-};
-
 export interface IAddClassModalProps {
   isOpen: boolean;
   onAddClass: (schema: Realm.ObjectSchema) => void;
@@ -23,7 +12,7 @@ export interface IAddClassModalProps {
 export interface IAddClassModalState {
   name: string;
   nameIsValid: boolean;
-  primaryKey: string;
+  primaryKey: boolean;
   primaryKeyName: string;
   primaryKeyType: string;
 }
@@ -31,7 +20,7 @@ export interface IAddClassModalState {
 const initialState = {
   name: '',
   nameIsValid: true,
-  primaryKey: PRIMARY_KEY_OPTIONS.none.key,
+  primaryKey: false,
   primaryKeyName: '',
   primaryKeyType: 'string',
 };
@@ -66,9 +55,9 @@ export class AddClassModal extends React.Component<
     });
   };
 
-  public onPKChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  public onPKChange = () => {
     this.setState({
-      primaryKey: e.target.value,
+      primaryKey: !this.state.primaryKey,
     });
   };
 
@@ -92,13 +81,12 @@ export class AddClassModal extends React.Component<
     const primaryKeyName = this.preparePrimaryKeyName(
       this.state.primaryKeyName,
     );
-    const hasPrimaryKey = primaryKey !== PRIMARY_KEY_OPTIONS.none.key;
 
     return {
       name,
-      ...hasPrimaryKey ? { primaryKey: primaryKeyName } : {},
+      ...primaryKey ? { primaryKey: primaryKeyName } : {},
       properties: {
-        ...hasPrimaryKey ? { [primaryKeyName]: primaryKeyType } : {},
+        ...primaryKey ? { [primaryKeyName]: primaryKeyType } : {},
       },
     };
   };

--- a/src/ui/realm-browser/AddClassModal/index.tsx
+++ b/src/ui/realm-browser/AddClassModal/index.tsx
@@ -7,10 +7,6 @@ export const PRIMARY_KEY_OPTIONS = {
     key: 'none',
     label: 'None',
   },
-  auto: {
-    key: 'auto',
-    label: 'Default',
-  },
   custom: {
     key: 'custom',
     label: 'Customized',
@@ -37,17 +33,7 @@ const initialState = {
   nameIsValid: true,
   primaryKey: PRIMARY_KEY_OPTIONS.none.key,
   primaryKeyName: '',
-  primaryKeyType: 'int',
-};
-
-const customPK = {
-  primaryKeyName: '',
-  primaryKeyType: 'int',
-};
-
-const autoPK = {
-  primaryKeyName: 'UUID',
-  primaryKeyType: 'int',
+  primaryKeyType: 'string',
 };
 
 export class AddClassModal extends React.Component<
@@ -81,13 +67,8 @@ export class AddClassModal extends React.Component<
   };
 
   public onPKChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const isAuto = e.target.value === PRIMARY_KEY_OPTIONS.auto.key;
-    const isCustom = e.target.value === PRIMARY_KEY_OPTIONS.custom.key;
-
     this.setState({
       primaryKey: e.target.value,
-      ...isAuto ? autoPK : {},
-      ...isCustom ? customPK : {},
     });
   };
 
@@ -103,8 +84,14 @@ export class AddClassModal extends React.Component<
     });
   };
 
+  private preparePrimaryKeyName = (primaryKeyName: string) =>
+    primaryKeyName === '' ? 'uuid' : primaryKeyName;
+
   private getSchema = (): Realm.ObjectSchema => {
-    const { name, primaryKey, primaryKeyType, primaryKeyName } = this.state;
+    const { name, primaryKey, primaryKeyType } = this.state;
+    const primaryKeyName = this.preparePrimaryKeyName(
+      this.state.primaryKeyName,
+    );
     const hasPrimaryKey = primaryKey !== PRIMARY_KEY_OPTIONS.none.key;
 
     return {

--- a/src/ui/realm-browser/RealmBrowser.tsx
+++ b/src/ui/realm-browser/RealmBrowser.tsx
@@ -52,7 +52,7 @@ export interface IRealmBrowserProps {
   schemas: Realm.ObjectSchema[];
   selectObject?: ISelectObjectState;
   updateObjectReference: (object: any) => void;
-  onAddClass: (name: string) => void;
+  onAddClass: (schema: Realm.ObjectSchema) => void;
   isAddClassOpen: boolean;
   toggleAddSchema: () => void;
   isClassNameAvailable: (name: string) => boolean;

--- a/src/ui/realm-browser/RealmBrowserContainer.tsx
+++ b/src/ui/realm-browser/RealmBrowserContainer.tsx
@@ -182,7 +182,7 @@ export class RealmBrowserContainer extends RealmLoadingComponent<
     });
   };
 
-  public onAddClass = async (name: string) => {
+  public onAddClass = async (schema: Realm.ObjectSchema) => {
     if (this.realm) {
       try {
         // The schema version needs to be bumped for local realms
@@ -194,13 +194,13 @@ export class RealmBrowserContainer extends RealmLoadingComponent<
         // Load it again with the new schema
         await this.loadRealm(
           this.props.realm,
-          [...this.state.schemas, { name, properties: {} }],
+          [...this.state.schemas, schema],
           nextSchemaVersion,
         );
         // Select the schema when it the realm has loaded
-        this.onClassSelected(name);
+        this.onClassSelected(schema.name);
       } catch (err) {
-        showError(`Failed creating the model "${name}"`, err);
+        showError(`Failed creating the model "${schema.name}"`, err);
       }
     }
   };


### PR DESCRIPTION
Now when you create a new class you have 3 choices for the PK field:

- Without primary key
![nopk](https://user-images.githubusercontent.com/13351933/33939136-46cbbf0a-e00a-11e7-9c74-15dd63a3afa9.gif)

- With a default value (UUID - int)
![defaultpk](https://user-images.githubusercontent.com/13351933/33939161-5d1e0c04-e00a-11e7-8f58-dddd760a4cb5.gif)

- With a customized one
![custompk](https://user-images.githubusercontent.com/13351933/33939172-6bb1b068-e00a-11e7-8cad-9ab0f38f617f.gif)
