### PR TITLE
Clean up only when opening the initial Realm Cloud application

### DIFF
--- a/src/main/Application.ts
+++ b/src/main/Application.ts
@@ -124,6 +124,8 @@ export class Application {
       // Quit the app if started multiple times
       electron.app.quit();
     } else {
+      // Clean up from any renderer processes
+      this.windowManager.cleanupRendererProcessDirectories();
       // Register as a listener for specific URLs
       this.registerProtocols();
       // In Mac we detect the files opened with `open-file` event otherwise we need get it from `process.argv`

--- a/src/main/WindowManager.ts
+++ b/src/main/WindowManager.ts
@@ -54,11 +54,6 @@ function getRendererHtmlPath() {
 export class WindowManager {
   public windows: IWindowHandle[] = [];
 
-  public constructor() {
-    // Call this to cleanup abandoned renderer process directories
-    this.cleanupRendererProcessDirectories();
-  }
-
   public createWindow(props: WindowTypedProps) {
     const windowOptions = getWindowOptions(props);
     sentry.addBreadcrumb({
@@ -179,6 +174,17 @@ export class WindowManager {
     });
   }
 
+  /** This will clean up any existing renderer directories */
+  public cleanupRendererProcessDirectories() {
+    const rendererPaths = getRendererProcessDirectories();
+    for (const rendererPath of rendererPaths) {
+      // Deleting these folders are not obvious side-effects, so let's log that
+      // tslint:disable-next-line:no-console
+      console.log(`Removing abandoned renderer directory ${rendererPath}`);
+      fs.removeSync(rendererPath);
+    }
+  }
+
   private cleanupRendererProcessDirectory(rendererPath: string) {
     try {
       fs.removeSync(rendererPath);
@@ -189,17 +195,6 @@ export class WindowManager {
         `Failed while cleaning up renderer directory ${rendererPath}`,
         err,
       );
-    }
-  }
-
-  /** This will clean up any existing renderer directories */
-  private cleanupRendererProcessDirectories() {
-    const rendererPaths = getRendererProcessDirectories();
-    for (const rendererPath of rendererPaths) {
-      // Deleting these folders are not obvious side-effects, so let's log that
-      // tslint:disable-next-line:no-console
-      console.log(`Removing abandoned renderer directory ${rendererPath}`);
-      fs.removeSync(rendererPath);
     }
   }
 


### PR DESCRIPTION
A followup to #847 - if Realm Studio is opened for the second time, it shouldn't attempt to clean up the existing instances renderer directories.