### PR TITLE
Renamed the provider used when authenticating to a cloud instance

### DIFF
--- a/src/services/raas/user.ts
+++ b/src/services/raas/user.ts
@@ -123,7 +123,7 @@ export const getTenantCredentials = (url: string): IServerCredentials => {
     kind: 'other',
     url,
     options: {
-      provider: 'jwt',
+      provider: 'jwt/central-owner',
       data: getToken(),
     },
   };


### PR DESCRIPTION
This fixed Studios part of step B in https://github.com/realm/raas/issues/470.

It shouldn't be merged and released before step A is completed.