### PR TITLE
Retrying authentication via GitHub

### DIFF
--- a/src/actions/main/Sender.ts
+++ b/src/actions/main/Sender.ts
@@ -43,6 +43,10 @@ export class Sender extends ActionSender {
     return this.send(MainActions.RefreshCloudStatus);
   }
 
+  public reopenGitHubUrl() {
+    return this.send(MainActions.ReopenGitHubUrl);
+  }
+
   public setRaasEndpoint(endpoint: raas.Endpoint) {
     return this.send(MainActions.SetRaasEndpoint, endpoint);
   }

--- a/src/main/Application.ts
+++ b/src/main/Application.ts
@@ -51,6 +51,9 @@ export class Application {
     [MainActions.RefreshCloudStatus]: () => {
       this.cloudManager.refresh();
     },
+    [MainActions.ReopenGitHubUrl]: () => {
+      this.cloudManager.reopenGitHubUrl();
+    },
     [MainActions.SetRaasEndpoint]: (endpoint: raas.Endpoint) => {
       return this.setRaasEndpoint(endpoint);
     },

--- a/src/main/Application.ts
+++ b/src/main/Application.ts
@@ -317,6 +317,7 @@ export class Application {
         // We need a timeout here, because the close event fires before the cloud status updates
         reject(new Error('Window was closed instead of authenticating'));
         this.cloudManager.removeListener(listener);
+        this.cloudManager.abortPendingGitHubAuthentications();
       });
       // If resolveUser is false - we resolve the promise as soon as the window loads
       if (!resolveUser) {

--- a/src/main/CloudManager.ts
+++ b/src/main/CloudManager.ts
@@ -149,6 +149,11 @@ export class CloudManager {
     }
   }
 
+  public abortPendingGitHubAuthentications() {
+    github.abortPendingAuthentications();
+    this.refresh();
+  }
+
   protected async authenticate(
     performAuthentication: () => Promise<raas.user.IAuthResponse>,
   ) {

--- a/src/main/CloudManager.ts
+++ b/src/main/CloudManager.ts
@@ -52,6 +52,7 @@ export class CloudManager {
   private static AUTHENTICATION_TIMEOUT = 5000;
   private listeningWindows: Electron.BrowserWindow[] = [];
   private listeners: CloudStatusListener[] = [];
+  private lastGitHubState?: string;
 
   public addListeningWindow(window: Electron.BrowserWindow) {
     this.listeningWindows.push(window);
@@ -78,7 +79,12 @@ export class CloudManager {
       waitingForUser: true,
       endpoint,
     });
-    const code = await github.authenticate();
+    const code = await github.authenticate(undefined, state => {
+      this.lastGitHubState = state;
+    });
+    // Forget the github state again ...
+    delete this.lastGitHubState;
+    // Authenticate with the newly obtained GitHub code
     return this.authenticate(() => {
       return raas.user.authenticateWithGitHub(code);
     });
@@ -88,39 +94,6 @@ export class CloudManager {
     return this.authenticate(() => {
       return raas.user.authenticateWithEmail(email, password);
     });
-  }
-
-  public async authenticate(
-    performAuthentication: () => Promise<raas.user.IAuthResponse>,
-  ) {
-    const endpoint = raas.getEndpoint();
-    try {
-      this.sendCloudStatus({
-        kind: 'authenticating',
-        waitingForUser: false,
-        endpoint,
-      });
-      const response = await timeout<raas.user.IAuthResponse>(
-        CloudManager.AUTHENTICATION_TIMEOUT,
-        new Error(
-          `Request timed out (waited ${
-            CloudManager.AUTHENTICATION_TIMEOUT
-          } ms)`,
-        ),
-        performAuthentication(),
-      );
-      raas.user.setToken(response.token);
-      this.refresh(true);
-      return response;
-    } catch (err) {
-      this.sendCloudStatus({
-        kind: 'error',
-        message: err.message,
-        endpoint,
-      });
-      // Allow callers to catch this error too, by rethrowing
-      throw err;
-    }
   }
 
   public async deauthenticate() {
@@ -165,6 +138,47 @@ export class CloudManager {
         message: err.message,
         endpoint,
       });
+    }
+  }
+
+  public reopenGitHubUrl() {
+    if (this.lastGitHubState) {
+      github.openUrl(this.lastGitHubState);
+    } else {
+      throw new Error('Expected an active GitHub authenticating state');
+    }
+  }
+
+  protected async authenticate(
+    performAuthentication: () => Promise<raas.user.IAuthResponse>,
+  ) {
+    const endpoint = raas.getEndpoint();
+    try {
+      this.sendCloudStatus({
+        kind: 'authenticating',
+        waitingForUser: false,
+        endpoint,
+      });
+      const response = await timeout<raas.user.IAuthResponse>(
+        CloudManager.AUTHENTICATION_TIMEOUT,
+        new Error(
+          `Request timed out (waited ${
+            CloudManager.AUTHENTICATION_TIMEOUT
+          } ms)`,
+        ),
+        performAuthentication(),
+      );
+      raas.user.setToken(response.token);
+      this.refresh(true);
+      return response;
+    } catch (err) {
+      this.sendCloudStatus({
+        kind: 'error',
+        message: err.message,
+        endpoint,
+      });
+      // Allow callers to catch this error too, by rethrowing
+      throw err;
     }
   }
 

