### PR TITLE
Comparing usernames when opening Cloud URLs

### DIFF
--- a/src/actions/main/Sender.ts
+++ b/src/actions/main/Sender.ts
@@ -19,7 +19,10 @@ export class Sender extends ActionSender {
     );
   }
 
-  public authenticateWithEmail(email: string, password: string): Promise<void> {
+  public authenticateWithEmail(
+    email: string,
+    password: string,
+  ): Promise<raas.user.IAuthResponse> {
     return this.send(MainActions.AuthenticateWithEmail, email, password);
   }
 

--- a/src/main/Application.ts
+++ b/src/main/Application.ts
@@ -290,7 +290,10 @@ export class Application {
         this.cloudManager.addListener(listener);
         // Reject the promise if the window is closed before cloud status turns authenticated
         window.once('close', () => {
-          reject(new Error('Window was closed'));
+          // We need a timeout here, because the close event fires before the cloud status updates
+          setTimeout(() => {
+            reject(new Error('Window was closed'));
+          }, 500);
         });
       } else {
         window.webContents.once('did-finish-load', () => {

--- a/src/main/Application.ts
+++ b/src/main/Application.ts
@@ -279,10 +279,7 @@ export class Application {
       // If resolve user is true - we wait for the authentication before resolving
       if (resolveUser) {
         const listener = (status: ICloudStatus) => {
-          if (
-            status.kind === 'authenticated' ||
-            status.kind === 'has-primary-subscription'
-          ) {
+          if (status.kind === 'authenticated') {
             this.cloudManager.removeListener(listener);
             resolve(status.user);
           } else if (status.kind === 'error') {

--- a/src/ui/CloudAuthentication/index.tsx
+++ b/src/ui/CloudAuthentication/index.tsx
@@ -52,6 +52,7 @@ class CloudAuthenticationContainer extends React.Component<
       this.setState({ isLoading: true, error: undefined });
       await main.authenticateWithEmail(email, password);
       this.setState({ isLoading: false });
+      this.setCloudIntroduced(true);
       // Close this window ..
       window.close();
     } catch (err) {

--- a/src/ui/greeting/CloudAction/CloudAction.tsx
+++ b/src/ui/greeting/CloudAction/CloudAction.tsx
@@ -45,35 +45,47 @@ export const CloudAction = ({
       </Alert>
     );
   } else if (cloudStatus && cloudStatus.kind === 'authenticated') {
-    return cloudStatus.user.canCreate ? (
-      <Button onClick={onServerCreate} color="primary">
-        Create Realm Cloud server
-      </Button>
-    ) : (
-      <Alert className="CloudAction__Alert" color="info">
-        You're on the waitlist to use Realm Cloud!{' '}
-        <span
-          className="CloudAction__ActionIcon"
-          onClick={() => onShare('twitter')}
-          title="Now that's something worth tweeting about!"
+    if (cloudStatus.primarySubscription) {
+      return (
+        <Button
+          onClick={() => onConnectToPrimarySubscription()}
+          color="primary"
         >
-          <i className="fa fa-twitter" />
-        </span>{' '}
-        <span
-          className="CloudAction__ActionIcon"
-          onClick={() => onShare('facebook')}
-          title="Now that's something worth sharing!"
-        >
-          <i className="fa fa-facebook" />
-        </span>{' '}
-        <span
-          className="CloudAction__ActionIcon"
-          onClick={() => onRefresh()}
-          title="Refresh this status"
-        >
-          <i className="fa fa-refresh" />
-        </span>
-        {/*
+          Connect to Realm Cloud
+        </Button>
+      );
+    } else if (cloudStatus.user.canCreate) {
+      return (
+        <Button onClick={onServerCreate} color="primary">
+          Create Realm Cloud server
+        </Button>
+      );
+    } else {
+      return (
+        <Alert className="CloudAction__Alert" color="info">
+          You're on the waitlist to use Realm Cloud!{' '}
+          <span
+            className="CloudAction__ActionIcon"
+            onClick={() => onShare('twitter')}
+            title="Now that's something worth tweeting about!"
+          >
+            <i className="fa fa-twitter" />
+          </span>{' '}
+          <span
+            className="CloudAction__ActionIcon"
+            onClick={() => onShare('facebook')}
+            title="Now that's something worth sharing!"
+          >
+            <i className="fa fa-facebook" />
+          </span>{' '}
+          <span
+            className="CloudAction__ActionIcon"
+            onClick={() => onRefresh()}
+            title="Refresh this status"
+          >
+            <i className="fa fa-refresh" />
+          </span>
+          {/*
         <span
           className="Greeting__ShareAction"
           onClick={() => onShare('reddit')}
@@ -89,14 +101,9 @@ export const CloudAction = ({
           <i className="fa fa-hacker-news" />
         </span>
         */}
-      </Alert>
-    );
-  } else if (cloudStatus && cloudStatus.kind === 'has-primary-subscription') {
-    return (
-      <Button onClick={() => onConnectToPrimarySubscription()} color="primary">
-        Connect to Realm Cloud
-      </Button>
-    );
+        </Alert>
+      );
+    }
   } else if (cloudStatus && cloudStatus.kind === 'error') {
     return (
       <Alert className="CloudAction__Alert" color="danger">

--- a/src/ui/greeting/GreetingContainer.tsx
+++ b/src/ui/greeting/GreetingContainer.tsx
@@ -83,7 +83,11 @@ export class GreetingContainer extends React.Component<
     try {
       if (!subscription) {
         const { cloudStatus } = this.state;
-        if (cloudStatus && cloudStatus.kind === 'has-primary-subscription') {
+        if (
+          cloudStatus &&
+          cloudStatus.kind === 'authenticated' &&
+          cloudStatus.primarySubscription
+        ) {
           return this.onConnectToPrimarySubscription(
             cloudStatus.primarySubscription,
           );


### PR DESCRIPTION
This fixes #637

When opening a cloud URL:
1. if the user is not authenticated - the CloudAuthentication window is shown and the server is connected to after succesful authentication.
2. if the user is authenticated but with a user that does not match the user ID encoded in the username of the requested URL - this dialog is shown: ![skaermbillede 2018-01-23 kl 16 38 57](https://user-images.githubusercontent.com/1243959/35284864-2ad13498-005c-11e8-806c-96c1052a7561.png)
if the user accepts this - they'll get deauthenticated, the CloudAuthentication will be displayed and the server is connected to after succesful authentication.
3. if the user is authenticated with a user that has the same id - we simply log into the instance.
4. if the cloud url does not contain a username, we'll assume the current user can connect and do as 3.