### PR TITLE
feat (realm-browser): Allow select multiples rows and delete all of them

### DIFF
--- a/src/ui/realm-browser/Content.tsx
+++ b/src/ui/realm-browser/Content.tsx
@@ -36,8 +36,10 @@ export const Content = ({
   onNewObjectClick,
   onQueryChange,
   onQueryHelp,
+  onResetHighlight,
   onSortEnd,
   onSortStart,
+  onTableBackgroundClick,
   progress,
   query,
 }: {
@@ -58,8 +60,10 @@ export const Content = ({
   onNewObjectClick?: () => void;
   onQueryChange: (query: string) => void;
   onQueryHelp: () => void;
+  onResetHighlight: () => void;
   onSortEnd?: SortEndHandler;
   onSortStart?: SortStartHandler;
+  onTableBackgroundClick: () => void;
   progress?: ILoadingProgress;
   query: string;
 }) => {
@@ -95,8 +99,10 @@ export const Content = ({
           onCellHighlighted={onCellHighlighted}
           onCellValidated={onCellValidated}
           onContextMenu={onContextMenu}
+          onResetHighlight={onResetHighlight}
           onSortEnd={onSortEnd}
           onSortStart={onSortStart}
+          onTableBackgroundClick={onTableBackgroundClick}
           query={query}
         />
         <Bottombar

--- a/src/ui/realm-browser/ContentContainer.tsx
+++ b/src/ui/realm-browser/ContentContainer.tsx
@@ -32,6 +32,7 @@ export interface IContentContainerProps {
   onCommitTransaction?: () => void;
   onContextMenu?: CellContextMenuHandler;
   onNewObjectClick?: () => void;
+  onResetHighlight: () => void;
   onSortEnd?: SortEndHandler;
   onSortStart?: SortStartHandler;
   progress?: ILoadingProgress;
@@ -52,10 +53,20 @@ export class ContentContainer extends React.Component<
     };
   }
 
+  public componentDidUpdate(
+    prevProps: IContentContainerProps,
+    prevState: IContentContainerState,
+  ) {
+    if (this.state.query !== prevState.query) {
+      this.props.onResetHighlight();
+    }
+  }
+
   public render() {
     return (
       <Content
         editMode={this.props.editMode || EditMode.InputBlur}
+        onTableBackgroundClick={this.onTableBackgroundClick}
         {...this.state}
         {...this.props}
         {...this}
@@ -71,5 +82,10 @@ export class ContentContainer extends React.Component<
     const url =
       'https://realm.io/docs/javascript/latest/api/tutorial-query-language.html';
     electron.shell.openExternal(url);
+  };
+
+  protected onTableBackgroundClick = () => {
+    // When clicking outside a cell. Reset the highlight.
+    this.props.onResetHighlight();
   };
 }

--- a/src/ui/realm-browser/RealmBrowser.scss
+++ b/src/ui/realm-browser/RealmBrowser.scss
@@ -243,6 +243,7 @@ $highlight-row-color: $black;
     }
 
     &__Cell {
+      user-select: none;
       &--highlighted {
         background: $highlight-cell-bg;
       }

--- a/src/ui/realm-browser/RealmBrowser.scss
+++ b/src/ui/realm-browser/RealmBrowser.scss
@@ -14,7 +14,6 @@ $realm-browser-more-indicator-light-color: rgba(0, 0, 0, 0);
 
 $color-row-stripe: mix($white, $color-dove, 50%);
 $highlight-row-bg: mix($white, $color-indigo, 75%);
-$highlight-cell-bg: mix($white, $color-indigo, 60%);
 $highlight-row-color: $black;
 
 .RealmBrowser {
@@ -203,7 +202,7 @@ $highlight-row-color: $black;
     &__Row {
       background: $white;
       position: relative;
-      transition: background-color 400ms;
+      transition: background-color 200ms;
 
       &--striped {
         background: $color-row-stripe;
@@ -244,9 +243,6 @@ $highlight-row-color: $black;
 
     &__Cell {
       user-select: none;
-      &--highlighted {
-        background: $highlight-cell-bg;
-      }
     }
 
     &__HeaderCell {

--- a/src/ui/realm-browser/RealmBrowser.tsx
+++ b/src/ui/realm-browser/RealmBrowser.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import * as Realm from 'realm';
 
-import { CreateObjectHandler, EditMode, ISelectObjectState } from '.';
+import {
+  CreateObjectHandler,
+  EditMode,
+  IConfirmModal,
+  ISelectObjectState,
+} from '.';
 import { ConfirmModal } from '../reusable/confirm-modal';
 import { ILoadingProgress, LoadingOverlay } from '../reusable/loading-overlay';
 import { AddClassModal } from './AddClassModal';
@@ -27,10 +32,7 @@ import './RealmBrowser.scss';
 
 export interface IRealmBrowserProps {
   columnToHighlight?: number;
-  confirmModal?: {
-    yes: () => void;
-    no: () => void;
-  };
+  confirmModal?: IConfirmModal;
   createObjectSchema?: Realm.ObjectSchema;
   dataVersion: number;
   dataVersionAtBeginning?: number;
@@ -151,8 +153,8 @@ export const RealmBrowser = ({
       </div>
       {confirmModal && (
         <ConfirmModal
-          title="Deleting object ..."
-          description="Are you sure you want to delete this object?"
+          title={confirmModal.title}
+          description={confirmModal.description}
           status={true}
           yes={confirmModal.yes}
           no={confirmModal.no}

--- a/src/ui/realm-browser/RealmBrowser.tsx
+++ b/src/ui/realm-browser/RealmBrowser.tsx
@@ -58,10 +58,11 @@ export interface IRealmBrowserProps {
   onCommitTransaction: () => void;
   onContextMenu: CellContextMenuHandler;
   onCreateDialogToggle: () => void;
-  onNewObjectClick: () => void;
   onCreateObject: CreateObjectHandler;
   onHideEncryptionDialog: () => void;
+  onNewObjectClick: () => void;
   onOpenWithEncryption: (key: string) => void;
+  onResetHighlight: () => void;
   onSortEnd: SortEndHandler;
   onSortStart: SortStartHandler;
   progress: ILoadingProgress;
@@ -100,11 +101,12 @@ export const RealmBrowser = ({
   onClassSelected,
   onCommitTransaction,
   onContextMenu,
-  onNewObjectClick,
   onCreateDialogToggle,
   onCreateObject,
   onHideEncryptionDialog,
+  onNewObjectClick,
   onOpenWithEncryption,
+  onResetHighlight,
   onSortEnd,
   onSortStart,
   progress,
@@ -146,6 +148,7 @@ export const RealmBrowser = ({
           onCommitTransaction={onCommitTransaction}
           onContextMenu={onContextMenu}
           onNewObjectClick={onNewObjectClick}
+          onResetHighlight={onResetHighlight}
           onSortEnd={onSortEnd}
           onSortStart={onSortStart}
           progress={progress}

--- a/src/ui/realm-browser/RealmBrowserContainer.tsx
+++ b/src/ui/realm-browser/RealmBrowserContainer.tsx
@@ -876,6 +876,10 @@ export class RealmBrowserContainer
     });
   };
 
+  public onResetHighlight = () => {
+    this.setState({ highlight: this.generateHighlight() });
+  };
+
   protected onRealmChanged = () => {
     this.setState({ dataVersion: this.state.dataVersion + 1 });
   };
@@ -928,10 +932,6 @@ export class RealmBrowserContainer
         },
       );
     }
-  };
-
-  protected onResetHighlight = () => {
-    this.setState({ highlight: this.generateHighlight() });
   };
 
   protected addListeners() {

--- a/src/ui/realm-browser/RealmBrowserContainer.tsx
+++ b/src/ui/realm-browser/RealmBrowserContainer.tsx
@@ -930,6 +930,10 @@ export class RealmBrowserContainer
     }
   };
 
+  protected onResetHighlight = () => {
+    this.setState({ highlight: this.generateHighlight() });
+  };
+
   protected addListeners() {
     ipcRenderer.addListener('export-schema', this.onExportSchema);
     window.addEventListener<'beforeunload'>(

--- a/src/ui/realm-browser/index.ts
+++ b/src/ui/realm-browser/index.ts
@@ -21,3 +21,10 @@ export enum EditMode {
 
 export type CreateObjectHandler = (className: string, values: {}) => void;
 export type EditModeChangeHandler = (editMode: EditMode) => void;
+
+export interface IConfirmModal {
+  title: string;
+  description: string;
+  yes: () => void;
+  no: () => void;
+}

--- a/src/ui/realm-browser/object-selector/ObjectSelector.tsx
+++ b/src/ui/realm-browser/object-selector/ObjectSelector.tsx
@@ -12,29 +12,32 @@ export interface IObjectSelectorStateProps {
 }
 
 export interface IObjectSelectorProps extends IObjectSelectorStateProps {
-  toggle: () => void;
   highlight?: IHighlight;
   isOptional: boolean;
   onCellClick: CellClickHandler;
+  onResetHighlight: () => void;
   onSelectObject: () => void;
   selectedObject: Realm.Object | null;
+  toggle: () => void;
 }
 
 export const ObjectSelector = ({
-  toggle,
   focus,
   highlight,
+  isOpen,
   isOptional,
   onCellClick,
+  onResetHighlight,
   onSelectObject,
   selectedObject,
-  isOpen,
+  toggle,
 }: IObjectSelectorProps) => (
   <Modal size="lg" isOpen={isOpen} toggle={toggle} className="ConfirmModal">
     <ModalHeader toggle={toggle}>Select a new {focus.className}</ModalHeader>
     <ModalBody className="RealmBrowser__SelectObject">
       <ContentContainer
         editMode={EditMode.Disabled}
+        onResetHighlight={onResetHighlight}
         focus={focus}
         highlight={highlight}
         onCellClick={onCellClick}

--- a/src/ui/realm-browser/object-selector/ObjectSelectorContainer.tsx
+++ b/src/ui/realm-browser/object-selector/ObjectSelectorContainer.tsx
@@ -34,6 +34,7 @@ export class ObjectSelectorContainer extends React.Component<
         isOpen={this.props.isOpen}
         isOptional={this.props.isOptional || false}
         onCellClick={this.onCellClick}
+        onResetHighlight={this.onResetHighlight}
         onSelectObject={this.onSelectObject}
         toggle={this.props.toggle}
         {...this.state}
@@ -53,6 +54,16 @@ export class ObjectSelectorContainer extends React.Component<
         rows: new Set([rowIndex]),
       },
       selectedObject: rowObject,
+    });
+  };
+
+  private onResetHighlight = () => {
+    this.setState({
+      highlight: {
+        column: 0,
+        rows: new Set([]),
+      },
+      selectedObject: null,
     });
   };
 

--- a/src/ui/realm-browser/object-selector/ObjectSelectorContainer.tsx
+++ b/src/ui/realm-browser/object-selector/ObjectSelectorContainer.tsx
@@ -50,7 +50,7 @@ export class ObjectSelectorContainer extends React.Component<
     this.setState({
       highlight: {
         column: columnIndex,
-        rows: [rowIndex],
+        rows: new Set([rowIndex]),
       },
       selectedObject: rowObject,
     });

--- a/src/ui/realm-browser/object-selector/ObjectSelectorContainer.tsx
+++ b/src/ui/realm-browser/object-selector/ObjectSelectorContainer.tsx
@@ -50,7 +50,7 @@ export class ObjectSelectorContainer extends React.Component<
     this.setState({
       highlight: {
         column: columnIndex,
-        row: rowIndex,
+        rows: [rowIndex],
       },
       selectedObject: rowObject,
     });

--- a/src/ui/realm-browser/table/Cell.tsx
+++ b/src/ui/realm-browser/table/Cell.tsx
@@ -118,9 +118,7 @@ export const Cell = ({
   });
   return (
     <div
-      className={classNames('RealmBrowser__Table__Cell', {
-        'RealmBrowser__Table__Cell--highlighted': isHighlighted,
-      })}
+      className={classNames('RealmBrowser__Table__Cell')}
       onClick={onCellClick}
       onContextMenu={onContextMenu}
       style={style}

--- a/src/ui/realm-browser/table/ContentGrid.tsx
+++ b/src/ui/realm-browser/table/ContentGrid.tsx
@@ -59,6 +59,12 @@ export interface IContentGridProps extends Partial<GridProps> {
   rowHeight: number;
   width: number;
 }
+const isRowHighlighted = (
+  highlight: IHighlight | undefined,
+  rowIndex: number,
+): boolean =>
+  (highlight && highlight.rows.find(row => row === rowIndex) !== undefined) ||
+  false;
 
 export class ContentGrid extends React.PureComponent<IContentGridProps, {}> {
   private cellRangeRenderer?: GridCellRangeRenderer;
@@ -120,17 +126,10 @@ export class ContentGrid extends React.PureComponent<IContentGridProps, {}> {
 
     const rowRenderer: GridRowRenderer = (rowProps: IGridRowProps) => {
       const { highlight, isSorting } = this.props;
-      const isHighlighted =
-        (highlight && highlight.row === rowProps.rowIndex) ||
-        (highlight &&
-          highlight.rowsSelected &&
-          highlight.rowsSelected.find(
-            otherRowSelected => otherRowSelected === rowProps.rowIndex,
-          ) !== undefined) ||
-        false;
+
       return (
         <Row
-          isHighlighted={isHighlighted}
+          isHighlighted={isRowHighlighted(highlight, rowProps.rowIndex)}
           key={rowProps.key}
           isSorting={isSorting}
           {...rowProps}
@@ -170,14 +169,15 @@ export class ContentGrid extends React.PureComponent<IContentGridProps, {}> {
           const { rowIndex, columnIndex } = cellProps;
           const rowObject = filteredSortedResults[cellProps.rowIndex];
           const cellValue = getCellValue(rowObject, cellProps);
-          const isHighlighted = highlight
-            ? highlight.row === rowIndex && highlight.column === columnIndex
+          const isCellHighlighted = highlight
+            ? isRowHighlighted(highlight, rowIndex) &&
+              highlight.column === columnIndex
             : false;
 
           return (
             <Cell
               editMode={editMode}
-              isHighlighted={isHighlighted}
+              isHighlighted={isCellHighlighted}
               key={cellProps.key}
               onCellClick={e => {
                 if (onCellClick) {
@@ -213,8 +213,9 @@ export class ContentGrid extends React.PureComponent<IContentGridProps, {}> {
               onHighlighted={() => {
                 if (onCellHighlighted) {
                   onCellHighlighted({
-                    row: rowIndex,
+                    rows: [rowIndex],
                     column: columnIndex,
+                    rowReferenceShiftClick: rowIndex,
                   });
                 }
               }}

--- a/src/ui/realm-browser/table/ContentGrid.tsx
+++ b/src/ui/realm-browser/table/ContentGrid.tsx
@@ -121,7 +121,13 @@ export class ContentGrid extends React.PureComponent<IContentGridProps, {}> {
     const rowRenderer: GridRowRenderer = (rowProps: IGridRowProps) => {
       const { highlight, isSorting } = this.props;
       const isHighlighted =
-        (highlight && highlight.row === rowProps.rowIndex) || false;
+        (highlight && highlight.row === rowProps.rowIndex) ||
+        (highlight &&
+          highlight.rowsSelected &&
+          highlight.rowsSelected.find(
+            otherRowSelected => otherRowSelected === rowProps.rowIndex,
+          ) !== undefined) ||
+        false;
       return (
         <Row
           isHighlighted={isHighlighted}
@@ -175,13 +181,16 @@ export class ContentGrid extends React.PureComponent<IContentGridProps, {}> {
               key={cellProps.key}
               onCellClick={e => {
                 if (onCellClick) {
-                  onCellClick({
-                    cellValue,
-                    columnIndex,
-                    property,
-                    rowIndex,
-                    rowObject,
-                  });
+                  onCellClick(
+                    {
+                      cellValue,
+                      columnIndex,
+                      property,
+                      rowIndex,
+                      rowObject,
+                    },
+                    e,
+                  );
                 }
               }}
               onValidated={valid => {

--- a/src/ui/realm-browser/table/ContentGrid.tsx
+++ b/src/ui/realm-browser/table/ContentGrid.tsx
@@ -118,6 +118,8 @@ export class ContentGrid extends React.PureComponent<IContentGridProps, {}> {
       key={cellProps.key}
       className="RealmBrowser__Table__Cell"
       style={cellProps.style}
+      // Prevent a click through to the table
+      onClick={e => e.stopPropagation()}
     />
   );
 
@@ -179,6 +181,8 @@ export class ContentGrid extends React.PureComponent<IContentGridProps, {}> {
               isHighlighted={isCellHighlighted}
               key={cellProps.key}
               onCellClick={e => {
+                // Prevent a click through to the table
+                e.stopPropagation();
                 if (onCellClick) {
                   onCellClick(
                     {

--- a/src/ui/realm-browser/table/ContentGrid.tsx
+++ b/src/ui/realm-browser/table/ContentGrid.tsx
@@ -62,9 +62,9 @@ export interface IContentGridProps extends Partial<GridProps> {
 const isRowHighlighted = (
   highlight: IHighlight | undefined,
   rowIndex: number,
-): boolean =>
-  (highlight && highlight.rows.find(row => row === rowIndex) !== undefined) ||
-  false;
+): boolean => {
+  return highlight ? highlight.rows.has(rowIndex) : false;
+};
 
 export class ContentGrid extends React.PureComponent<IContentGridProps, {}> {
   private cellRangeRenderer?: GridCellRangeRenderer;
@@ -170,8 +170,7 @@ export class ContentGrid extends React.PureComponent<IContentGridProps, {}> {
           const rowObject = filteredSortedResults[cellProps.rowIndex];
           const cellValue = getCellValue(rowObject, cellProps);
           const isCellHighlighted = highlight
-            ? isRowHighlighted(highlight, rowIndex) &&
-              highlight.column === columnIndex
+            ? isRowHighlighted(highlight, rowIndex)
             : false;
 
           return (
@@ -200,6 +199,7 @@ export class ContentGrid extends React.PureComponent<IContentGridProps, {}> {
               }}
               onContextMenu={e => {
                 e.stopPropagation();
+                // Open the context menu
                 if (onContextMenu) {
                   onContextMenu(e, {
                     cellValue,
@@ -213,9 +213,8 @@ export class ContentGrid extends React.PureComponent<IContentGridProps, {}> {
               onHighlighted={() => {
                 if (onCellHighlighted) {
                   onCellHighlighted({
-                    rows: [rowIndex],
-                    column: columnIndex,
-                    rowReferenceShiftClick: rowIndex,
+                    rowIndex,
+                    columnIndex,
                   });
                 }
               }}

--- a/src/ui/realm-browser/table/Table.tsx
+++ b/src/ui/realm-browser/table/Table.tsx
@@ -49,6 +49,7 @@ export interface ITableProps {
   onSortClick: (property: IPropertyWithName) => void;
   onSortEnd?: SortEndHandler;
   onSortStart?: SortStartHandler;
+  onTableBackgroundClick: () => void;
   scrollProps: ScrollSyncProps;
   sizeProps: AutoSizerProps;
   sorting?: ISorting;
@@ -75,6 +76,7 @@ export const Table = ({
   onSortClick,
   onSortEnd,
   onSortStart,
+  onTableBackgroundClick,
   scrollProps,
   sizeProps,
   sorting,
@@ -99,6 +101,9 @@ export const Table = ({
         if (onContextMenu) {
           onContextMenu(e);
         }
+      }}
+      onClick={e => {
+        onTableBackgroundClick();
       }}
     >
       <MoreIndicator position="bottom" visible={scrollBottom > 0} />

--- a/src/ui/realm-browser/table/TableContainer.tsx
+++ b/src/ui/realm-browser/table/TableContainer.tsx
@@ -34,6 +34,8 @@ export interface IBaseTableContainerProps {
   onCellHighlighted?: CellHighlightedHandler;
   onCellValidated?: CellValidatedHandler;
   onContextMenu?: CellContextMenuHandler;
+  onResetHighlight: () => void;
+  onTableBackgroundClick: () => void;
   onSortEnd?: SortEndHandler;
   onSortStart?: SortStartHandler;
   query: string;
@@ -93,6 +95,7 @@ export class TableContainer extends React.PureComponent<
         onSortClick={this.onSortClick}
         onSortEnd={this.onSortEnd}
         onSortStart={this.onSortStart}
+        onTableBackgroundClick={this.props.onTableBackgroundClick}
         scrollProps={this.props.scrollProps}
         sizeProps={this.props.sizeProps}
         sorting={this.state.sorting}
@@ -152,6 +155,10 @@ export class TableContainer extends React.PureComponent<
         this.gridContent.recomputeGridSize();
         this.gridHeader.recomputeGridSize();
       }
+    }
+
+    if (this.state.sorting !== prevState.sorting) {
+      this.props.onResetHighlight();
     }
   }
 

--- a/src/ui/realm-browser/table/TableContainer.tsx
+++ b/src/ui/realm-browser/table/TableContainer.tsx
@@ -126,16 +126,16 @@ export class TableContainer extends React.PureComponent<
     prevState: ITableContainerState,
   ) {
     if (this.gridContent && this.props.highlight) {
-      const rowChanged =
+      const rowsChanged =
         !prevProps.highlight ||
-        prevProps.highlight.row !== this.props.highlight.row;
+        prevProps.highlight.rows !== this.props.highlight.rows;
       const columnChanged =
         !prevProps.highlight ||
         prevProps.highlight.column !== this.props.highlight.column;
-      if (rowChanged || columnChanged) {
+      if (rowsChanged || columnChanged) {
         this.gridContent.scrollToCell({
           columnIndex: this.props.highlight.column || 0,
-          rowIndex: this.props.highlight.row || 0,
+          rowIndex: this.props.highlight.rows[0] || 0,
         });
       }
     } else if (this.gridContent && this.props.focus !== prevProps.focus) {

--- a/src/ui/realm-browser/table/TableContainer.tsx
+++ b/src/ui/realm-browser/table/TableContainer.tsx
@@ -135,7 +135,7 @@ export class TableContainer extends React.PureComponent<
       if (rowsChanged || columnChanged) {
         this.gridContent.scrollToCell({
           columnIndex: this.props.highlight.column || 0,
-          rowIndex: this.props.highlight.rows[0] || 0,
+          rowIndex: this.props.highlight.lastRowIndexClicked || 0,
         });
       }
     } else if (this.gridContent && this.props.focus !== prevProps.focus) {

--- a/src/ui/realm-browser/table/index.ts
+++ b/src/ui/realm-browser/table/index.ts
@@ -19,6 +19,7 @@ export type CellClickHandler = (
     rowIndex: number;
     columnIndex: number;
   },
+  e?: React.MouseEvent<any>,
 ) => void;
 
 export type CellContextMenuHandler = (
@@ -44,6 +45,7 @@ export interface IHighlight {
   row?: number;
   column?: number;
   center?: boolean;
+  rowsSelected?: number[];
 }
 
 export interface ISorting {

--- a/src/ui/realm-browser/table/index.ts
+++ b/src/ui/realm-browser/table/index.ts
@@ -33,7 +33,9 @@ export type CellContextMenuHandler = (
   },
 ) => void;
 
-export type CellHighlightedHandler = (highlight: IHighlight) => void;
+export type CellHighlightedHandler = (
+  cell: { rowIndex: number; columnIndex: number },
+) => void;
 
 export type CellValidatedHandler = (
   rowIndex: number,
@@ -42,15 +44,11 @@ export type CellValidatedHandler = (
 ) => void;
 
 export interface IHighlight {
-  rows: number[];
+  rows: Set<number>;
   column?: number;
   center?: boolean;
-  rowReferenceShiftClick?: number | undefined;
+  lastRowIndexClicked?: number;
 }
-
-export const defaultHighlightValue = {
-  rows: [],
-};
 
 export interface ISorting {
   property: IPropertyWithName;

--- a/src/ui/realm-browser/table/index.ts
+++ b/src/ui/realm-browser/table/index.ts
@@ -42,11 +42,15 @@ export type CellValidatedHandler = (
 ) => void;
 
 export interface IHighlight {
-  row?: number;
+  rows: number[];
   column?: number;
   center?: boolean;
-  rowsSelected?: number[];
+  rowReferenceShiftClick?: number | undefined;
 }
+
+export const defaultHighlightValue = {
+  rows: [],
+};
 
 export interface ISorting {
   property: IPropertyWithName;

--- a/src/ui/reusable/utils.ts
+++ b/src/ui/reusable/utils.ts
@@ -1,0 +1,5 @@
+export const getRange = (number1: number, number2: number): number[] => {
+  const start = Math.min(number1, number2);
+  const end = Math.max(number1, number2);
+  return Array.from({ length: 1 + end - start }, (v, k) => k + start);
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
       "es5",
       "es6"
     ],
+    "downlevelIteration": true,
     "noImplicitAny": true,
     "removeComments": true,
     "sourceMap": true,


### PR DESCRIPTION
@kraenhansen Main logic is done and currently, you can select multiples rows and delete them but I am still working on cleaning the code.

![multipleselectdelete](https://user-images.githubusercontent.com/13351933/34608417-8583634a-f218-11e7-94bf-795b7af65e72.gif)
