### PR TITLE
Upgraded Realm JS to 2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11951,7 +11951,8 @@
     "querystringify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
-      "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
+      "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
+      "dev": true
     },
     "randomatic": {
       "version": "1.1.7",
@@ -12275,9 +12276,9 @@
       }
     },
     "realm": {
-      "version": "2.2.14",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-2.2.14.tgz",
-      "integrity": "sha1-AkTwzsNIQdVgR8SIP9SVodQIu28=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-2.6.0.tgz",
+      "integrity": "sha1-isj2GVZEldcQ0luJzMzL5XDELag=",
       "requires": {
         "command-line-args": "4.0.7",
         "decompress": "4.2.0",
@@ -12291,13 +12292,22 @@
         "request": "2.85.0",
         "stream-counter": "1.0.0",
         "sync-request": "3.0.1",
-        "url-parse": "1.1.9"
+        "url-parse": "1.4.0"
       },
       "dependencies": {
-        "nan": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-          "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+        "querystringify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+          "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
+        },
+        "url-parse": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
+          "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
+          "requires": {
+            "querystringify": "2.0.0",
+            "requires-port": "1.0.0"
+          }
         }
       }
     },
@@ -15341,6 +15351,7 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
       "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
+      "dev": true,
       "requires": {
         "querystringify": "1.0.0",
         "requires-port": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "react-sortable-hoc": "^0.6.8",
     "react-virtualized": "^9.18.5",
     "reactstrap": "^4.8.0",
-    "realm": "^2.2.14",
+    "realm": "^2.6.0",
     "uuid": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrading Realm JS to 2.6.0 which will make it incompatible with version 2.x of the server.