### PR TITLE
Health check ros before connecting and reconnecting

### DIFF
--- a/src/services/ros/index.ts
+++ b/src/services/ros/index.ts
@@ -58,6 +58,8 @@ export enum UserRole {
 }
 
 export const isAvailable = async (url: string) => {
-  const response = await fetch(`${url}/health`);
+  const parsedUrl = new URL(url);
+  parsedUrl.pathname = 'health';
+  const response = await fetch(parsedUrl.toString());
   return response.status === 200;
 };

--- a/src/ui/reusable/loading-overlay/LoadingOverlay.tsx
+++ b/src/ui/reusable/loading-overlay/LoadingOverlay.tsx
@@ -23,22 +23,21 @@ export const LoadingOverlay = ({
 }) => {
   // If a progress has been supplied, it overrides loading
   const isVisible = progress ? progress.status !== 'done' : loading;
-  const showDots = progress ? progress.status === 'in-progress' : loading;
+  // Show the progress bar if we know how far we've made it
+  const showProgress =
+    progress &&
+    typeof progress.transferable === 'number' &&
+    typeof progress.transferred === 'number';
+  // Show the dots if making progress but being uncertain on how far
+  const showDots = progress
+    ? progress.status === 'in-progress' && !showProgress
+    : loading;
   return isVisible ? (
     <div
       className={classNames('LoadingOverlay', {
         'LoadingOverlay--no-fade': !fade,
       })}
     >
-      {progress &&
-        typeof progress.transferable === 'number' &&
-        typeof progress.transferred === 'number' && (
-          <Progress
-            className="LoadingOverlay__Progress"
-            value={progress.transferred}
-            max={progress.transferable}
-          />
-        )}
       {progress && progress.status === 'failed' ? (
         <section className="LoadingOverlay__Failure">
           <i
@@ -52,6 +51,14 @@ export const LoadingOverlay = ({
           {progress.message}
         </section>
       ) : null}
+      {progress &&
+        showProgress && (
+          <Progress
+            className="LoadingOverlay__Progress"
+            value={progress.transferred}
+            max={progress.transferable}
+          />
+        )}
       {showDots ? <LoadingDots /> : null}
       {progress && progress.retry ? (
         <Button

--- a/src/ui/reusable/realm-loading-component/RealmLoadingComponent.tsx
+++ b/src/ui/reusable/realm-loading-component/RealmLoadingComponent.tsx
@@ -246,6 +246,7 @@ export abstract class RealmLoadingComponent<
   private progressChanged = (transferred: number, transferable: number) => {
     this.setState({
       progress: {
+        message: 'Downloading Realm',
         status: transferred >= transferable ? 'done' : 'in-progress',
         transferred,
         transferable,

--- a/src/utils/countdown.ts
+++ b/src/utils/countdown.ts
@@ -1,0 +1,12 @@
+import { wait } from './wait';
+
+export const countdown = async (
+  interval: number,
+  start: number,
+  onCount: (n: number) => void,
+): Promise<void> => {
+  for (let n = start; n >= 1; n--) {
+    onCount(n);
+    await wait(interval);
+  }
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,3 @@
+export { countdown } from './countdown';
 export { timeout } from './timeout';
+export { wait } from './wait';

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -1,0 +1,7 @@
+export const wait = (ms: number): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+};


### PR DESCRIPTION
This fixes #615 and should prevent #417 and generally any authentication errors that we've been seeing from the server not being ready.

![reconnecting](https://user-images.githubusercontent.com/1243959/35442857-03cab140-02a9-11e8-9718-2a916231e29b.gif)
