### PR TITLE
Only errors that are known to be non-fatal should be suppressed

### DIFF
--- a/src/ui/ServerAdministration/index.tsx
+++ b/src/ui/ServerAdministration/index.tsx
@@ -423,7 +423,10 @@ class ServerAdministrationContainer
           },
         },
       });
-    } else if (error.isFatal) {
+    } else if (error.isFatal === false) {
+      /* tslint:disable-next-line:no-console */
+      console.warn(`A non-fatal sync error happened: ${error.message}`, error);
+    } else {
       this.setState({
         progress: {
           status: 'failed',
@@ -434,9 +437,6 @@ class ServerAdministrationContainer
           },
         },
       });
-    } else {
-      /* tslint:disable-next-line:no-console */
-      console.warn(`A non-fatal sync error happened: ${error.message}`, error);
     }
   };
 

--- a/src/ui/reusable/RealmLoadingComponent/index.tsx
+++ b/src/ui/reusable/RealmLoadingComponent/index.tsx
@@ -163,16 +163,16 @@ export abstract class RealmLoadingComponent<
   ) => {
     if (error.message === 'SSL server certificate rejected') {
       this.certificateWasRejected = true;
-    } else if (error.isFatal) {
+    } else if (error.isFatal === false) {
+      /* tslint:disable-next-line:no-console */
+      console.warn(`A non-fatal sync error happened: ${error.message}`, error);
+    } else {
       this.setState({
         progress: {
           message: error.message,
           status: 'failed',
         },
       });
-    } else {
-      /* tslint:disable-next-line:no-console */
-      console.warn(`A non-fatal sync error happened: ${error.message}`, error);
     }
   };
 


### PR DESCRIPTION
This will ensure that errors that does not have the `isFatal` field is shown to the user when opening the realm browser or server administration window.

This (somewhat) fixes https://github.com/realm/realm-studio/issues/835:

<img width="1136" alt="skaermbillede 2018-06-14 kl 19 58 57" src="https://user-images.githubusercontent.com/1243959/41430147-878c01ea-700f-11e8-8b78-73e6790afe02.png">
