### PR TITLE
Add support for disabling internal features.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ If you've checked out this repository, install and start it by running
     npm install
     npm start
 
+Some internal features, only usable by Realm employees, are hidden by default and are only shown if the following
+environment variable is set:
+
+    export ENABLE_REALM_STUDIO_INTERNAL_FEATURES=""
+
 ## Developing
 
 Please read the [guidelines](./GUIDELINES.md) to familiarize with the code style and tools used to develop Realm Studio.

--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ If you've checked out this repository, install and start it by running
     npm install
     npm start
 
-Some internal features, only usable by Realm employees, are hidden by default and are only shown if the following
-environment variable is set:
-
-    export ENABLE_REALM_STUDIO_INTERNAL_FEATURES=""
-
 ## Developing
 
 Please read the [guidelines](./GUIDELINES.md) to familiarize with the code style and tools used to develop Realm Studio.
@@ -48,6 +43,11 @@ checker or run the lint command:
 ### Parameters
 
 The application has support for some parameters that can be supplied when starting it:
+
+- THe `REALM_STUDIO_INTERNAL_FEATURES` environment variable can be set to show features in Realm Studio that
+  are only useful for Realm employees, like being able to select the Staging server for the Cloud.
+
+      REALM_STUDIO_INTERNAL_FEATURES=true
 
 - The `DISPLAY` environment variable can be set to the index of the display that windows should be created on.
   So to start the application, opening windows on your secondary monitor, run

--- a/src/main/MainMenu.ts
+++ b/src/main/MainMenu.ts
@@ -5,8 +5,8 @@ import { ImportFormat } from '../services/data-importer';
 import * as raas from '../services/raas';
 
 const isProduction = process.env.NODE_ENV === 'production';
-const internalFeatureKey = 'ENABLE_REALM_STUDIO_INTERNAL_FEATURES';
-const showInternalFeatures = process.env[internalFeatureKey] !== undefined; // Show features only relevant for Realm employees
+const showInternalFeatures =
+  process.env.REALM_STUDIO_INTERNAL_FEATURES === 'true'; // Show features only relevant for Realm employees
 
 export const getDefaultMenuTemplate = (
   updateMenu: () => void,

--- a/src/main/MainMenu.ts
+++ b/src/main/MainMenu.ts
@@ -4,7 +4,7 @@ import { main } from '../actions/main';
 import { ImportFormat } from '../services/data-importer';
 import * as raas from '../services/raas';
 
-const isProduction = process.env.NODE_ENV !== 'production';
+const isProduction = process.env.NODE_ENV === 'production';
 const internalFeatureKey = 'ENABLE_REALM_STUDIO_INTERNAL_FEATURES';
 const showInternalFeatures = process.env[internalFeatureKey] !== undefined; // Show features only relevant for Realm employees
 
@@ -165,7 +165,7 @@ export const getDefaultMenuTemplate = (
       for (let j = menuItem.submenu.length - 1; j >= 0; j--) {
         const subMenuItem: electron.MenuItemConstructorOptions =
           menuItem.submenu[j];
-        if (!subMenuItem.visible) {
+        if (subMenuItem.visible === false) {
           menuItem.submenu.splice(j, 1);
         }
       }

--- a/src/main/MainMenu.ts
+++ b/src/main/MainMenu.ts
@@ -4,7 +4,9 @@ import { main } from '../actions/main';
 import { ImportFormat } from '../services/data-importer';
 import * as raas from '../services/raas';
 
-const isProduction = process.env.NODE_ENV === 'production';
+const isProduction = process.env.NODE_ENV !== 'production';
+const internalFeatureKey = 'ENABLE_REALM_STUDIO_INTERNAL_FEATURES';
+const showInternalFeatures = process.env[internalFeatureKey] !== undefined; // Show features only relevant for Realm employees
 
 export const getDefaultMenuTemplate = (
   updateMenu: () => void,
@@ -89,6 +91,7 @@ export const getDefaultMenuTemplate = (
         },
         {
           label: 'Change endpoint',
+          visible: showInternalFeatures,
           submenu: [
             {
               type: 'radio',
@@ -147,6 +150,26 @@ export const getDefaultMenuTemplate = (
         { role: 'quit' },
       ],
     });
+  }
+
+  // Workaround for https://github.com/electron/electron/issues/8703
+  // In some cases the setting for `visible` is not respected, instead
+  // just manually remove all items marked invisible.
+  for (let i = template.length - 1; i >= 0; i--) {
+    const menuItem: electron.MenuItemConstructorOptions = template[i];
+    if (menuItem.visible === false) {
+      template.splice(i, 1);
+      continue;
+    }
+    if (menuItem.submenu instanceof Array) {
+      for (let j = menuItem.submenu.length - 1; j >= 0; j--) {
+        const subMenuItem: electron.MenuItemConstructorOptions =
+          menuItem.submenu[j];
+        if (!subMenuItem.visible) {
+          menuItem.submenu.splice(j, 1);
+        }
+      }
+    }
   }
 
   return template;


### PR DESCRIPTION
Fixes #718 

A better solution would probably be to indicate this depending on if a Github login is used that is a member of the Realm organization, but this will also require changes to the server so seems to be a bit out of scope for now.

This is the practical approach, which just requires setting an environment variable. 