--- a/src/main/MainActions.ts
+++ b/src/main/MainActions.ts
@@ -4,6 +4,7 @@ export enum MainActions {
   CheckForUpdates = 'check-for-updates',
   Deauthenticate = 'deauthenticate',
   RefreshCloudStatus = 'refresh-cloud-status',
+  ReopenGitHubUrl = 'reopen-github-url',
   SetRaasEndpoint = 'set-raas-endpoint',
   ShowCloudAuthentication = 'show-cloud-authentication',
   ShowConnectToServer = 'show-connect-to-server',

--- a/src/services/github/index.ts
+++ b/src/services/github/index.ts
@@ -80,3 +80,12 @@ export const handleOauthCallback = (options: IOAuthCallbackOptions) => {
     });
   }
 };
+
+export const abortPendingAuthentications = () => {
+  const err = new Error('Pending GitHub authentications were aborted');
+  Object.entries(authenticationPromises).forEach(([state, { reject }]) => {
+    // Forget about the promise and reject it
+    delete authenticationPromises[state];
+    reject(err);
+  });
+};

--- a/src/ui/CloudAuthentication/CloudAuthentication.tsx
+++ b/src/ui/CloudAuthentication/CloudAuthentication.tsx
@@ -1,7 +1,7 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 
-import { Mode } from '.';
+import { Mode, Status } from '.';
 import cloudLogo from '../../../static/svgs/cloud-logo.svg';
 import { LoadingOverlay } from '../reusable/LoadingOverlay';
 
