### PR TITLE
CSV importer improved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14983,9 +14983,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.1.tgz",
+      "integrity": "sha512-h6pM2f/GDchCFlldnriOhs1QHuwbnmj6/v7499eMHqPeW4V2G0elua2eIc2nu8v2NdHV0Gm+tzX83Hr6nUFjQA==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "tslint-eslint-rules": "^4.1.1",
     "tslint-plugin-prettier": "^1.2.0",
     "tslint-react": "^3.2.0",
-    "typescript": "^2.7.2",
+    "typescript": "^2.9.1",
     "uglifyjs-webpack-plugin": "^1.2.4",
     "url-loader": "^0.6.2",
     "webpack": "^4.1.1",

--- a/src/main/Application.ts
+++ b/src/main/Application.ts
@@ -242,34 +242,35 @@ export class Application {
 
   public showImportData(format: dataImporter.ImportFormat) {
     return new Promise((resolve, reject) => {
-      electron.dialog.showOpenDialog(
-        {
-          properties: ['openFile', 'multiSelections'],
-          filters: [{ name: 'CSV File(s)', extensions: ['csv', 'CSV'] }],
-        },
-        selectedPaths => {
-          if (selectedPaths) {
-            // Generate the Realm from the provided CSV file(s)
-            const schemaGenerator = new ImportSchemaGenerator(
-              ImportFormat.CSV,
-              selectedPaths,
-            );
-            const schema = schemaGenerator.generate();
-            const importer = getDataImporter(format, selectedPaths, schema);
-            const generatedRealm = importer.import(
-              path.dirname(selectedPaths[0]),
-            );
-            // close Realm in main process (to be opened in Renderer process)
-            generatedRealm.close();
-
-            // Open a RealmBrowser using the generated Realm file.
-            this.openLocalRealmAtPath(generatedRealm.path).then(
-              resolve,
-              reject,
-            );
-          }
-        },
+      // Ask the users for the file names of files to import
+      const paths = dataImporter.showOpenDialog(format);
+      if (!paths || paths.length === 0) {
+        // Don't do anything if the user cancelled or selected no files
+        return;
+      }
+      // Generate the Realm from the provided CSV file(s)
+      const schema = dataImporter.generateSchema(
+        dataImporter.ImportFormat.CSV,
+        paths,
       );
+      // Get the importer
+      const importer = dataImporter.getDataImporter(format, paths, schema);
+      // Start the import
+      const defaultPath = path.dirname(paths[0]) + '/default.realm';
+      const destinationPath = electron.dialog.showSaveDialog({
+        defaultPath,
+        title: 'Choose where to store the imported data',
+        filters: [{ name: 'Realm file', extensions: ['realm'] }],
+      });
+      if (!destinationPath) {
+        // Don't do anything if the user cancelled or selected no files
+        return;
+      }
+      const generatedRealm = importer.import(destinationPath);
+      // Close Realm in main process (to be opened in Renderer process)
+      generatedRealm.close();
+      // Open a RealmBrowser using the generated Realm file.
+      this.openLocalRealmAtPath(generatedRealm.path).then(resolve, reject);
     });
   }
 

--- a/src/main/Application.ts
+++ b/src/main/Application.ts
@@ -22,8 +22,7 @@ import { URL } from 'url';
 import * as path from 'path';
 import { MainReceiver } from '../actions/main';
 import { CLOUD_PROTOCOL, STUDIO_PROTOCOL } from '../constants';
-import { getDataImporter, ImportFormat } from '../services/data-importer';
-import ImportSchemaGenerator from '../services/data-importer/ImportSchemaGenerator';
+import * as dataImporter from '../services/data-importer';
 import * as github from '../services/github';
 import * as raas from '../services/raas';
 import { realms } from '../services/ros';
@@ -87,7 +86,7 @@ export class Application {
     [MainActions.ShowGreeting]: () => {
       return this.showGreeting();
     },
-    [MainActions.ShowImportData]: (format: ImportFormat) => {
+    [MainActions.ShowImportData]: (format: dataImporter.ImportFormat) => {
       return this.showImportData(format);
     },
     [MainActions.ShowOpenLocalRealm]: () => {
@@ -241,7 +240,7 @@ export class Application {
     });
   }
 
-  public showImportData(format: ImportFormat) {
+  public showImportData(format: dataImporter.ImportFormat) {
     return new Promise((resolve, reject) => {
       electron.dialog.showOpenDialog(
         {

--- a/src/main/MainMenu.ts
+++ b/src/main/MainMenu.ts
@@ -22,6 +22,7 @@ import { main } from '../actions/main';
 import { ImportFormat } from '../services/data-importer';
 import * as raas from '../services/raas';
 import { store } from '../store';
+import { showError } from '../ui/reusable/errors';
 
 const isProduction = process.env.NODE_ENV === 'production';
 const showInternalFeatures =
@@ -52,7 +53,9 @@ export const getDefaultMenuTemplate = (
               id: 'import-csv',
               label: 'CSV',
               click: () => {
-                main.showImportData(ImportFormat.CSV);
+                main.showImportData(ImportFormat.CSV).catch(err => {
+                  showError('Failed to import data', err);
+                });
               },
             },
           ],

--- a/src/main/MainMenu.ts
+++ b/src/main/MainMenu.ts
@@ -49,6 +49,7 @@ export const getDefaultMenuTemplate = (
           id: 'import',
           submenu: [
             {
+              id: 'import-csv',
               label: 'CSV',
               click: () => {
                 main.showImportData(ImportFormat.CSV);

--- a/src/services/data-importer/DataImporter.ts
+++ b/src/services/data-importer/DataImporter.ts
@@ -38,11 +38,11 @@ export abstract class DataImporter {
    * Creates a new, empty Realm file, formatted with the schema properties provided
    * with the `ImportSchema` parameter.
    *
-   * @param output An absolute path to the folder that will hold the new Realm file.
+   * @param output An absolute path to the new Realm file.
    */
-  public createNewRealmFile(output: string): Realm {
+  public createNewRealmFile(path: string): Realm {
     const realm = new Realm({
-      path: `${output}/default.realm`,
+      path,
       schema: this.importSchema,
     });
     return realm;

--- a/src/services/data-importer/ImportObjectSchema.ts
+++ b/src/services/data-importer/ImportObjectSchema.ts
@@ -1,0 +1,8 @@
+export class ImportObjectSchema implements Realm.ObjectSchema {
+  public name: string;
+  public properties: Realm.PropertiesTypes = {};
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}

--- a/src/services/data-importer/ImportObjectSchema.ts
+++ b/src/services/data-importer/ImportObjectSchema.ts
@@ -1,3 +1,21 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
 export class ImportObjectSchema implements Realm.ObjectSchema {
   public name: string;
   public properties: Realm.PropertiesTypes = {};

--- a/src/services/data-importer/SchemaGenerator.ts
+++ b/src/services/data-importer/SchemaGenerator.ts
@@ -16,35 +16,18 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import * as Realm from 'realm';
+/**
+ * Will analyze the contents of files provided to it, and intelligently
+ * generate a schema definition object with which the structure of a Realm file can be created.
+ *
+ * This is then used to map the raw data to the appropriate properties when performing the import to Realm.
+ */
+export abstract class SchemaGenerator {
+  protected paths: string[];
 
-import * as csv from './csv';
-export { csv };
+  constructor(paths: string[]) {
+    this.paths = paths;
+  }
 
-export * from './ui';
-
-export enum ImportFormat {
-  CSV = 'csv',
-  // JSON = 'json',
+  public abstract generate(): Realm.ObjectSchema[];
 }
-
-export const generateSchema = (format: ImportFormat, paths: string[]) => {
-  if (format === ImportFormat.CSV) {
-    const generator = new csv.CSVSchemaGenerator(paths);
-    return generator.generate();
-  } else {
-    throw new Error('Not supported yet');
-  }
-};
-
-export const getDataImporter = (
-  format: ImportFormat,
-  paths: string[],
-  schema: Realm.ObjectSchema[],
-) => {
-  if (format === ImportFormat.CSV) {
-    return new csv.CSVDataImporter(paths, schema);
-  } else {
-    throw new Error('Not supported yet');
-  }
-};

--- a/src/services/data-importer/csv/CSVDataImporter.ts
+++ b/src/services/data-importer/csv/CSVDataImporter.ts
@@ -16,10 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import fs = require('fs-extra');
-import fsExtra = require('fs-extra');
-import papaparse = require('papaparse');
-import * as fsPath from 'path';
+import * as fs from 'fs-extra';
+import * as papaparse from 'papaparse';
+
 import { DataImporter } from '../DataImporter';
 
 export class CSVDataImporter extends DataImporter {
@@ -114,7 +113,7 @@ export class CSVDataImporter extends DataImporter {
     } catch (e) {
       realm.close();
       // in case of an error remove the created Realm
-      fsExtra.removeSync(realm.path);
+      fs.removeSync(realm.path);
       throw e;
     }
     return realm;

--- a/src/services/data-importer/csv/index.ts
+++ b/src/services/data-importer/csv/index.ts
@@ -1,0 +1,2 @@
+export { CSVDataImporter } from './CSVDataImporter';
+export { CSVSchemaGenerator } from './CSVSchemaGenerator';

--- a/src/services/data-importer/ui.ts
+++ b/src/services/data-importer/ui.ts
@@ -16,5 +16,22 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-export { CSVDataImporter } from './CSVDataImporter';
-export { CSVSchemaGenerator } from './CSVSchemaGenerator';
+import * as electron from 'electron';
+
+import { ImportFormat } from '.';
+
+export const showOpenDialog = (
+  format: ImportFormat = ImportFormat.CSV,
+): string[] => {
+  const dialog = electron.dialog || electron.remote.dialog;
+
+  if (format !== ImportFormat.CSV) {
+    throw new Error(
+      `Currently, only CSV import is supported - format was ${format}`,
+    );
+  }
+  return dialog.showOpenDialog({
+    properties: ['openFile', 'multiSelections'],
+    filters: [{ name: 'CSV File(s)', extensions: ['csv', 'CSV'] }],
+  });
+};

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,37 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import * as dataImporter from './data-importer';
+import * as github from './github';
+import * as keytar from './keytar';
+import * as mixpanel from './mixpanel';
+import * as raas from './raas';
+import * as ros from './ros';
+import * as schemaExport from './schema-export';
+import * as tutorials from './tutorials';
+
+export {
+  dataImporter,
+  github,
+  keytar,
+  mixpanel,
+  raas,
+  ros,
+  schemaExport,
+  tutorials,
+};

--- a/src/services/ros/realms.ts
+++ b/src/services/ros/realms.ts
@@ -93,21 +93,20 @@ export const create = (
   user: Realm.Sync.User,
   realmPath: string,
 ): Promise<Realm> => {
-  const url = getUrl(user, realmPath);
-  const config = {
-    sync: {
-      user,
-      url,
-      error: onCreateRealmErrorCallback,
-    },
-    schema: [],
-  };
-  // Using the async Realm.open to now block the UI and wait for the Realm to upload
-  return Realm.open(config);
-};
-
-export const onCreateRealmErrorCallback = (err: any) => {
-  showError('Error while creating new synced realm', err);
+  return new Promise((resolve, reject) => {
+    const url = getUrl(user, realmPath);
+    // Using the async Realm.open to allow the caller to know when the Realm to got uploaded
+    Realm.open({
+      sync: {
+        user,
+        url,
+        error: (session, err) => {
+          reject(err);
+        },
+      },
+      schema: [],
+    }).then(resolve, reject);
+  });
 };
 
 export const remove = async (user: Realm.Sync.User, realmPath: string) => {

--- a/src/services/ros/realms.ts
+++ b/src/services/ros/realms.ts
@@ -92,6 +92,7 @@ export const open = async (
 export const create = (
   user: Realm.Sync.User,
   realmPath: string,
+  schema: Realm.ObjectSchema[] = [],
 ): Promise<Realm> => {
   return new Promise((resolve, reject) => {
     const url = getUrl(user, realmPath);
@@ -104,7 +105,7 @@ export const create = (
           reject(err);
         },
       },
-      schema: [],
+      schema,
     }).then(resolve, reject);
   });
 };

--- a/src/ui/RealmBrowser/CreateObjectDialog/types/DataControl.tsx
+++ b/src/ui/RealmBrowser/CreateObjectDialog/types/DataControl.tsx
@@ -17,9 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import { Button, Input, InputGroup, InputGroupAddon } from 'reactstrap';
-import * as Realm from 'realm';
 
 import { IBaseControlProps } from './TypeControl';
 
@@ -38,11 +36,13 @@ export const DataControl = ({
         onChange={e => {
           if (fileInput && fileInput.files && fileInput.files.length >= 1) {
             const firstFile = fileInput.files.item(0);
-            const reader = new FileReader();
-            reader.addEventListener('load', () => {
-              onChange(reader.result);
-            });
-            reader.readAsArrayBuffer(firstFile);
+            if (firstFile) {
+              const reader = new FileReader();
+              reader.addEventListener('load', () => {
+                onChange(reader.result);
+              });
+              reader.readAsArrayBuffer(firstFile);
+            }
           }
         }}
         required={!property.optional}

--- a/src/ui/RealmBrowser/CreateObjectDialog/types/DateControl.tsx
+++ b/src/ui/RealmBrowser/CreateObjectDialog/types/DateControl.tsx
@@ -19,7 +19,6 @@
 import * as moment from 'moment';
 import * as React from 'react';
 import { Button, Input, InputGroup, InputGroupAddon } from 'reactstrap';
-import * as Realm from 'realm';
 
 import { parseDate } from '../../parsers';
 

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -41,7 +41,6 @@ import { Focus, getClassName, IClassFocus, IListFocus } from './focus';
 import * as primitives from './primitives';
 import { RealmBrowser } from './RealmBrowser';
 import * as schemaUtils from './schema-utils';
-import { isSelected } from './Sidebar';
 import {
   CellChangeHandler,
   CellClickHandler,
@@ -613,7 +612,7 @@ class RealmBrowserContainer
     e.preventDefault();
     const { focus } = this.state;
 
-    const menu = new remote.Menu();
+    const contextMenu = new remote.Menu();
 
     if (params) {
       const { property, rowObject, rowIndex, columnIndex } = params;
@@ -630,7 +629,7 @@ class RealmBrowserContainer
 
       // If we clicked a property that refers to an object
       if (property && property.type === 'object') {
-        menu.append(
+        contextMenu.append(
           new remote.MenuItem({
             label: 'Update reference',
             click: () => {
@@ -647,7 +646,7 @@ class RealmBrowserContainer
           this.state.highlight.rows.size > 1,
         );
 
-        menu.append(
+        contextMenu.append(
           new remote.MenuItem({
             label,
             click: () => {

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -1112,34 +1112,12 @@ class RealmBrowserContainer
   private onImportIntoExistingRealm = (
     format: dataImporter.ImportFormat = dataImporter.ImportFormat.CSV,
   ) => {
-    if (format !== ImportFormat.CSV) {
-      throw new Error(
-        `Currently, only CSV import is supported - format was ${format}`,
-      );
-    }
-    remote.dialog.showOpenDialog(
-      {
-        properties: ['openFile', 'multiSelections'],
-        filters: [{ name: 'CSV File(s)', extensions: ['csv', 'CSV'] }],
-      },
-      selectedPaths => {
-        if (selectedPaths && selectedPaths.length > 0) {
-          this.performCSVImport(selectedPaths);
-        }
-      },
-    );
-  };
-
-  private performCSVImport(fromPaths: string[]) {
-    if (this.realm) {
-      const schemaGenerator = new ImportSchemaGenerator(
-        ImportFormat.CSV,
-        fromPaths,
-      );
+    const paths = dataImporter.showOpenDialog(format);
+    if (this.realm && paths.length > 0) {
       try {
-        const schema = schemaGenerator.generate();
+        const schema = dataImporter.generateSchema(format, paths);
         try {
-          const importer = new CSVDataImporter(fromPaths, schema);
+          const importer = dataImporter.getDataImporter(format, paths, schema);
           importer.importInto(this.realm);
         } catch (err) {
           showError('Faild to import data', err);
@@ -1148,7 +1126,7 @@ class RealmBrowserContainer
         showError('Faild to generate schema', err);
       }
     }
-  }
+  };
 }
 
 export { RealmBrowserContainer as RealmBrowser };

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -25,7 +25,7 @@ import { ImportFormat } from '../../services/data-importer';
 import { CSVDataImporter } from '../../services/data-importer/csv/CSVDataImporter';
 import ImportSchemaGenerator from '../../services/data-importer/ImportSchemaGenerator';
 import { Language, SchemaExporter } from '../../services/schema-export';
-import { getRange, menuUtils } from '../../utils';
+import { getRange, menu } from '../../utils';
 import {
   IMenuGenerator,
   IMenuGeneratorProps,
@@ -237,7 +237,7 @@ class RealmBrowserContainer
       ],
     };
 
-    return menuUtils.performModifications(template, [
+    return menu.performModifications(template, [
       {
         action: 'append',
         id: 'import',

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -679,7 +679,7 @@ class RealmBrowserContainer
       !primitives.isPrimitive(focus.property.objectType)
     ) {
       const className = getClassName(focus);
-      menu.append(
+      contextMenu.append(
         new remote.MenuItem({
           label: `Add existing ${className}`,
           click: () => {
@@ -692,7 +692,7 @@ class RealmBrowserContainer
     // If we right-clicking on the content we can always create a new object
     if (focus) {
       const className = getClassName(focus);
-      menu.append(
+      contextMenu.append(
         new remote.MenuItem({
           label: `Create new ${className}`,
           click: () => {
@@ -703,8 +703,8 @@ class RealmBrowserContainer
     }
 
     // If we have items to show - popup the menu
-    if (menu.items.length > 0) {
-      menu.popup(remote.getCurrentWindow(), {
+    if (contextMenu.items.length > 0) {
+      contextMenu.popup(remote.getCurrentWindow(), {
         x: e.clientX,
         y: e.clientY,
       });

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -21,9 +21,8 @@ import * as path from 'path';
 import * as React from 'react';
 import * as Realm from 'realm';
 
-import { ImportFormat } from '../../services/data-importer';
-import { CSVDataImporter } from '../../services/data-importer/csv/CSVDataImporter';
-import ImportSchemaGenerator from '../../services/data-importer/ImportSchemaGenerator';
+import * as dataImporter from '../../services/data-importer';
+import { CSVDataImporter } from '../../services/data-importer/csv';
 import { Language, SchemaExporter } from '../../services/schema-export';
 import { getRange, menu } from '../../utils';
 import {
@@ -1111,7 +1110,7 @@ class RealmBrowserContainer
   };
 
   private onImportIntoExistingRealm = (
-    format: ImportFormat = ImportFormat.CSV,
+    format: dataImporter.ImportFormat = dataImporter.ImportFormat.CSV,
   ) => {
     if (format !== ImportFormat.CSV) {
       throw new Error(

--- a/src/ui/ServerAdministration/CreateRealmDialog/CreateRealmDialog.tsx
+++ b/src/ui/ServerAdministration/CreateRealmDialog/CreateRealmDialog.tsx
@@ -30,18 +30,22 @@ import {
 } from 'reactstrap';
 
 export const CreateRealmDialog = ({
+  isBusy,
   isOpen,
-  toggle,
+  onCancelRealmCreation,
   onPathChanged,
   onSubmit,
   path,
 }: {
+  isBusy: boolean;
   isOpen: boolean;
-  toggle: () => void;
+  onCancelRealmCreation: () => void;
   onPathChanged: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   path: string;
 }) => {
+  // Toggling is only supporting cancellation - wonder if the other could ever happen?
+  const toggle = isOpen ? onCancelRealmCreation : undefined;
   return (
     <Modal isOpen={isOpen} toggle={toggle}>
       <Form onSubmit={onSubmit}>
@@ -61,8 +65,10 @@ export const CreateRealmDialog = ({
           </FormGroup>
         </ModalBody>
         <ModalFooter>
-          <Button color="primary">Create Realm</Button>{' '}
-          <Button color="secondary" onClick={toggle}>
+          <Button color="primary" disabled={isBusy}>
+            Create Realm
+          </Button>{' '}
+          <Button color="secondary" disabled={isBusy} onClick={toggle}>
             Cancel
           </Button>
         </ModalFooter>

--- a/src/ui/ServerAdministration/CreateRealmDialog/CreateRealmDialog.tsx
+++ b/src/ui/ServerAdministration/CreateRealmDialog/CreateRealmDialog.tsx
@@ -68,7 +68,16 @@ export const CreateRealmDialog = ({
           <Button color="primary" disabled={isBusy}>
             Create Realm
           </Button>{' '}
-          <Button color="secondary" disabled={isBusy} onClick={toggle}>
+          <Button
+            color="secondary"
+            disabled={isBusy}
+            onClick={e => {
+              e.preventDefault();
+              if (toggle) {
+                toggle();
+              }
+            }}
+          >
             Cancel
           </Button>
         </ModalFooter>

--- a/src/ui/ServerAdministration/CreateRealmDialog/index.tsx
+++ b/src/ui/ServerAdministration/CreateRealmDialog/index.tsx
@@ -21,9 +21,10 @@ import * as React from 'react';
 import { CreateRealmDialog } from './CreateRealmDialog';
 
 export interface ICreateRealmDialogContainerProps {
+  isBusy: boolean;
   isOpen: boolean;
-  onRealmCreated: (path: string) => void;
-  toggle: () => void;
+  onRealmCreation: (path: string) => void;
+  onCancelRealmCreation: () => void;
 }
 
 export interface ICreateRealmDialogContainerState {
@@ -34,25 +35,24 @@ class CreateRealmDialogContainer extends React.Component<
   ICreateRealmDialogContainerProps,
   ICreateRealmDialogContainerState
 > {
-  public state: ICreateRealmDialogContainerState = {
-    path: '',
-  };
+  public state: ICreateRealmDialogContainerState = { path: '' };
+
+  public componentDidUpdate(prevProps: ICreateRealmDialogContainerProps) {
+    // Reset the path when the dialog opens
+    if (this.props.isOpen && !prevProps.isOpen) {
+      this.setState({ path: '' });
+    }
+  }
 
   public render() {
     return <CreateRealmDialog {...this.props} {...this.state} {...this} />;
   }
 
-  public onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  public onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const { path } = this.state;
     // Await the realm being created
-    await this.props.onRealmCreated(path);
-    // Reset the state
-    this.setState({
-      path: '',
-    });
-    // And hide the dialog
-    this.props.toggle();
+    this.props.onRealmCreation(path);
   };
 
   public onPathChanged = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
@@ -27,35 +27,30 @@ import {
 } from '../shared/FilterableTable';
 import { FloatingControls } from '../shared/FloatingControls';
 import { displayUser } from '../utils';
-import { CreateRealmDialog } from './CreateRealmDialog';
 import { RealmSidebar } from './RealmSidebar';
 
 export const RealmsTable = ({
   getRealmFromId,
   getRealmPermissions,
-  isCreateRealmOpen,
-  onRealmCreated,
   onRealmDeletion,
   onRealmOpened,
   onRealmSelected,
   onRealmTypeUpgrade,
   realms,
   selectedRealmPath,
-  toggleCreateRealm,
+  onRealmCreation,
   searchString,
   onSearchStringChange,
 }: {
   getRealmFromId: (path: string) => IRealmFile | undefined;
   getRealmPermissions: (path: string) => Realm.Results<IPermission>;
-  isCreateRealmOpen: boolean;
-  onRealmCreated: (path: string) => void;
   onRealmDeletion: (path: string) => void;
   onRealmOpened: (path: string) => void;
   onRealmSelected: (path: string | null) => void;
   onRealmTypeUpgrade: (path: string) => void;
   realms: Realm.Results<IRealmFile>;
   selectedRealmPath: string | null;
-  toggleCreateRealm: () => void;
+  onRealmCreation: () => void;
   searchString: string;
   onSearchStringChange: (query: string) => void;
 }) => {
@@ -87,14 +82,8 @@ export const RealmsTable = ({
       </FilterableTable>
 
       <FloatingControls isOpen={selectedRealmPath === null}>
-        <Button onClick={toggleCreateRealm}>Create new Realm</Button>
+        <Button onClick={onRealmCreation}>Create new Realm</Button>
       </FloatingControls>
-
-      <CreateRealmDialog
-        isOpen={isCreateRealmOpen}
-        toggle={toggleCreateRealm}
-        onRealmCreated={onRealmCreated}
-      />
 
       <RealmSidebar
         getRealmPermissions={getRealmPermissions}

--- a/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
@@ -20,7 +20,7 @@ import * as React from 'react';
 import { Column } from 'react-virtualized';
 import { Button } from 'reactstrap';
 
-import { IPermission, IRealmFile, RealmType } from '../../../services/ros';
+import { IPermission, IRealmFile } from '../../../services/ros';
 import {
   FilterableTable,
   FilterableTableWrapper,

--- a/src/ui/ServerAdministration/RealmsTable/index.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/index.tsx
@@ -133,6 +133,10 @@ class RealmsTableContainer extends React.PureComponent<
       const realm = await this.props.createRealm();
       this.onRealmSelected(realm.path);
     } catch (err) {
+      if (err.message === 'Realm creation cancelled') {
+        // This is an expected expression to be thrown - no need to show it
+        return;
+      }
       showError('Failed to create Realm', err);
     }
   };

--- a/src/ui/ServerAdministration/ServerAdministration.tsx
+++ b/src/ui/ServerAdministration/ServerAdministration.tsx
@@ -18,7 +18,10 @@
 
 import * as React from 'react';
 
+import { ros } from '../../services';
 import { ILoadingProgress, LoadingOverlay } from '../reusable/LoadingOverlay';
+
+import { CreateRealmDialog } from './CreateRealmDialog';
 import { Dashboard } from './Dashboard';
 import { GettingStarted } from './GettingStarted';
 import { Log } from './Log';
@@ -43,8 +46,13 @@ interface IServerAdministrationProps {
   adminRealm?: Realm;
   adminRealmChanges: number;
   adminRealmProgress: ILoadingProgress;
+  createRealm: () => Promise<ros.IRealmFile>;
   isCloudTenant: boolean;
+  isCreateRealmOpen: boolean;
+  isCreatingRealm: boolean;
   isRealmOpening: boolean;
+  onCancelRealmCreation: () => void;
+  onRealmCreation: (path: string) => void;
   onRealmOpened: (path: string) => void;
   onReconnect: () => void;
   onTabChanged: (tab: Tab) => void;
@@ -59,6 +67,7 @@ const renderContent = ({
   activeTab,
   adminRealm,
   adminRealmChanges,
+  createRealm,
   isCloudTenant,
   onRealmOpened,
   onValidateCertificatesChange,
@@ -74,6 +83,7 @@ const renderContent = ({
       <RealmsTable
         adminRealm={adminRealm}
         adminRealmChanges={adminRealmChanges}
+        createRealm={createRealm}
         onRealmOpened={onRealmOpened}
         onValidateCertificatesChange={onValidateCertificatesChange}
         user={user}
@@ -103,11 +113,14 @@ export const ServerAdministration = (props: IServerAdministrationProps) => {
     activeTab,
     adminRealmProgress,
     isCloudTenant,
+    isCreateRealmOpen,
+    isCreatingRealm,
     isRealmOpening,
+    onCancelRealmCreation,
+    onRealmCreation,
     onReconnect,
     onTabChanged,
     serverVersion,
-    syncError,
     user,
   } = props;
 
@@ -126,6 +139,14 @@ export const ServerAdministration = (props: IServerAdministrationProps) => {
       <div className="ServerAdministration__content">
         {adminRealmProgress.status === 'done' ? renderContent(props) : null}
       </div>
+
+      <CreateRealmDialog
+        isBusy={isCreatingRealm}
+        isOpen={isCreateRealmOpen}
+        onCancelRealmCreation={onCancelRealmCreation}
+        onRealmCreation={onRealmCreation}
+      />
+
       <LoadingOverlay
         loading={!user || isRealmOpening}
         progress={adminRealmProgress}

--- a/src/ui/ServerAdministration/index.tsx
+++ b/src/ui/ServerAdministration/index.tsx
@@ -20,19 +20,22 @@ import * as electron from 'electron';
 import * as os from 'os';
 import * as React from 'react';
 import * as Realm from 'realm';
+import { URL } from 'url';
 
 import { main } from '../../actions/main';
 import { ICloudStatus } from '../../main/CloudManager';
+import { dataImporter, ros } from '../../services';
 import {
-  IAdminTokenCredentials,
-  IRealmFile,
-  isAvailable,
-  IUser,
-  IUsernamePasswordCredentials,
-  realms,
-  users,
-} from '../../services/ros';
-import { countdown, wait } from '../../utils';
+  countdown,
+  createPromiseHandle,
+  IPromiseHandle,
+  menu,
+  wait,
+} from '../../utils';
+import {
+  IMenuGenerator,
+  IMenuGeneratorProps,
+} from '../../windows/MenuGenerator';
 import { IServerAdministrationWindowProps } from '../../windows/WindowProps';
 import { showError } from '../reusable/errors';
 import {
@@ -40,7 +43,6 @@ import {
   RealmLoadingComponent,
 } from '../reusable/RealmLoadingComponent';
 
-import { ValidateCertificatesChangeHandler } from './RealmsTable';
 import { ServerAdministration, Tab } from './ServerAdministration';
 
 export interface IServerAdministrationContainerProps
@@ -53,31 +55,37 @@ export interface IServerAdministrationContainerState
   activeTab: Tab | null;
   // This will increment when the realm changes to trigger updates to the UI.
   adminRealmChanges: number;
+  isCreateRealmOpen: boolean;
+  isCreatingRealm: boolean;
   isRealmOpening: boolean;
-  user: Realm.Sync.User | null;
   serverVersion?: string;
+  user: Realm.Sync.User | null;
 }
 
-class ServerAdministrationContainer extends RealmLoadingComponent<
-  IServerAdministrationContainerProps,
-  IServerAdministrationContainerState
-> {
+class ServerAdministrationContainer
+  extends RealmLoadingComponent<
+    IServerAdministrationContainerProps & IMenuGeneratorProps,
+    IServerAdministrationContainerState
+  >
+  implements IMenuGenerator {
   public state: IServerAdministrationContainerState = {
     activeTab: null,
     adminRealmChanges: 0,
+    isCreateRealmOpen: false,
+    isCreatingRealm: false,
     isRealmOpening: false,
     progress: { status: 'idle' },
     user: null,
   };
 
   protected availabilityPromise?: Promise<string | undefined>;
+  protected createRealmPromiseHandle?: IPromiseHandle<ros.IRealmFile>;
 
   public async componentDidMount() {
     // Start listening on changes to the cloud-status
     electron.ipcRenderer.on('cloud-status', this.cloudStatusChanged);
 
     await this.authenticate();
-
     if (this.props.isCloudTenant) {
       this.setState({
         activeTab: Tab.GettingStarted,
@@ -113,7 +121,12 @@ class ServerAdministrationContainer extends RealmLoadingComponent<
         adminRealm={this.realm}
         adminRealmChanges={this.state.adminRealmChanges}
         adminRealmProgress={this.state.progress}
+        createRealm={this.createRealm}
         isCloudTenant={this.props.isCloudTenant || false}
+        isCreateRealmOpen={this.state.isCreateRealmOpen}
+        isCreatingRealm={this.state.isCreatingRealm}
+        onCancelRealmCreation={this.onCancelRealmCreation}
+        onRealmCreation={this.onRealmCreation}
         onValidateCertificatesChange={this.onValidateCertificatesChange}
         validateCertificates={this.props.validateCertificates}
       />
@@ -126,9 +139,9 @@ class ServerAdministrationContainer extends RealmLoadingComponent<
       this.setState({ isRealmOpening: true });
       try {
         // Let the UI update before sync waiting on the window to appear
-        const realm: realms.ISyncedRealmToLoad = {
+        const realm: ros.realms.ISyncedRealmToLoad = {
           authentication: this.props.credentials,
-          mode: realms.RealmLoadingMode.Synced,
+          mode: ros.realms.RealmLoadingMode.Synced,
           path,
           validateCertificates: this.props.validateCertificates,
         };
@@ -178,7 +191,7 @@ class ServerAdministrationContainer extends RealmLoadingComponent<
         },
       });
       // Authenticate towards the server
-      const user = await users.authenticate(this.props.credentials);
+      const user = await ros.users.authenticate(this.props.credentials);
       this.setState({
         progress: {
           status: 'in-progress',
@@ -215,7 +228,7 @@ class ServerAdministrationContainer extends RealmLoadingComponent<
                 message: `Checking availability`,
               },
             });
-            const availability = await isAvailable(url);
+            const availability = await ros.isAvailable(url);
             if (availability.available) {
               // Let's resolve the promise, delete it and break the endless loop
               resolve(availability.version);
@@ -261,7 +274,7 @@ class ServerAdministrationContainer extends RealmLoadingComponent<
       });
       await this.loadRealm({
         authentication: user,
-        mode: realms.RealmLoadingMode.Synced,
+        mode: ros.realms.RealmLoadingMode.Synced,
         path: '__admin',
         validateCertificates: this.props.validateCertificates,
       });
@@ -276,7 +289,7 @@ class ServerAdministrationContainer extends RealmLoadingComponent<
   }
 
   protected async loadRealm(
-    realm: realms.ISyncedRealmToLoad | realms.ILocalRealmToLoad,
+    realm: ros.realms.ISyncedRealmToLoad | ros.realms.ILocalRealmToLoad,
   ) {
     if (
       this.certificateWasRejected &&
@@ -324,6 +337,10 @@ class ServerAdministrationContainer extends RealmLoadingComponent<
     } else {
       return baseUrl;
     }
+  }
+
+  protected showImportData(format: dataImporter.ImportFormat) {
+    // Tumbleweed
   }
 
   protected onRealmChanged = () => {
@@ -388,6 +405,92 @@ class ServerAdministrationContainer extends RealmLoadingComponent<
     props.validateCertificates = validateCertificates;
     url.searchParams.set('props', JSON.stringify(props));
     location.replace(url.toString());
+  };
+
+  protected onRealmCreation = async (path: string) => {
+    try {
+      this.setState({ isCreatingRealm: true });
+      if (this.realm && this.state.user) {
+        const serverPath = this.guessServerPath(path);
+        // Check if the Realm already exists
+        const existingRealmFile = this.realm.objectForPrimaryKey(
+          'RealmFile',
+          serverPath,
+        );
+        if (existingRealmFile) {
+          throw new Error('Another Realm with this path already exists');
+        }
+        // Create a new Realm at the path specificed by the user
+        const newRealm = await ros.realms.create(this.state.user, path);
+        // Close the Realm - we don't need it open anymore
+        newRealm.close();
+        // If we are waiting for the realm to be created - hang on to the path
+        if (this.createRealmPromiseHandle) {
+          // Because we awaited creation - the admin Realm has most probably synced already
+          const newRealmFile = this.realm.objectForPrimaryKey<ros.IRealmFile>(
+            'RealmFile',
+            serverPath,
+          );
+          // If the file was available - resolve the create realm promise
+          if (newRealmFile) {
+            this.createRealmPromiseHandle.resolve(newRealmFile);
+          } else {
+            throw new Error(`Could not find Realm at '${serverPath}'`);
+          }
+        }
+      }
+    } catch (err) {
+      if (this.createRealmPromiseHandle) {
+        this.createRealmPromiseHandle.reject(err);
+      } else {
+        // Rethrow
+        throw err;
+      }
+    } finally {
+      this.setState({ isCreatingRealm: false });
+    }
+  };
+
+  protected guessServerPath(path: string): string {
+    if (path.indexOf('/') !== 0) {
+      // Prepend a slash
+      path = `/${path}`;
+    }
+    // Replace the ~ with the user id
+    if (this.state.user) {
+      path = path.replace('~', this.state.user.identity);
+    }
+    return path;
+  }
+
+  protected createRealm = () => {
+    if (this.createRealmPromiseHandle) {
+      throw new Error('You can only create one Realm at a time');
+    } else {
+      this.setState({ isCreateRealmOpen: true });
+      this.createRealmPromiseHandle = createPromiseHandle();
+      return this.createRealmPromiseHandle.promise.then(
+        realmFile => {
+          delete this.createRealmPromiseHandle;
+          this.setState({ isCreateRealmOpen: false });
+          return realmFile;
+        },
+        reason => {
+          delete this.createRealmPromiseHandle;
+          this.setState({ isCreateRealmOpen: false });
+          throw reason;
+        },
+      );
+    }
+  };
+
+  protected onCancelRealmCreation = async () => {
+    if (this.state.isCreateRealmOpen && this.createRealmPromiseHandle) {
+      const err = new Error('Realm creation cancelled');
+      this.createRealmPromiseHandle.reject(err);
+    } else {
+      this.setState({ isCreateRealmOpen: false });
+    }
   };
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,10 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-export { countdown } from './countdown';
-export { timeout } from './timeout';
-export { wait } from './wait';
-export { getRange } from './range';
+export * from './countdown';
+export * from './timeout';
+export * from './wait';
+export * from './range';
+export * from './promise-handle';
 
 import * as menu from './menu';
-export { menu as menuUtils };
+export { menu };

--- a/src/utils/promise-handle.test.ts
+++ b/src/utils/promise-handle.test.ts
@@ -29,14 +29,10 @@ describe('promise handle', () => {
     assert(handle.promise instanceof Promise);
   });
 
-  it('can resolve the promise (calling cleanup)', done => {
-    let cleanedUp = false;
-    const handle = createPromiseHandle(() => {
-      cleanedUp = true;
-    });
+  it('can resolve the promise', done => {
+    const handle = createPromiseHandle();
     handle.promise.then(result => {
       assert.equal(result, 'w00t');
-      assert.equal(cleanedUp, true);
       done();
     });
     process.nextTick(() => {
@@ -44,14 +40,10 @@ describe('promise handle', () => {
     });
   });
 
-  it('can reject the promise (calling cleanup)', done => {
-    let cleanedUp = false;
-    const handle = createPromiseHandle(() => {
-      cleanedUp = true;
-    });
+  it('can reject the promise', done => {
+    const handle = createPromiseHandle();
     handle.promise.catch(result => {
       assert.equal(result, 'w00t');
-      assert.equal(cleanedUp, true);
       done();
     });
     process.nextTick(() => {

--- a/src/utils/promise-handle.test.ts
+++ b/src/utils/promise-handle.test.ts
@@ -1,0 +1,61 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import * as assert from 'assert';
+
+import { createPromiseHandle } from './promise-handle';
+
+describe('promise handle', () => {
+  it('can create a handle', () => {
+    const handle = createPromiseHandle();
+    assert.equal(typeof handle.resolve, 'function');
+    assert.equal(typeof handle.reject, 'function');
+    assert.equal(typeof handle.promise, 'object');
+    assert(handle.promise instanceof Promise);
+  });
+
+  it('can resolve the promise (calling cleanup)', done => {
+    let cleanedUp = false;
+    const handle = createPromiseHandle(() => {
+      cleanedUp = true;
+    });
+    handle.promise.then(result => {
+      assert.equal(result, 'w00t');
+      assert.equal(cleanedUp, true);
+      done();
+    });
+    process.nextTick(() => {
+      handle.resolve('w00t');
+    });
+  });
+
+  it('can reject the promise (calling cleanup)', done => {
+    let cleanedUp = false;
+    const handle = createPromiseHandle(() => {
+      cleanedUp = true;
+    });
+    handle.promise.catch(result => {
+      assert.equal(result, 'w00t');
+      assert.equal(cleanedUp, true);
+      done();
+    });
+    process.nextTick(() => {
+      handle.reject('w00t');
+    });
+  });
+});

--- a/src/utils/promise-handle.ts
+++ b/src/utils/promise-handle.ts
@@ -1,0 +1,49 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+// This utility can be used to create a promise and externalize the resolve and reject methods to the caller
+
+export interface IPromiseHandle<T> {
+  promise: Promise<T>;
+  resolve: (result: T) => void;
+  reject: (reason: any) => void;
+}
+
+export const createPromiseHandle = <T extends any>(
+  cleanupCallback?: () => void,
+) => {
+  const handle: Partial<IPromiseHandle<T>> = {};
+  handle.promise = new Promise<T>((resolve, reject) => {
+    handle.resolve = resolve;
+    handle.reject = reject;
+  }).then(
+    (value: T) => {
+      if (cleanupCallback) {
+        cleanupCallback();
+      }
+      return value;
+    },
+    (reason: any) => {
+      if (cleanupCallback) {
+        cleanupCallback();
+      }
+      throw reason;
+    },
+  );
+  return handle as IPromiseHandle<T>;
+};

--- a/src/utils/promise-handle.ts
+++ b/src/utils/promise-handle.ts
@@ -24,26 +24,11 @@ export interface IPromiseHandle<T> {
   reject: (reason: any) => void;
 }
 
-export const createPromiseHandle = <T extends any>(
-  cleanupCallback?: () => void,
-) => {
+export const createPromiseHandle = <T extends any>() => {
   const handle: Partial<IPromiseHandle<T>> = {};
   handle.promise = new Promise<T>((resolve, reject) => {
     handle.resolve = resolve;
     handle.reject = reject;
-  }).then(
-    (value: T) => {
-      if (cleanupCallback) {
-        cleanupCallback();
-      }
-      return value;
-    },
-    (reason: any) => {
-      if (cleanupCallback) {
-        cleanupCallback();
-      }
-      throw reason;
-    },
-  );
+  });
   return handle as IPromiseHandle<T>;
 };

--- a/src/windows/CloudAuthenticationWindow.tsx
+++ b/src/windows/CloudAuthenticationWindow.tsx
@@ -17,7 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { IWindow } from './Window';
-import { ICloudAuthenticationWindowTypedProps } from './WindowTypedProps';
 
 export interface ICloudAuthenticationWindowProps {
   message?: string;

--- a/src/windows/GreetingWindow.tsx
+++ b/src/windows/GreetingWindow.tsx
@@ -17,7 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { IWindow } from './Window';
-import { IGreetingWindowTypedProps } from './WindowTypedProps';
 
 // tslint:disable-next-line:no-empty-interface
 export interface IGreetingWindowProps {

--- a/src/windows/MenuGenerator.ts
+++ b/src/windows/MenuGenerator.ts
@@ -16,9 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { MenuItem, MenuItemConstructorOptions, remote } from 'electron';
+import { MenuItemConstructorOptions, remote } from 'electron';
 
-import { main } from '../actions/main';
 import { getDefaultMenuTemplate } from '../main/MainMenu';
 
 // TODO: Throw if this is called from the main process
@@ -33,8 +32,6 @@ export interface IMenuGenerator {
 export interface IMenuGeneratorProps {
   updateMenu(): void;
 }
-
-const isProduction = process.env.NODE_ENV === 'production';
 
 export const generateMenu = (
   generator: IMenuGenerator | undefined,

--- a/src/windows/RealmBrowserWindow.tsx
+++ b/src/windows/RealmBrowserWindow.tsx
@@ -16,14 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import * as React from 'react';
 import { URL } from 'url';
 
-import * as ros from '../services/ros';
-import { RealmBrowser } from '../ui';
+import { ros } from '../services';
 
 import { IWindow } from './Window';
-import { IRealmBrowserWindowTypedProps } from './WindowTypedProps';
 
 export interface IRealmBrowserWindowProps {
   realm: ros.realms.ISyncedRealmToLoad | ros.realms.ILocalRealmToLoad;

--- a/src/windows/ServerAdministrationWindow.tsx
+++ b/src/windows/ServerAdministrationWindow.tsx
@@ -16,13 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import * as React from 'react';
-
 import * as ros from '../services/ros';
-import { ServerAdministration } from '../ui';
 
 import { IWindow } from './Window';
-import { IServerAdministrationWindowTypedProps } from './WindowTypedProps';
 
 export interface IServerAdministrationWindowProps {
   credentials: ros.IServerCredentials;

--- a/src/windows/TutorialWindow.tsx
+++ b/src/windows/TutorialWindow.tsx
@@ -16,12 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import * as React from 'react';
-
 import * as tutorials from '../services/tutorials';
 
 import { IWindow } from './Window';
-import { ITutorialWindowTypedProps } from './WindowTypedProps';
 
 export interface ITutorialWindowProps {
   id: string;

--- a/src/windows/Window.tsx
+++ b/src/windows/Window.tsx
@@ -20,11 +20,6 @@ import { IMenuGeneratorProps } from './MenuGenerator';
 import { WindowProps } from './WindowProps';
 import { WindowType, WindowTypedProps } from './WindowTypedProps';
 
-interface ITrackedProperties {
-  type: WindowType;
-  [name: string]: string;
-}
-
 export interface IWindow {
   getComponent(): React.ComponentClass<WindowTypedProps & IMenuGeneratorProps>;
   getWindowOptions(

--- a/src/windows/WindowComponent.tsx
+++ b/src/windows/WindowComponent.tsx
@@ -32,7 +32,6 @@ import {
   IMenuGeneratorProps,
 } from './MenuGenerator';
 import { getWindowClass } from './Window';
-import { WindowProps } from './WindowProps';
 import { WindowType, WindowTypedProps } from './WindowTypedProps';
 
 // TODO: Consider if we can have the window not show before a connection has been established.
@@ -40,10 +39,6 @@ import { WindowType, WindowTypedProps } from './WindowTypedProps';
 interface ITrackedProperties {
   type: WindowType;
   [name: string]: string;
-}
-
-interface IWindowComponentProps {
-  children: React.ReactChild;
 }
 
 const getCurrentWindowProps = (): WindowTypedProps => {
@@ -65,7 +60,7 @@ export abstract class WindowComponent extends React.Component
   protected CurrentWindowComponent = this.CurrentWindow.getComponent();
 
   public componentDidMount() {
-    const trackedProperties = {
+    const trackedProperties: ITrackedProperties = {
       ...this.CurrentWindow.getTrackedProperties(this.windowProps),
       type: this.windowProps.type,
     };

--- a/src/windows/WindowTypedProps.ts
+++ b/src/windows/WindowTypedProps.ts
@@ -16,8 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { IMenuGeneratorProps } from './MenuGenerator';
-
 import {
   ICloudAuthenticationWindowProps,
   IConnectToServerWindowProps,


### PR DESCRIPTION
This improves CSV importing in a couple of ways:
- Users can now import CSV into a server when selecting "Create Realm from > CSV" from the "Server Administration" window. And when importing locally the user will be asked for a destination file (which fixes #685 and #536).
- Showing an error when CSV importing fails (which fixes #534).