### PR TITLE
Fixed adding a property when a list of primitives already exists

### DIFF
--- a/src/ui/RealmBrowser/AddPropertyModal/index.tsx
+++ b/src/ui/RealmBrowser/AddPropertyModal/index.tsx
@@ -26,7 +26,7 @@ export interface IAddPropertyModalProps {
   focus: IClassFocus;
   isOpen: boolean;
   isPropertyNameAvailable: (name: string) => boolean;
-  onAddProperty: (property: Realm.PropertiesTypes) => void;
+  onAddProperty: (name: string, type: Realm.PropertyType) => void;
   schemas: Realm.ObjectSchema[];
   toggle: () => void;
 }
@@ -77,7 +77,8 @@ class AddPropertyModalContainer extends React.Component<
 
   public onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    this.props.onAddProperty(this.getSchemaProperty());
+    const type = this.getSchemaType();
+    this.props.onAddProperty(this.state.name, type);
     this.props.toggle();
     this.setState(initialState);
   };
@@ -142,9 +143,8 @@ class AddPropertyModalContainer extends React.Component<
     });
   };
 
-  private getSchemaProperty = () => {
+  private getSchemaType = () => {
     const {
-      name,
       type: propertyType,
       optional,
       isList,
@@ -153,9 +153,7 @@ class AddPropertyModalContainer extends React.Component<
     const optionalMarker =
       optional && !(isList && !primitiveTypeSelected) ? '?' : '';
     const listMarker = isList ? '[]' : '';
-    return {
-      [name]: `${propertyType}${optionalMarker}${listMarker}`,
-    };
+    return `${propertyType}${optionalMarker}${listMarker}`;
   };
 
   private getClassesTypes = (schemas: Realm.ObjectSchema[]): string[] =>

--- a/src/ui/RealmBrowser/RealmBrowser.tsx
+++ b/src/ui/RealmBrowser/RealmBrowser.tsx
@@ -66,7 +66,7 @@ export interface IRealmBrowserProps {
   isEncryptionDialogVisible: boolean;
   isPropertyNameAvailable: (name: string) => boolean;
   onAddClass: (schema: Realm.ObjectSchema) => void;
-  onAddProperty: (property: Realm.PropertiesTypes) => void;
+  onAddProperty: (name: string, type: Realm.PropertyType) => void;
   onCancelTransaction: () => void;
   onCellChange: CellChangeHandler;
   onCellClick: CellClickHandler;

--- a/src/ui/RealmBrowser/Table/HeaderCell.tsx
+++ b/src/ui/RealmBrowser/Table/HeaderCell.tsx
@@ -28,10 +28,10 @@ import { IPropertyWithName } from '..';
 const HANDLE_WIDTH = 5;
 const HANDLE_OFFSET = Math.ceil(HANDLE_WIDTH / 2);
 
-const getPropertyDescription = (property: Realm.ObjectSchemaProperty) => {
+const getPropertyType = (property: Realm.ObjectSchemaProperty) => {
   switch (property.type) {
     case 'list':
-      return `${property.objectType}[]`;
+      return property.objectType;
     case 'object':
     case 'linkingObjects':
       return property.objectType;
@@ -40,12 +40,12 @@ const getPropertyDescription = (property: Realm.ObjectSchemaProperty) => {
   }
 };
 
-const getPropertyPostfix = (property: Realm.ObjectSchemaProperty) => {
-  return property.optional ? '?' : '';
-};
-
 export const getPropertyDisplayed = (property: Realm.ObjectSchemaProperty) => {
-  return getPropertyDescription(property) + getPropertyPostfix(property);
+  return [
+    getPropertyType(property),
+    property.optional ? '?' : '',
+    property.type === 'list' ? '[]' : '',
+  ].join('');
 };
 
 const isPropertySortable = (property: IPropertyWithName) => {

--- a/src/ui/RealmBrowser/schema-utils.ts
+++ b/src/ui/RealmBrowser/schema-utils.ts
@@ -1,0 +1,73 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import * as Realm from 'realm';
+
+import { isPrimitive } from './primitives';
+
+export const addProperty = (
+  objectSchemas: Realm.ObjectSchema[],
+  className: string,
+  propertyName: string,
+  propertyType: Realm.PropertyType,
+) => {
+  return objectSchemas.map(schema => {
+    if (schema.name === className) {
+      // Return the modified object schema
+      return {
+        ...schema,
+        properties: {
+          ...schema.properties,
+          [propertyName]: propertyType,
+        },
+      };
+    } else {
+      return schema;
+    }
+  });
+};
+
+function cleanUpProperty(
+  property: Realm.ObjectSchemaProperty,
+): Realm.ObjectSchemaProperty | string {
+  if (
+    property.type === 'list' &&
+    property.objectType &&
+    isPrimitive(property.objectType)
+  ) {
+    return `${property.objectType}${property.optional ? '?' : ''}[]`;
+  } else {
+    return property;
+  }
+}
+
+// A mitigation before https://github.com/realm/realm-js/issues/1847 gets fixed
+export const cleanUpSchema = (objectSchemas: Realm.ObjectSchema[]) => {
+  return objectSchemas.map(schema => {
+    const properties: Realm.PropertiesTypes = {};
+    for (const [name, property] of Object.entries(schema.properties)) {
+      properties[name] =
+        typeof property === 'string' ? property : cleanUpProperty(property);
+    }
+    // Return the modified object schema
+    return {
+      ...schema,
+      properties,
+    };
+  });
+};


### PR DESCRIPTION
This fixes #792 by cleaning the schema before saving it back to the Realm.

The root cause was a bug in Realm JS that I now reported as https://github.com/realm/realm-js/issues/1847.