### PR TITLE
Sentry fallback to production

### DIFF
--- a/src/sentry.js
+++ b/src/sentry.js
@@ -1,7 +1,7 @@
 // Initialize the Sentry for early error catching
 // This is external to the bundle and will be copied by WebPack to catch any errors that may happen early
 
-const isProduction = process.env.NODE_ENV === 'production';
+const isProduction = process.env.NODE_ENV !== 'development';
 
 const Sentry = require('@sentry/electron');
 Sentry.init({


### PR DESCRIPTION
We were determining the environment based on the existence of a `NODE_ENV` variable - this falls back to `"production"` if its not available.