### PR TITLE
Fix margin missing from checkbox

### DIFF
--- a/src/ui/ConnectToServer/ConnectToServer.scss
+++ b/src/ui/ConnectToServer/ConnectToServer.scss
@@ -97,6 +97,7 @@
   &__SaveCredentials {
     flex-grow: 1;
     font-size: .8rem;
+    padding-left: $spacer * 1.3;
   }
 
   &__SaveCredentials,


### PR DESCRIPTION
Fixes #817 

![image](https://user-images.githubusercontent.com/406066/41229068-ea8185c8-6d7a-11e8-82b2-1383add20820.png)

The fix is a bit hackish, but the URL field also have a hover effect which is taken into account when placed on the screen. Something the checkbox do not, so to align them when both have no focus the padding for the checkbox needs to be offset a little.