### PR TITLE
Enable scrollbar if error cannot fit on screen

### DIFF
--- a/src/ui/reusable/loading-overlay/LoadingOverlay.scss
+++ b/src/ui/reusable/loading-overlay/LoadingOverlay.scss
@@ -24,6 +24,7 @@
   justify-content: center;
   left: 0;
   opacity: 0;
+  overflow: auto;
   position: absolute;
   right: 0;
   top: 0;


### PR DESCRIPTION
A slightly different use case than https://github.com/realm/realm-studio/issues/693

In my case, the error was too long vertically. This PR adds scrollbars if the content overflows both horizontally and vertically. We should probably still word-wrap the error message, but my first attempt at that failed, so better leave it out of this PR

Old:
![image](https://user-images.githubusercontent.com/406066/36837640-3d1eb320-1d3d-11e8-833c-a19ee1eb326d.png)


New:
![image](https://user-images.githubusercontent.com/406066/36837682-5b65bf72-1d3d-11e8-974c-0ed5acfc88b4.png)
