### PR TITLE
Reconnect button on loading overlay

### DIFF
--- a/src/ui/server-administration/ServerAdministration.tsx
+++ b/src/ui/server-administration/ServerAdministration.tsx
@@ -33,7 +33,6 @@ export const ServerAdministration = ({
   onReconnect,
   onTabChanged,
   onValidateCertificatesChange,
-  syncError,
   user,
   validateCertificates,
 }: {
@@ -45,7 +44,6 @@ export const ServerAdministration = ({
   onReconnect: () => void;
   onTabChanged: (tab: Tab) => void;
   onValidateCertificatesChange: ValidateCertificatesChangeHandler;
-  syncError?: Realm.Sync.SyncError;
   user: Realm.Sync.User | null;
   validateCertificates: boolean;
 }) => {
@@ -103,7 +101,6 @@ export const ServerAdministration = ({
         <Status
           onReconnect={onReconnect}
           progress={adminRealmProgress}
-          syncError={syncError}
           user={user}
         />
       </Navbar>

--- a/src/ui/server-administration/ServerAdministrationContainer.tsx
+++ b/src/ui/server-administration/ServerAdministrationContainer.tsx
@@ -33,7 +33,6 @@ export interface IServerAdministrationContainerState
   extends IRealmLoadingComponentState {
   activeTab: Tab;
   isRealmOpening: boolean;
-  syncError?: Realm.Sync.SyncError;
   user: Realm.Sync.User | null;
 }
 
@@ -166,7 +165,12 @@ export class ServerAdministrationContainer extends RealmLoadingComponent<
         validateCertificates: this.props.validateCertificates,
       });
     } catch (err) {
-      showError('Failed to open the __admin Realm', err);
+      this.setState({
+        progress: {
+          status: 'failed',
+          message: `Failed to open the __admin Realm: ${err.message}`,
+        },
+      });
     }
   }
 
@@ -202,7 +206,14 @@ export class ServerAdministrationContainer extends RealmLoadingComponent<
       this.certificateWasRejected = true;
     } else {
       this.setState({
-        syncError: error,
+        progress: {
+          status: 'failed',
+          message: error.message,
+          retry: {
+            label: 'Reconnect',
+            onRetry: this.onReconnect,
+          },
+        },
       });
     }
   };

--- a/src/ui/server-administration/Status.tsx
+++ b/src/ui/server-administration/Status.tsx
@@ -7,27 +7,23 @@ import { ILoadingProgress } from '../reusable/loading-overlay';
 export interface IStatusProps {
   onReconnect: () => void;
   progress: ILoadingProgress;
-  syncError?: Realm.Sync.SyncError;
   user: Realm.Sync.User | null;
 }
 
-export const Status = ({
-  onReconnect,
-  progress,
-  syncError,
-  user,
-}: IStatusProps) => {
+export const Status = ({ onReconnect, progress, user }: IStatusProps) => {
   if (user) {
-    if (syncError) {
+    if (progress.status === 'failed') {
       return (
         <p className="ServerAdministration__Status">
           <i className="fa fa-exclamation-circle" /> Failed synchronizing: "
           <span className="ServerAdministration__Status__error">
-            {syncError.message}
+            {progress.message}
           </span>"&nbsp;
-          <Button size="sm" onClick={onReconnect}>
-            Reconnect now
-          </Button>
+          {progress.retry ? (
+            <Button size="sm" onClick={progress.retry.onRetry}>
+              Reconnect now
+            </Button>
+          ) : null}
         </p>
       );
     } else if (progress.status === 'in-progress') {


### PR DESCRIPTION
This uses the loading progress instead of a syncError state.