### PR TITLE
Add support for toggling system and partial Realms off.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,13 @@
       "dev": true
     },
     "@types/electron-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/electron-store/-/electron-store-1.2.0.tgz",
-      "integrity": "sha512-qezZBoImiM50OnRku8LG0VRJVd2feKsbGE/cM0ewUM6L6wTLab7sHjX8RUPtByJXhsUNWsojx9Wl4XGm55knXA==",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/electron-store/-/electron-store-1.3.0.tgz",
+      "integrity": "sha512-PplQbntPl3xNcckjizjoQShPwLot72jFiaI67CZ0JOr+AuGwqXdL73sU3vfuuP+RZecOh8vX1G7yWjmxs4lvBQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.47"
+      }
     },
     "@types/faker": {
       "version": "4.1.1",
@@ -215,16 +218,8 @@
       "integrity": "sha512-s2ZfgRWXeNUQTQE3O85CDDrU2Uo90pMlMkTxkz85wQOuzVxB8t4cubMPup3WlTPFKHQgb6lDkAHS3ljkUSFO6A==",
       "dev": true,
       "requires": {
-        "7zip-bin-linux": "1.3.1",
         "7zip-bin-mac": "1.0.1"
       }
-    },
-    "7zip-bin-linux": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/7zip-bin-linux/-/7zip-bin-linux-1.3.1.tgz",
-      "integrity": "sha512-Wv1uEEeHbTiS1+ycpwUxYNuIcyohU6Y6vEqY3NquBkeqy0YhVdsNUGsj0XKSRciHR6LoJSEUuqYUexmws3zH7Q==",
-      "dev": true,
-      "optional": true
     },
     "7zip-bin-mac": {
       "version": "1.0.1",
@@ -3082,7 +3077,6 @@
           "integrity": "sha512-QU3oR1dLLVrYGRkb7LU17jMCpIkWtXXW7q71ECXWXkR9vOv37VjykqpvFgs29HgSCNLZHnNKJzdG6RwAW0LwIA==",
           "dev": true,
           "requires": {
-            "7zip-bin-linux": "1.3.1",
             "7zip-bin-mac": "1.0.1"
           }
         },

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
   },
   "devDependencies": {
     "@types/classnames": "^2.2.3",
-    "@types/electron-store": "^1.2.0",
+    "@types/electron-store": "^1.3.0",
     "@types/faker": "^4.1.1",
     "@types/fs-extra": "^4.0.2",
     "@types/isomorphic-fetch": "0.0.34",

--- a/src/main/MainMenu.ts
+++ b/src/main/MainMenu.ts
@@ -78,6 +78,15 @@ export const getDefaultMenuTemplate = (
             updateMenu();
           },
         },
+        {
+          label: `Show system users`,
+          type: 'checkbox',
+          checked: store.shouldShowSystemUsers(),
+          click: async () => {
+            await store.toggleShowSystemUsers();
+            updateMenu();
+          },
+        },
         { type: 'separator' },
         { role: 'resetzoom' },
         { role: 'zoomin' },

