### PR TITLE
Open cloud urls

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,2 @@
-export const PROTOCOL = 'x-realm-studio';
+export const CLOUD_PROTOCOL = 'x-realm-cloud';
+export const STUDIO_PROTOCOL = 'x-realm-studio';

--- a/src/main/Application.ts
+++ b/src/main/Application.ts
@@ -338,8 +338,8 @@ export class Application {
         }
       }
     } else if (url.protocol === `${CLOUD_PROTOCOL}:`) {
-      // Check the hostname to ensure it ends on "realm.io"
-      const trustedHosts = ['.realm.io'];
+      // Check the hostname to ensure it ends on a trusted domain
+      const trustedHosts = ['.realm.io', '.realmlab.net'];
       const trusted = trustedHosts.reduce((result, host) => {
         return result || url.host.endsWith(host);
       }, false);

--- a/src/services/github/index.ts
+++ b/src/services/github/index.ts
@@ -2,7 +2,7 @@ import * as electron from 'electron';
 import { URL } from 'url';
 import { v4 as uuid } from 'uuid';
 
-import { PROTOCOL } from '../../constants';
+import { STUDIO_PROTOCOL } from '../../constants';
 
 interface IAuthenticationHandler {
   resolve: (code: string) => void;
@@ -14,7 +14,7 @@ const authenticationPromises: { [state: string]: IAuthenticationHandler } = {};
 export const OPEN_URL_ACTION = 'github-oauth';
 export const GITHUB_CLIENT_ID = '9e947af0f244f295235c';
 export const GITHUB_AUTHORIZE_URL = 'https://github.com/login/oauth/authorize';
-export const GITHUB_REDIRECT_URI = `${PROTOCOL}://${OPEN_URL_ACTION}`;
+export const GITHUB_REDIRECT_URI = `${STUDIO_PROTOCOL}://${OPEN_URL_ACTION}`;
 
 export interface IOAuthCallbackOptions {
   code: string;


### PR DESCRIPTION
This fixes #612 by registering the app as a listener for "x-realm-cloud" links and validating the domain name agains a list of trusted domains, propting the user to proceed if the domain name is not trusted (.realm.io or .realmlab.net):

<img width="532" alt="skaermbillede 2018-01-17 kl 12 28 29" src="https://user-images.githubusercontent.com/1243959/35041304-946b7d8c-fb84-11e7-83b0-57568f059bf9.png">

☝️ this says realm.io, but this was just to test the dialog - it will only show if not trusted.