@@ -13,23 +13,25 @@ import { VerifyEmailOverlay } from './VerifyEmailOverlay';
 import './CloudAuthentication.scss';
 
 interface ICloudAuthenticationProps {
-  isLoading: boolean;
   message?: string;
   mode: Mode;
   onAuthenticateWithEmail: (email: string, password: string) => void;
   onAuthenticateWithGitHub: () => void;
   onModeChange: (mode: Mode) => void;
+  onReopenGitHubUrl: () => void;
   onSignUp: (email: string, password: string) => void;
+  status: Status;
 }
 
 export const CloudAuthentication = ({
-  isLoading,
   message,
   mode,
   onAuthenticateWithEmail,
   onAuthenticateWithGitHub,
   onModeChange,
+  onReopenGitHubUrl,
   onSignUp,
+  status,
 }: ICloudAuthenticationProps) => (
   <div
     className={classNames(
@@ -66,6 +68,20 @@ export const CloudAuthentication = ({
         <VerifyEmailOverlay onModeChange={onModeChange} />
       )}
     </div>
-    <LoadingOverlay loading={isLoading} />
+    <LoadingOverlay
+      loading={status !== 'idle'}
+      progress={
+        status === 'awaiting-github'
+          ? {
+              status: 'in-progress',
+              message: 'Waiting for you to grant access',
+              retry: {
+                onRetry: onReopenGitHubUrl,
+                label: 'Open GitHub again',
+              },
+            }
+          : undefined
+      }
+    />
   </div>
 );

--- a/src/ui/CloudAuthentication/index.tsx
+++ b/src/ui/CloudAuthentication/index.tsx
@@ -10,13 +10,18 @@ import { CloudAuthentication } from './CloudAuthentication';
 const INTRODUCED_STORAGE_KEY = 'cloud-introduced';
 
 export type Mode = 'introduction' | 'log-in' | 'sign-up' | 'verify-email';
+export type Status =
+  | 'idle'
+  | 'authenticating'
+  | 'signing-up'
+  | 'awaiting-github';
 
 interface ICloudAuthenticationContainerProps {
   message?: string;
 }
 
 interface ICloudAuthenticationContainerState {
-  isLoading: boolean;
+  status: Status;
   mode: Mode;
 }
 
@@ -29,7 +34,7 @@ class CloudAuthenticationContainer extends React.Component<
     const wasCloudIntroduced =
       localStorage.getItem(INTRODUCED_STORAGE_KEY) !== null;
     this.state = {
-      isLoading: false,
+      status: 'idle',
       mode: wasCloudIntroduced ? 'log-in' : 'introduction',
     };
   }
@@ -37,13 +42,14 @@ class CloudAuthenticationContainer extends React.Component<
   public render() {
     return (
       <CloudAuthentication
-        isLoading={this.state.isLoading}
         message={this.props.message}
         mode={this.state.mode}
         onAuthenticateWithEmail={this.onAuthenticateWithEmail}
         onAuthenticateWithGitHub={this.onAuthenticateWithGitHub}
         onModeChange={this.onModeChange}
+        onReopenGitHubUrl={this.onReopenGitHubUrl}
         onSignUp={this.onSignUp}
+        status={this.state.status}
       />
     );
   }
@@ -52,26 +58,28 @@ class CloudAuthenticationContainer extends React.Component<
     email: string,
     password: string,
   ) => {
-    this.setState({ isLoading: true });
+    this.setState({ status: 'authenticating' });
     try {
       await main.authenticateWithEmail(email, password);
       this.setCloudIntroduced(true);
       // We could have closed not but it will get closed when the status updates
     } catch (err) {
       showError('Failed to authenticate with email', err);
-      this.setState({ isLoading: false });
+    } finally {
+      this.setState({ status: 'idle' });
     }
   };
 
   protected onAuthenticateWithGitHub = async () => {
-    this.setState({ isLoading: true });
+    this.setState({ status: 'awaiting-github' });
     try {
       const response = await main.authenticateWithGitHub();
       this.setCloudIntroduced(true);
       // We could have closed not but it will get closed when the status updates
     } catch (err) {
       showError('Failed to authenticate with GitHub', err);
-      this.setState({ isLoading: false });
+    } finally {
+      this.setState({ status: 'idle' });
     }
   };
 
@@ -79,16 +87,21 @@ class CloudAuthenticationContainer extends React.Component<
     this.setState({ mode });
   };
 
+  protected onReopenGitHubUrl = () => {
+    main.reopenGitHubUrl();
+  };
+
   protected onSignUp = async (email: string, password: string) => {
-    this.setState({ isLoading: true });
+    this.setState({ status: 'signing-up' });
     try {
       await raas.user.postEmailSignup(email, password);
       this.setCloudIntroduced(true);
       this.setState({ mode: 'verify-email' });
     } catch (err) {
       showError('Failed to sign up', err);
+    } finally {
+      this.setState({ status: 'idle' });
     }
-    this.setState({ isLoading: false });
   };
 
   protected setCloudIntroduced(introduced: boolean) {

--- a/src/ui/CloudAuthentication/index.tsx
+++ b/src/ui/CloudAuthentication/index.tsx
@@ -77,7 +77,10 @@ class CloudAuthenticationContainer extends React.Component<
       this.setCloudIntroduced(true);
       // We could have closed not but it will get closed when the status updates
     } catch (err) {
-      showError('Failed to authenticate with GitHub', err);
+      // This error is expected when closing down
+      if (err.message !== 'Pending GitHub authentications were aborted') {
+        showError('Failed to authenticate with GitHub', err);
+      }
     } finally {
       this.setState({ status: 'idle' });
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,11 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2017",
     "module": "commonjs",
 
     "allowJs": true,
     "baseUrl": ".",
     "jsx": "react",
-    "lib": [
-      "dom",
-      "es5",
-      "es6"
-    ],
     "downlevelIteration": true,
     "noImplicitAny": true,
     "removeComments": true,


### PR DESCRIPTION
This fixes #700 by
- [x] Adding a retry button when authenticating via GitHub.
- [x] Canceling any pending login if the authentication window is closed before authentication succeeds.

<img width="512" alt="skaermbillede 2018-05-29 kl 16 38 33" src="https://user-images.githubusercontent.com/1243959/40665903-ca198e5a-635e-11e8-9cb1-56c7d77cf8a8.png">