--- a/src/main/MainMenu.ts
+++ b/src/main/MainMenu.ts
@@ -63,7 +63,7 @@ export const getDefaultMenuTemplate = (
         {
           label: `Show partial Realms`,
           type: 'checkbox',
-          checked: store.showPartialRealms(),
+          checked: store.shouldShowPartialRealms(),
           click: async () => {
             await store.toggleShowPartialRealms();
             updateMenu();
@@ -72,7 +72,7 @@ export const getDefaultMenuTemplate = (
         {
           label: `Show system Realms`,
           type: 'checkbox',
-          checked: store.showSystemRealms(),
+          checked: store.shouldShowSystemRealms(),
           click: async () => {
             await store.toggleShowSystemRealms();
             updateMenu();

--- a/src/main/MainMenu.ts
+++ b/src/main/MainMenu.ts
@@ -3,6 +3,7 @@ import * as electron from 'electron';
 import { main } from '../actions/main';
 import { ImportFormat } from '../services/data-importer';
 import * as raas from '../services/raas';
+import { store } from '../store';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
@@ -59,6 +60,25 @@ export const getDefaultMenuTemplate = (
         { role: 'reload', visible: !isProduction },
         { role: 'toggledevtools', visible: !isProduction },
         { type: 'separator', visible: !isProduction },
+        {
+          label: `Show partial Realms`,
+          type: 'checkbox',
+          checked: store.showPartialRealms(),
+          click: async () => {
+            await store.toggleShowPartialRealms();
+            updateMenu();
+          },
+        },
+        {
+          label: `Show system Realms`,
+          type: 'checkbox',
+          checked: store.showSystemRealms(),
+          click: async () => {
+            await store.toggleShowSystemRealms();
+            updateMenu();
+          },
+        },
+        { type: 'separator' },
         { role: 'resetzoom' },
         { role: 'zoomin' },
         { role: 'zoomout' },

--- a/src/store.ts
+++ b/src/store.ts
@@ -20,11 +20,11 @@ class RealmStudioStore {
     this.store.set(this.KEY_SHOW_SYSTEM_REALMS, !currentValue);
   }
 
-  public showPartialRealms(): boolean {
+  public shouldShowPartialRealms(): boolean {
     return this.store.get(this.KEY_SHOW_PARTIAL_REALMS, false);
   }
 
-  public showSystemRealms(): boolean {
+  public shouldShowSystemRealms(): boolean {
     return this.store.get(this.KEY_SHOW_SYSTEM_REALMS, false);
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -7,6 +7,7 @@ export { store };
 class RealmStudioStore {
   public readonly KEY_SHOW_PARTIAL_REALMS = 'realmlist.show-partial-realms';
   public readonly KEY_SHOW_SYSTEM_REALMS = 'realmlist.show-system-realms';
+  public readonly KEY_SHOW_SYSTEM_USERS = 'userlist.show-system-users';
 
   private store = new ElectronStore();
 
@@ -20,12 +21,21 @@ class RealmStudioStore {
     this.store.set(this.KEY_SHOW_SYSTEM_REALMS, !currentValue);
   }
 
+  public toggleShowSystemUsers() {
+    const currentValue = this.store.get(this.KEY_SHOW_SYSTEM_USERS, false);
+    this.store.set(this.KEY_SHOW_SYSTEM_USERS, !currentValue);
+  }
+
   public shouldShowPartialRealms(): boolean {
     return this.store.get(this.KEY_SHOW_PARTIAL_REALMS, false);
   }
 
   public shouldShowSystemRealms(): boolean {
     return this.store.get(this.KEY_SHOW_SYSTEM_REALMS, false);
+  }
+
+  public shouldShowSystemUsers(): boolean {
+    return this.store.get(this.KEY_SHOW_SYSTEM_USERS, false);
   }
 
   // Subclassing ElectronStore results in

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,5 +2,56 @@
 // @see https://github.com/realm/realm-studio/blob/master/src/renderer.tsx#L15-L30
 
 import ElectronStore = require('electron-store');
-const store = new ElectronStore();
 export { store };
+
+class RealmStudioStore {
+  public readonly KEY_SHOW_PARTIAL_REALMS = 'realmlist.show-partial-realms';
+  public readonly KEY_SHOW_SYSTEM_REALMS = 'realmlist.show-system-realms';
+
+  private store = new ElectronStore();
+
+  public toggleShowPartialRealms() {
+    const currentValue = this.store.get(this.KEY_SHOW_PARTIAL_REALMS, false);
+    this.store.set(this.KEY_SHOW_PARTIAL_REALMS, !currentValue);
+  }
+
+  public toggleShowSystemRealms() {
+    const currentValue = this.store.get(this.KEY_SHOW_SYSTEM_REALMS, false);
+    this.store.set(this.KEY_SHOW_SYSTEM_REALMS, !currentValue);
+  }
+
+  public showPartialRealms(): boolean {
+    return this.store.get(this.KEY_SHOW_PARTIAL_REALMS, false);
+  }
+
+  public showSystemRealms(): boolean {
+    return this.store.get(this.KEY_SHOW_SYSTEM_REALMS, false);
+  }
+
+  // Subclassing ElectronStore results in
+  // `Class constructor ElectronStore cannot be invoked without 'new'`
+  public set(key: string, value: any): void {
+    this.store.set(key, value);
+  }
+
+  public get(key: string, defaultValue?: any): any {
+    return this.store.get(key, defaultValue);
+  }
+
+  public onDidChange(
+    key: string,
+    callback: (newValue: any, oldValue: any) => void,
+  ): void {
+    this.store.onDidChange(key, callback);
+  }
+
+  public delete(key: string) {
+    this.store.delete(key);
+  }
+
+  public has(key: string): boolean {
+    return this.store.has(key);
+  }
+}
+
+const store = new RealmStudioStore();

--- a/src/ui/server-administration/realms/RealmsTableContainer.tsx
+++ b/src/ui/server-administration/realms/RealmsTableContainer.tsx
@@ -42,8 +42,8 @@ export class RealmsTableContainer extends React.PureComponent<
       isCreateRealmOpen: false,
       selectedRealmPath: null,
       searchString: '',
-      showPartialRealms: store.showPartialRealms(),
-      showSystemRealms: store.showSystemRealms(),
+      showPartialRealms: store.shouldShowPartialRealms(),
+      showSystemRealms: store.shouldShowSystemRealms(),
     };
   }
 

--- a/src/ui/server-administration/users/UsersTableContainer.tsx
+++ b/src/ui/server-administration/users/UsersTableContainer.tsx
@@ -1,7 +1,7 @@
 import * as electron from 'electron';
 import * as React from 'react';
 import * as Realm from 'realm';
-import { store } from '../../../store'
+import { store } from '../../../store';
 
 import * as ros from '../../../services/ros';
 import { showError } from '../../reusable/errors';


### PR DESCRIPTION
Fixes #508 

Add UI controls for hiding/showing Partial and System Realms. They are hidden by default.

Default:
![image](https://user-images.githubusercontent.com/406066/37286547-80860816-2602-11e8-960b-1d8bb5cce101.png)

Enable system realms:
![image](https://user-images.githubusercontent.com/406066/37286563-8e350cf0-2602-11e8-9f6d-8bcb91d34c5e.png)

Enable partial Realms:
![image](https://user-images.githubusercontent.com/406066/37286575-9c1c5d5a-2602-11e8-9c33-9c8e5cfbf59d.png)
