### PR TITLE
Disallow selecting optional for lists of model classes

### DIFF
--- a/src/ui/realm-browser/AddPropertyModal/View.tsx
+++ b/src/ui/realm-browser/AddPropertyModal/View.tsx
@@ -19,6 +19,7 @@ export const View = ({
   focus,
   isList,
   isOpen,
+  primitiveTypeSelected,
   name,
   nameIsValid,
   onIsListChange,
@@ -34,6 +35,7 @@ export const View = ({
   focus: IClassFocus;
   isList: boolean;
   isOpen: boolean;
+  primitiveTypeSelected: boolean;
   name: string;
   nameIsValid: boolean;
   onIsListChange: () => void;
@@ -103,7 +105,7 @@ export const View = ({
               Make this a list of {type}s
             </Label>
           </FormGroup>
-          <FormGroup check>
+          <FormGroup check style={{visibility: !primitiveTypeSelected && isList ? 'hidden' : 'visible' }}>
             <Label check>
               <Input
                 type="checkbox"

--- a/src/ui/realm-browser/AddPropertyModal/View.tsx
+++ b/src/ui/realm-browser/AddPropertyModal/View.tsx
@@ -105,7 +105,13 @@ export const View = ({
               Make this a list of {type}s
             </Label>
           </FormGroup>
-          <FormGroup check style={{visibility: !primitiveTypeSelected && isList ? 'hidden' : 'visible' }}>
+          <FormGroup
+            check
+            style={{
+              visibility:
+                !primitiveTypeSelected && isList ? 'hidden' : 'visible',
+            }}
+          >
             <Label check>
               <Input
                 type="checkbox"

--- a/src/ui/realm-browser/AddPropertyModal/index.tsx
+++ b/src/ui/realm-browser/AddPropertyModal/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { IClassFocus } from '../focus';
-import { TYPES } from '../primitives';
+import * as primitives from '../primitives';
 import { View } from './View';
 
 export interface IAddPropertyModalProps {
@@ -76,7 +76,7 @@ export class AddPropertyModal extends React.Component<
     const newValue = e.target.value;
     this.setState({
       type: newValue,
-      primitiveTypeSelected: this.isPrimitiveType(newValue, this.props.schemas),
+      primitiveTypeSelected: primitives.isPrimitive(newValue),
     });
   };
 
@@ -98,7 +98,7 @@ export class AddPropertyModal extends React.Component<
       disabled: true,
       show: true,
     };
-    const primitiveTypesOptions = TYPES.map(type => ({
+    const primitiveTypesOptions = primitives.TYPES.map(type => ({
       value: type,
       disabled: false,
       show: true,
@@ -132,18 +132,14 @@ export class AddPropertyModal extends React.Component<
       isList,
       primitiveTypeSelected,
     } = this.state;
+    const optionalMarker =
+      optional && !(isList && !primitiveTypeSelected) ? '?' : '';
+    const listMarker = isList ? '[]' : '';
     return {
-      [name]: `${propertyType}${optional && !(isList && !primitiveTypeSelected)
-        ? '?'
-        : ''}${isList ? '[]' : ''}`,
+      [name]: `${propertyType}${optionalMarker}${listMarker}`,
     };
   };
 
   private getClassesTypes = (schemas: Realm.ObjectSchema[]): string[] =>
     schemas.map(schema => schema.name);
-
-  private isPrimitiveType = (
-    type: string,
-    schemas: Realm.ObjectSchema[],
-  ): boolean => schemas.filter(schema => schema.name === type).length === 0;
 }

--- a/src/ui/realm-browser/AddPropertyModal/index.tsx
+++ b/src/ui/realm-browser/AddPropertyModal/index.tsx
@@ -18,6 +18,7 @@ export interface IAddPropertyModalState {
   type: string;
   isList: boolean;
   optional: boolean;
+  primitiveTypeSelected: boolean;
   nameIsValid: boolean;
   typeOptions: ITypeOption[];
 }
@@ -33,6 +34,7 @@ const initialState = {
   optional: false,
   nameIsValid: true,
   isList: false,
+  primitiveTypeSelected: false,
 };
 
 export class AddPropertyModal extends React.Component<
@@ -74,6 +76,7 @@ export class AddPropertyModal extends React.Component<
     const newValue = e.target.value;
     this.setState({
       type: newValue,
+      primitiveTypeSelected: this.isPrimitiveType(newValue, this.props.schemas),
     });
   };
 
@@ -122,12 +125,25 @@ export class AddPropertyModal extends React.Component<
   };
 
   private getSchemaProperty = () => {
-    const { name, type: propertyType, optional, isList } = this.state;
+    const {
+      name,
+      type: propertyType,
+      optional,
+      isList,
+      primitiveTypeSelected,
+    } = this.state;
     return {
-      [name]: `${propertyType}${optional ? '?' : ''}${isList ? '[]' : ''}`,
+      [name]: `${propertyType}${optional && !(isList && !primitiveTypeSelected)
+        ? '?'
+        : ''}${isList ? '[]' : ''}`,
     };
   };
 
   private getClassesTypes = (schemas: Realm.ObjectSchema[]): string[] =>
     schemas.map(schema => schema.name);
+
+  private isPrimitiveType = (
+    type: string,
+    schemas: Realm.ObjectSchema[],
+  ): boolean => schemas.filter(schema => schema.name === type).length === 0;
 }


### PR DESCRIPTION
Fallout from https://github.com/realm/realm-java/issues/5788

It was possible to select an illegal combination of flags/types, i.e. A list of realm model classes are never allowed to be optional.

This PR hides the option when that combination is chosen. To avoid flickering and make it easy to go back the checkbox is just `invisible` but not removed (so modal size doesn't change), and the flag is remembered, but just ignored when creating a list:

Old behaviour:
![image](https://user-images.githubusercontent.com/406066/36859124-bc15d0f6-1d7d-11e8-9149-9d18532684ca.png)

New behaviour:
![image](https://user-images.githubusercontent.com/406066/36859287-22c75806-1d7e-11e8-81ce-8305ec4bed0f.png)

