### PR TITLE
Fixing windows flicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ The application has support for some parameters that can be supplied when starti
 
       DISPLAY=1 npm run dev
 
-- If the `OPEN_DEV_TOOLS` environment variable is sat every window being opened will have the developer tools opened.
+- If the `REALM_STUDIO_DEV_TOOLS` environment variable is sat every window being opened will have the developer
+tools opened.
 
-      OPEN_DEV_TOOLS=true npm run dev
+      REALM_STUDIO_DEV_TOOLS=true npm run dev
 
 - If the `REACT_PERF` environment variable is sat, the window URLs will get "?react_perf" appended, which will
 activate profiling of React components on the Chrome timeline:

--- a/src/main/WindowManager.ts
+++ b/src/main/WindowManager.ts
@@ -34,7 +34,7 @@ export class WindowManager {
     });
 
     // Open up the dev tools, if not in production mode
-    if (!isProduction && process.env.OPEN_DEV_TOOLS) {
+    if (process.env.REALM_STUDIO_DEV_TOOLS) {
       window.webContents.once('did-finish-load', () => {
         window.webContents.openDevTools({
           mode: 'detach',

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -8,6 +8,9 @@
 // Applying https://www.mobomo.com/2014/05/better-font-smoothing-in-chrome-on-mac-os-x/
 html {
   -webkit-font-smoothing: antialiased;
+  // Adding "overflow: hidden;" to prevent scrollbar flickering on Windows
+  // fixing https://github.com/realm/realm-studio/issues/599
+  overflow: hidden;
 }
 
 body {


### PR DESCRIPTION
This fixes #599 by adding an overflow hidden on the root html element.

All lists expecting a scrollbar must implement their own container with `overflow: auto;` or similar.