### PR TITLE
Using more verbose Dockerfiles with node 8

### DIFF
--- a/Dockerfile.releasing
+++ b/Dockerfile.releasing
@@ -1,6 +1,18 @@
-FROM electronuserland/builder:wine-chrome
+FROM electronuserland/builder:8
 
-# Install libsecret-1 and remove the apt-get cache afterwards
-RUN apt-get -qq update && apt-get -qq install -y \
-  libsecret-1-dev \
- && rm -rf /var/lib/apt/lists/*
+# This got copied from https://github.com/electron-userland/electron-builder/blob/master/docker/wine/Dockerfile
+# See https://github.com/electron-userland/electron-builder/issues/2531
+
+RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common && dpkg --add-architecture i386 && curl -L https://dl.winehq.org/wine-builds/Release.key > Release.key && apt-key add Release.key && apt-add-repository https://dl.winehq.org/wine-builds/ubuntu && \
+  apt-get update && \
+  apt-get -y remove software-properties-common libdbus-glib-1-2 python3-dbus python3-gi python3-pycurl python3-software-properties && \
+  apt-get install -y --no-install-recommends winehq-stable && \
+  # Install a dependency used by keytar
+  apt-get -qq install -y libsecret-1-dev && \
+  # clean
+  apt-get clean && rm -rf /var/lib/apt/lists/* && unlink Release.key
+
+RUN curl -L https://github.com/electron-userland/electron-builder-binaries/releases/download/wine-2.0.3-mac-10.13/wine-home.zip > /tmp/wine-home.zip && unzip /tmp/wine-home.zip -d /root/.wine && unlink /tmp/wine-home.zip
+
+ENV WINEDEBUG -all,err+all
+ENV WINEDLLOVERRIDES winemenubuilder.exe=d

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,9 +1,27 @@
-FROM electronuserland/builder:wine-chrome
+FROM electronuserland/builder:8
 
-# Install libsecret-1 and remove the apt-get cache afterwards
-RUN apt-get -qq update && apt-get -qq install -y \
-  libsecret-1-dev \
- && rm -rf /var/lib/apt/lists/*
+# This got copied from https://github.com/electron-userland/electron-builder/blob/master/docker/wine/Dockerfile
+# See https://github.com/electron-userland/electron-builder/issues/2531
+
+RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common && dpkg --add-architecture i386 && curl -L https://dl.winehq.org/wine-builds/Release.key > Release.key && apt-key add Release.key && apt-add-repository https://dl.winehq.org/wine-builds/ubuntu && \
+  apt-get update && \
+  apt-get -y remove software-properties-common libdbus-glib-1-2 python3-dbus python3-gi python3-pycurl python3-software-properties && \
+  apt-get install -y --no-install-recommends winehq-stable && \
+  # Next three lines are copied from https://github.com/electron-userland/electron-builder/blob/master/docker/wine-chrome/Dockerfile
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
+  apt-get update -y && apt-get install -y --no-install-recommends xvfb google-chrome-stable && \
+  # Install a dependency used by keytar
+  apt-get -qq install -y libsecret-1-dev && \
+  # clean
+  apt-get clean && rm -rf /var/lib/apt/lists/* && unlink Release.key
+
+RUN curl -L https://github.com/electron-userland/electron-builder-binaries/releases/download/wine-2.0.3-mac-10.13/wine-home.zip > /tmp/wine-home.zip && unzip /tmp/wine-home.zip -d /root/.wine && unlink /tmp/wine-home.zip
+
+ENV WINEDEBUG -all,err+all
+ENV WINEDLLOVERRIDES winemenubuilder.exe=d
+
+# The next few lines are the only commands special to our Dockerfile
 
 ADD package.json /tmp/package.json
 ADD package-lock.json /tmp/package-lock.json

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "realm-studio",
   "productName": "Realm Studio",
   "version": "1.21.1",
-  "description": "A tool for everything Realm",
+  "description": "A tool for everything Realm!",
   "author": {
     "name": "Realm Inc.",
     "email": "info@realm.io",


### PR DESCRIPTION
Because electron builder is not versioning the dockerfiles in a way that we can pin the version of node (see https://github.com/electron-userland/electron-builder/issues/2531#issuecomment-392762851) and Realm JS doesn't support Node 10 (see https://github.com/realm/realm-js/issues/1813) this introduces move verbose Dockerfiles that uses the node 8 base image provided by electron builder.