### PR TITLE
Upgraded Realm JS to 2.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12300,9 +12300,9 @@
       }
     },
     "realm": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-2.2.4.tgz",
-      "integrity": "sha1-6wo/bt1IUVZ+VfTT9ZdOPIm1cfs=",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-2.2.5.tgz",
+      "integrity": "sha1-xKC00mq7fUt2OgkVv3XAx844SpU=",
       "requires": {
         "command-line-args": "4.0.7",
         "decompress": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "react-sortable-hoc": "^0.6.8",
     "react-virtualized": "^9.11.1",
     "reactstrap": "^4.8.0",
-    "realm": "2.2.4",
+    "realm": "^2.2.5",
     "uuid": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This includes a fix that solves crashes on Linux