### PR TITLE
Showing an error when connecting to an incompatible version of ROS

### DIFF
--- a/src/ui/ServerAdministration/index.tsx
+++ b/src/ui/ServerAdministration/index.tsx
@@ -287,8 +287,10 @@ class ServerAdministrationContainer extends RealmLoadingComponent<
       serverVersion: version,
       progress: {
         status: 'failed',
-        message: `You are connecting to a Realm Object Server, which version is not longer supported by this version of Realm Studio.\n
-          You can download a version of Studio that is backwards compatible with older versions of the Realm Object Server, but that release won't receive updates.`,
+        message: `You are connecting to an old Realm Object Server,
+          no longer supported by Realm Studio.\n
+          You can download an older compatible version of Realm Studio,
+          which won't receive updates.`,
         retry: {
           label: 'Downgrade Realm Studio',
           onRetry: this.onDowngradeStudio,


### PR DESCRIPTION
This will be fixing https://github.com/realm/realm-studio/issues/755 by:
- [x] Prompting the user to download a ROS 2 compatible version of Studio if connecting to an old server.

![skaermbillede 2018-05-29 kl 14 20 37](https://user-images.githubusercontent.com/1243959/40658422-7b4c6df0-634b-11e8-9477-d05a08aa9803.png)

Clicking "Downgrade Realm Studio" closes the window and opens the URL to start the download in the users native browser.
