### PR TITLE
Dropdown on multiple cloud instances

### DIFF
--- a/src/main/CloudManager.ts
+++ b/src/main/CloudManager.ts
@@ -3,6 +3,8 @@ import * as raas from '../services/raas';
 import * as ros from '../services/ros';
 import { timeout } from '../utils';
 
+export type IInstance = raas.user.ISubscription;
+
 interface IBaseCloudStatus {
   kind: string;
   endpoint: raas.Endpoint;
@@ -29,7 +31,7 @@ export interface IAuthenticatingCloudStatus extends IBaseCloudStatus {
 export interface IAuthenticatedCloudStatus extends IBaseCloudStatus {
   kind: 'authenticated';
   justAuthenticated: boolean;
-  primarySubscription?: raas.user.ISubscription;
+  instances: IInstance[];
   raasToken: string;
   account: raas.user.IAccountResponse;
 }
@@ -138,17 +140,16 @@ export class CloudManager {
           endpoint,
         });
         const account = await raas.user.getAccount();
-        const subscriptions = await raas.user.getSubscriptions();
+        // We use "instance" internally instead of subscriptions
+        const instances = await raas.user.getSubscriptions();
         const status: IAuthenticatedCloudStatus = {
           kind: 'authenticated',
+          account,
           endpoint,
           justAuthenticated,
           raasToken,
-          account,
+          instances,
         };
-        if (subscriptions.length > 0) {
-          status.primarySubscription = subscriptions[0];
-        }
         this.sendCloudStatus(status);
       } else {
         this.sendCloudStatus({

--- a/src/ui/greeting/CloudAction/CloudAction.tsx
+++ b/src/ui/greeting/CloudAction/CloudAction.tsx
@@ -56,7 +56,7 @@ export const CloudAction = ({
       </Alert>
     );
   } else if (cloudStatus && cloudStatus.kind === 'authenticated') {
-    if (cloudStatus.instances.length > 0) {
+    if (cloudStatus.instances.length > 1) {
       return (
         <ButtonDropdown
           isOpen={isCloudInstancesDropdownOpen}
@@ -73,6 +73,15 @@ export const CloudAction = ({
             ))}
           </DropdownMenu>
         </ButtonDropdown>
+      );
+    } else if (cloudStatus.instances.length === 1) {
+      return (
+        <Button
+          color="primary"
+          onClick={() => onConnectToCloudInstance(cloudStatus.instances[0])}
+        >
+          Connect to Realm Cloud
+        </Button>
       );
     } else if (cloudStatus.account.emailVerified) {
       return (

--- a/src/ui/greeting/CloudAction/CloudAction.tsx
+++ b/src/ui/greeting/CloudAction/CloudAction.tsx
@@ -1,9 +1,16 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
-import { Alert, Button } from 'reactstrap';
+import {
+  Alert,
+  Button,
+  ButtonDropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownToggle,
+} from 'reactstrap';
 
 import cloudLogo from '../../../../static/svgs/cloud-logo-simple.svg';
-import { ICloudStatus } from '../../../main/CloudManager';
+import { ICloudStatus, IInstance } from '../../../main/CloudManager';
 import { LoadingDots } from '../../reusable/loading-dots';
 import { SocialNetwork } from '../GreetingContainer';
 
@@ -11,22 +18,26 @@ import './CloudAction.scss';
 
 export interface ICloudActionButtonProps {
   cloudStatus?: ICloudStatus;
+  isCloudInstancesDropdownOpen: boolean;
   onAuthenticate: () => void;
-  onConnectToPrimarySubscription: () => void;
+  onConnectToCloudInstance: (instance: IInstance) => void;
   onDeauthenticate: () => void;
-  onRefresh: () => void;
   onInstanceCreate: () => void;
+  onRefresh: () => void;
   onShare: (socialNetwork: SocialNetwork) => void;
+  onToggleCloudInstancesDropdown: () => void;
 }
 
 export const CloudAction = ({
   cloudStatus,
+  isCloudInstancesDropdownOpen,
   onAuthenticate,
-  onConnectToPrimarySubscription,
+  onConnectToCloudInstance,
   onDeauthenticate,
-  onRefresh,
   onInstanceCreate,
+  onRefresh,
   onShare,
+  onToggleCloudInstancesDropdown,
 }: ICloudActionButtonProps) => {
   if (cloudStatus && cloudStatus.kind === 'authenticating') {
     return (
@@ -45,14 +56,23 @@ export const CloudAction = ({
       </Alert>
     );
   } else if (cloudStatus && cloudStatus.kind === 'authenticated') {
-    if (cloudStatus.primarySubscription) {
+    if (cloudStatus.instances.length > 0) {
       return (
-        <Button
-          onClick={() => onConnectToPrimarySubscription()}
-          color="primary"
+        <ButtonDropdown
+          isOpen={isCloudInstancesDropdownOpen}
+          toggle={onToggleCloudInstancesDropdown}
         >
-          Connect to Realm Cloud
-        </Button>
+          <DropdownToggle color="primary" caret>
+            Connect to Realm Cloud
+          </DropdownToggle>
+          <DropdownMenu>
+            {cloudStatus.instances.map(instance => (
+              <DropdownItem onClick={() => onConnectToCloudInstance(instance)}>
+                {instance.projectName || instance.tenantUrl}
+              </DropdownItem>
+            ))}
+          </DropdownMenu>
+        </ButtonDropdown>
       );
     } else if (cloudStatus.account.emailVerified) {
       return (

--- a/src/ui/greeting/Greeting.tsx
+++ b/src/ui/greeting/Greeting.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Button, ButtonGroup } from 'reactstrap';
 import * as util from 'util';
 
-import { ICloudStatus } from '../../main/CloudManager';
+import { ICloudStatus, IInstance } from '../../main/CloudManager';
 import { IUpdateStatus } from '../../main/Updater';
 import { IServerCredentials } from '../../services/ros';
 
@@ -18,32 +18,34 @@ import './Greeting.scss';
 
 export const Greeting = ({
   cloudStatus,
+  isCloudInstancesDropdownOpen,
   isSyncEnabled,
   onAuthenticate,
   onCheckForUpdates,
-  onCloudSubscriptionCreated,
-  onConnectToPrimarySubscription,
+  onConnectToCloudInstance,
   onConnectToServer,
   onDeauthenticate,
+  onInstanceCreate,
   onOpenLocalRealm,
   onRefreshCloudStatus,
-  onInstanceCreate,
   onShare,
+  onToggleCloudInstancesDropdown,
   updateStatus,
   version,
 }: {
   cloudStatus?: ICloudStatus;
+  isCloudInstancesDropdownOpen: boolean;
   isSyncEnabled: boolean;
   onAuthenticate: () => void;
   onCheckForUpdates: () => void;
-  onCloudSubscriptionCreated: () => void;
-  onConnectToPrimarySubscription: () => void;
+  onConnectToCloudInstance: (instance: IInstance) => void;
   onConnectToServer: () => void;
   onDeauthenticate: () => void;
+  onInstanceCreate: () => void;
   onOpenLocalRealm: () => void;
   onRefreshCloudStatus: () => void;
-  onInstanceCreate: () => void;
   onShare: (socialNetwork: SocialNetwork) => void;
+  onToggleCloudInstancesDropdown: () => void;
   updateStatus: IUpdateStatus;
   version: string;
 }) => (
@@ -64,12 +66,14 @@ export const Greeting = ({
         <div className="Greeting__Action">
           <CloudAction
             cloudStatus={cloudStatus}
+            isCloudInstancesDropdownOpen={isCloudInstancesDropdownOpen}
             onAuthenticate={onAuthenticate}
-            onConnectToPrimarySubscription={onConnectToPrimarySubscription}
+            onConnectToCloudInstance={onConnectToCloudInstance}
             onDeauthenticate={onDeauthenticate}
-            onRefresh={onRefreshCloudStatus}
             onInstanceCreate={onInstanceCreate}
+            onRefresh={onRefreshCloudStatus}
             onShare={onShare}
+            onToggleCloudInstancesDropdown={onToggleCloudInstancesDropdown}
           />
         </div>
         <div className="Greeting__SecondaryActions">


### PR DESCRIPTION
This fixes #674.

Users with a single instance is not affected - it will still show a button from which they will connect to their instance immediately.

For a user with more than one instance the button will be a dropdown from which they can select their instance by its name:

![skaermbillede 2018-03-14 kl 15 35 58](https://user-images.githubusercontent.com/1243959/37409222-17c76e94-279e-11e8-9288-a77db976a166.png)
![skaermbillede 2018-03-14 kl 15 36 03](https://user-images.githubusercontent.com/1243959/37409233-1c1dd168-279e-11e8-8241-c8da0da9b071.png)
