### PR TITLE
Reconnect trusting certificate & going into failed state on fatal errors

### DIFF
--- a/src/ui/server-administration/ServerAdministrationContainer.tsx
+++ b/src/ui/server-administration/ServerAdministrationContainer.tsx
@@ -288,7 +288,19 @@ export class ServerAdministrationContainer extends RealmLoadingComponent<
   ) => {
     if (error.message === 'SSL server certificate rejected') {
       this.certificateWasRejected = true;
-    } else {
+      this.setState({
+        progress: {
+          status: 'failed',
+          message: 'The servers certificate could not be trusted',
+          retry: {
+            label: 'Reconnect, trusting the certificate',
+            onRetry: () => {
+              this.props.onValidateCertificatesChange(false);
+            },
+          },
+        },
+      });
+    } else if (error.isFatal) {
       this.setState({
         progress: {
           status: 'failed',


### PR DESCRIPTION
This PR fixes the immediate described in #677. It does this by not waiting for the `Realm.open` rejection before showing the error and allowing the user to trust the certificate (blindly).

For a prettier and less obstructive UX we should fix https://github.com/realm/realm-studio/issues/678 as well.