### PR TITLE
Only show fatal errors - log a warning otherwise

### DIFF
--- a/src/ui/reusable/RealmLoadingComponent/index.tsx
+++ b/src/ui/reusable/RealmLoadingComponent/index.tsx
@@ -145,8 +145,11 @@ export abstract class RealmLoadingComponent<
   ) => {
     if (error.message === 'SSL server certificate rejected') {
       this.certificateWasRejected = true;
+    } else if (error.isFatal) {
+      showError('Error while synchronizing Realm', error);
     } else {
-      showError('Failed while synchronizing Realm', error);
+      /* tslint:disable-next-line:no-console */
+      console.warn(`A non-fatal sync error happened: ${error.message}`, error);
     }
   };
 


### PR DESCRIPTION
Instead of showing a message box that blocks user interaction on every sync error, this will only show the message box for fatal errors. This was already the case for the server administration window - but this fixes the issue for the realm browser too.

- This fixes https://github.com/realm/realm-studio/issues/709
- This fixes https://github.com/realm/realm-studio/issues/766