### PR TITLE
Better contrast between placeholder and user text in input fields

### DIFF
--- a/styles/variables/_colors.scss
+++ b/styles/variables/_colors.scss
@@ -21,6 +21,7 @@ $brand-danger: $color-sexy-salmon;
 $brand-info: $color-ultramarine;
 $btn-secondary-bg: $color-dove;
 $btn-secondary-border: $color-dove;
+$input-color-placeholder: rgba($color-elephant, .6);
 
 $state-info-text: $color-ultramarine;
 $state-info-bg: lighten($color-ultramarine, 50%);


### PR DESCRIPTION
Before this PR the placeholder had almost exactly the same colour as the real text, making it confusing when editing fields with a placeholder text.

This PR increases the contrast, so it is easier to tell the difference. The change is global for all input fields.

Before:
![image](https://user-images.githubusercontent.com/406066/36853670-58dd4cd4-1d6f-11e8-8cfc-471c08189bdd.png)


After:
![image](https://user-images.githubusercontent.com/406066/36853695-626d1b76-1d6f-11e8-9096-c18c985b04b9.png)
