### PR TITLE
Ensuring svg-baker and svg-sprite-loader runtimes gets into the bundle

### DIFF
--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -13,6 +13,8 @@ module.exports = (env) => {
       whitelist: [
         /webpack(\/.*)?/,
         'electron-devtools-installer',
+        /svg-baker-runtime(\/.*)?/,
+        /svg-sprite-loader(\/.*)?/,
       ]
     }),
   ];


### PR DESCRIPTION
This fixes #622