### PR TITLE
Showing realm state size in the RealmsTabel and RealmSidebar

### DIFF
--- a/src/services/ros/realms.ts
+++ b/src/services/ros/realms.ts
@@ -18,7 +18,12 @@
 
 import * as Realm from 'realm';
 
-import { IRealmFile, IServerCredentials, RealmType } from '.';
+import {
+  fetchAuthenticated,
+  IRealmFile,
+  IServerCredentials,
+  RealmType,
+} from '.';
 import { showError } from '../../ui/reusable/errors';
 
 export enum RealmLoadingMode {
@@ -111,26 +116,13 @@ export const create = (
 };
 
 export const remove = async (user: Realm.Sync.User, realmPath: string) => {
-  const server = user.server;
-  const encodedUrl = encodeURIComponent(realmPath);
-  const url = new URL(`/realms/files/${encodedUrl}`, server);
-  const request = new Request(url.toString(), {
-    method: 'DELETE',
-    headers: new Headers({
-      Authorization: user.token,
-      Accept: 'application/json, text/plain, */*',
-      'Content-Type': 'application/json',
-    }),
-  });
-  const response = await fetch(request);
-  const body = await response.json();
-  if (response.ok) {
-    return body;
-  } else if (body && body.message) {
-    throw new Error(`Could not remove Realm: ${body.message}`);
-  } else {
-    throw new Error(`Could not remove Realm`);
-  }
+  const encodedPath = encodeURIComponent(realmPath);
+  return fetchAuthenticated(
+    user,
+    `/realms/files/${encodedPath}`,
+    { method: 'DELETE' },
+    `Could not remove Realm`,
+  );
 };
 
 export const changeType = async (
@@ -138,32 +130,18 @@ export const changeType = async (
   realmPath: string,
   type: RealmType,
 ) => {
-  const server = user.server;
-  const encodedUrl = encodeURIComponent(realmPath);
-  const url = new URL(`/realms/files/${encodedUrl}`, server);
-  const request = new Request(url.toString(), {
-    method: 'PATCH',
-    headers: new Headers({
-      Authorization: user.token,
-      Accept: 'application/json, text/plain, */*',
-      'Content-Type': 'application/json',
-    }),
-    body: JSON.stringify({
-      realmType: type,
-    }),
-  });
-  const response = await fetch(request);
-  if (response.ok) {
-    return response.json();
-  } else {
-    if (response.status === 404) {
-      throw new Error(
-        'Failed to change the type of the Realm: Is the server running the latest version?',
-      );
-    } else {
-      throw new Error('Failed to change type of the Realm');
-    }
-  }
+  const encodedPath = encodeURIComponent(realmPath);
+  return fetchAuthenticated(
+    user,
+    `/realms/files/${encodedPath}`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify({
+        realmType: type,
+      }),
+    },
+    'Failed to change type of the Realm',
+  );
 };
 
 export const update = (realmId: string, values: Partial<IRealmFile>) => {
@@ -181,56 +159,24 @@ export const getStats = async (
   user: Realm.Sync.User,
   metricNames: string,
 ): Promise<IStatisticsResponse> => {
-  const server = user.server;
-  const url = new URL(`/stats/${metricNames}`, server);
-  const request = new Request(url.toString(), {
-    method: 'GET',
-    headers: new Headers({
-      Authorization: user.token,
-      Accept: 'application/json, text/plain, */*',
-      'Content-Type': 'application/json',
-    }),
-  });
-  const response = await fetch(request);
-  if (response.ok) {
-    return response.json();
-  } else {
-    if (response.status === 404) {
-      throw new Error(
-        'Failed to get statistics: Is the server running the latest version?',
-      );
-    } else {
-      throw new Error('Failed to get statistics');
-    }
-  }
+  return fetchAuthenticated(
+    user,
+    `/stats/${metricNames}`,
+    { method: 'GET' },
+    'Failed to get statistics',
+  );
 };
 
 export const reportRealmStateSize = async (
   user: Realm.Sync.User,
   path: string = '',
 ) => {
-  const server = user.server;
-  const url = new URL(`/stats/report-realm-state-size/${path}`, server);
-  const request = new Request(url.toString(), {
-    method: 'POST',
-    headers: new Headers({
-      Authorization: user.token,
-      Accept: 'application/json, text/plain, */*',
-      'Content-Type': 'application/json',
-    }),
-  });
-  const response = await fetch(request);
-  if (response.ok) {
-    return response.json();
-  } else {
-    if (response.status === 404) {
-      throw new Error(
-        'Failed to report realm state size: Is the server running the latest version?',
-      );
-    } else {
-      throw new Error('Failed to report realm state size');
-    }
-  }
+  return fetchAuthenticated(
+    user,
+    `/stats/report-realm-state-size/${path}`,
+    { method: 'POST' },
+    'Failed to report realm state size',
+  );
 };
 
 export const getSizes = async (user: Realm.Sync.User) => {

--- a/src/services/ros/realms.ts
+++ b/src/services/ros/realms.ts
@@ -161,7 +161,7 @@ export const getStats = async (
 ): Promise<IStatisticsResponse> => {
   return fetchAuthenticated(
     user,
-    `/stats/${metricNames}`,
+    `/stats/instant/${metricNames}`,
     { method: 'GET' },
     'Failed to get statistics',
   );

--- a/src/ui/ServerAdministration/RealmsTable/MissingSizeBadge.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/MissingSizeBadge.tsx
@@ -16,13 +16,13 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-export * from './countdown';
-export * from './timeout';
-export * from './wait';
-export * from './range';
-export * from './promise-handle';
-export * from './renderer-process-directory';
-export * from './pretty-bytes';
+import * as React from 'react';
+import { Badge } from 'reactstrap';
 
-import * as menu from './menu';
-export { menu };
+import { LoadingDots } from '../../reusable/LoadingDots';
+
+export const MissingSizeBadge = () => (
+  <Badge title="Size is being calculated">
+    <LoadingDots />
+  </Badge>
+);

--- a/src/ui/ServerAdministration/RealmsTable/RealmSidebar/RealmSidebar.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmSidebar/RealmSidebar.tsx
@@ -28,6 +28,7 @@ import './RealmSidebar.scss';
 
 export const RealmSidebar = ({
   getRealmPermissions,
+  getRealmStateSize,
   isOpen,
   onRealmDeletion,
   onRealmOpened,
@@ -36,6 +37,7 @@ export const RealmSidebar = ({
   realm,
 }: {
   getRealmPermissions: (path: string) => Realm.Results<ros.IPermission>;
+  getRealmStateSize: (path: string) => number | undefined;
   isOpen: boolean;
   onRealmDeletion: (path: string) => void;
   onRealmOpened: (path: string) => void;
@@ -52,11 +54,12 @@ export const RealmSidebar = ({
       {currentRealm &&
         currentRealm.isValid() && (
           <RealmSidebarCard
-            getRealmPermissions={getRealmPermissions}
             onRealmDeletion={onRealmDeletion}
             onRealmOpened={onRealmOpened}
             onRealmTypeUpgrade={onRealmTypeUpgrade}
+            permissions={getRealmPermissions(currentRealm.path)}
             realm={currentRealm}
+            stateSize={getRealmStateSize(currentRealm.path)}
           />
         )}
     </Sidebar>

--- a/src/ui/ServerAdministration/RealmsTable/RealmSidebar/RealmSidebarCard.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmSidebar/RealmSidebarCard.tsx
@@ -21,25 +21,26 @@ import { Button, Card, CardBody, CardText, CardTitle } from 'reactstrap';
 import * as Realm from 'realm';
 
 import * as ros from '../../../../services/ros';
-import { displayUser, shortenRealmPath } from '../../utils';
+import { displayUser, prettyBytes, shortenRealmPath } from '../../utils';
 import { RealmTypeBadge } from '../RealmTypeBadge';
 
 import { PermissionsTable } from './PermissionsTable';
 
 export const RealmSidebarCard = ({
-  getRealmPermissions,
   onRealmDeletion,
   onRealmOpened,
   onRealmTypeUpgrade,
+  permissions,
   realm,
+  stateSize,
 }: {
-  getRealmPermissions: (path: string) => Realm.Results<ros.IPermission>;
   onRealmDeletion: (path: string) => void;
   onRealmOpened: (path: string) => void;
   onRealmTypeUpgrade: (path: string) => void;
   realm: ros.IRealmFile;
+  permissions: Realm.Results<ros.IPermission>;
+  stateSize?: number;
 }) => {
-  const permissions = realm ? getRealmPermissions(realm.path) : null;
   // Determine if the Realm can be upgraded to a "reference" Realm,
   // It can if its defined and not already "partial" or "reference"
   const canUpgradeType = realm
@@ -58,8 +59,11 @@ export const RealmSidebarCard = ({
           </span>
         </CardTitle>
         <CardText className="RealmSidebar__SubTitle">
-          Owned by {displayUser(realm.owner)}
+          Owned by: {displayUser(realm.owner)}
         </CardText>
+        {typeof stateSize === 'number' ? (
+          <CardText>Size of state: {prettyBytes(stateSize)}</CardText>
+        ) : null}
       </CardBody>
       <CardBody className="RealmSidebar__Tables">
         {permissions ? <PermissionsTable permissions={permissions} /> : null}

--- a/src/ui/ServerAdministration/RealmsTable/RealmSidebar/RealmSidebarCard.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmSidebar/RealmSidebarCard.tsx
@@ -59,10 +59,12 @@ export const RealmSidebarCard = ({
           </span>
         </CardTitle>
         <CardText className="RealmSidebar__SubTitle">
-          Owned by: {displayUser(realm.owner)}
+          Owned by {displayUser(realm.owner)}
         </CardText>
         {typeof stateSize === 'number' ? (
-          <CardText>Size of state: {prettyBytes(stateSize)}</CardText>
+          <CardText className="RealmSidebar__SubTitle">
+            Data size: {prettyBytes(stateSize)}
+          </CardText>
         ) : null}
       </CardBody>
       <CardBody className="RealmSidebar__Tables">

--- a/src/ui/ServerAdministration/RealmsTable/RealmSidebar/index.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmSidebar/index.tsx
@@ -24,6 +24,7 @@ import * as ros from '../../../../services/ros';
 
 export interface IRealmSidebarContainerProps {
   getRealmPermissions: (path: string) => Realm.Results<ros.IPermission>;
+  getRealmStateSize: (path: string) => number | undefined;
   isOpen: boolean;
   onRealmDeletion: (path: string) => void;
   onRealmOpened: (path: string) => void;

--- a/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
@@ -30,35 +30,40 @@ import { displayUser, prettyBytes } from '../utils';
 
 import { MissingSizeBadge } from './MissingSizeBadge';
 import { RealmSidebar } from './RealmSidebar';
+import { StateSizeHeader } from './StateSizeHeader';
 
 export const RealmsTable = ({
   getRealmFromId,
   getRealmPermissions,
   getRealmStateSize,
+  isFetchRealmSizes,
+  onRealmCreation,
   onRealmDeletion,
   onRealmOpened,
   onRealmSelected,
+  onRealmStateSizeRefresh,
   onRealmTypeUpgrade,
+  onSearchStringChange,
   realms,
   realmStateSizes,
-  selectedRealmPath,
-  onRealmCreation,
   searchString,
-  onSearchStringChange,
+  selectedRealmPath,
 }: {
   getRealmFromId: (path: string) => IRealmFile | undefined;
   getRealmPermissions: (path: string) => Realm.Results<IPermission>;
   getRealmStateSize: (path: string) => number | undefined;
+  isFetchRealmSizes: boolean;
+  onRealmCreation: () => void;
   onRealmDeletion: (path: string) => void;
   onRealmOpened: (path: string) => void;
   onRealmSelected: (path: string | null) => void;
+  onRealmStateSizeRefresh: () => void;
   onRealmTypeUpgrade: (path: string) => void;
+  onSearchStringChange: (query: string) => void;
   realms: Realm.Results<IRealmFile>;
   realmStateSizes?: { [path: string]: number };
-  selectedRealmPath: string | null;
-  onRealmCreation: () => void;
   searchString: string;
-  onSearchStringChange: (query: string) => void;
+  selectedRealmPath: string | null;
 }) => {
   return (
     <FilterableTableWrapper>
@@ -90,6 +95,13 @@ export const RealmsTable = ({
           dataKey="path"
           /* Don't show the size column if all sizes are unknown */
           width={realmStateSizes ? 100 : 0}
+          headerRenderer={props => (
+            <StateSizeHeader
+              {...props}
+              isRefreshing={isFetchRealmSizes}
+              onRefresh={onRealmStateSizeRefresh}
+            />
+          )}
           cellRenderer={({ cellData }) =>
             realmStateSizes && typeof realmStateSizes[cellData] === 'number' ? (
               prettyBytes(realmStateSizes[cellData])

--- a/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
@@ -76,17 +76,17 @@ export const RealmsTable = ({
         <Column
           label="Owner"
           dataKey="owner"
-          width={300}
+          width={200}
           cellRenderer={({ cellData }) => displayUser(cellData)}
         />
         <Column
           label="Type"
           dataKey="realmType"
-          width={200}
+          width={100}
           cellRenderer={({ cellData }) => cellData || 'full'}
         />
         <Column
-          label="State Size"
+          label="Data Size"
           dataKey="path"
           /* Don't show the size column if all sizes are unknown */
           width={realmStateSizes ? 100 : 0}

--- a/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
@@ -26,17 +26,21 @@ import {
   FilterableTableWrapper,
 } from '../shared/FilterableTable';
 import { FloatingControls } from '../shared/FloatingControls';
-import { displayUser } from '../utils';
+import { displayUser, prettyBytes } from '../utils';
+
+import { MissingSizeBadge } from './MissingSizeBadge';
 import { RealmSidebar } from './RealmSidebar';
 
 export const RealmsTable = ({
   getRealmFromId,
   getRealmPermissions,
+  getRealmStateSize,
   onRealmDeletion,
   onRealmOpened,
   onRealmSelected,
   onRealmTypeUpgrade,
   realms,
+  realmStateSizes,
   selectedRealmPath,
   onRealmCreation,
   searchString,
@@ -44,11 +48,13 @@ export const RealmsTable = ({
 }: {
   getRealmFromId: (path: string) => IRealmFile | undefined;
   getRealmPermissions: (path: string) => Realm.Results<IPermission>;
+  getRealmStateSize: (path: string) => number | undefined;
   onRealmDeletion: (path: string) => void;
   onRealmOpened: (path: string) => void;
   onRealmSelected: (path: string | null) => void;
   onRealmTypeUpgrade: (path: string) => void;
   realms: Realm.Results<IRealmFile>;
+  realmStateSizes?: { [path: string]: number };
   selectedRealmPath: string | null;
   onRealmCreation: () => void;
   searchString: string;
@@ -79,6 +85,19 @@ export const RealmsTable = ({
           width={200}
           cellRenderer={({ cellData }) => cellData || 'full'}
         />
+        <Column
+          label="State Size"
+          dataKey="path"
+          /* Don't show the size column if all sizes are unknown */
+          width={realmStateSizes ? 100 : 0}
+          cellRenderer={({ cellData }) =>
+            realmStateSizes && typeof realmStateSizes[cellData] === 'number' ? (
+              prettyBytes(realmStateSizes[cellData])
+            ) : (
+              <MissingSizeBadge />
+            )
+          }
+        />
       </FilterableTable>
 
       <FloatingControls isOpen={selectedRealmPath === null}>
@@ -87,6 +106,7 @@ export const RealmsTable = ({
 
       <RealmSidebar
         getRealmPermissions={getRealmPermissions}
+        getRealmStateSize={getRealmStateSize}
         isOpen={selectedRealmPath !== null}
         onRealmDeletion={onRealmDeletion}
         onRealmOpened={onRealmOpened}

--- a/src/ui/ServerAdministration/RealmsTable/StateSizeHeader/RefreshIcon.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/StateSizeHeader/RefreshIcon.tsx
@@ -16,21 +16,29 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-@import "~realm-studio-styles/variables";
+import * as classNames from 'classnames';
+import * as React from 'react';
 
-.StateSizeHeader {
-  &__RefreshIcon {
-    cursor: pointer;
-    padding: 0 ($spacer / 2);
-
-    &--refreshing {
-      color: $elephant;
-      cursor: progress;
-    }
-  }
-
-  &__QuestionIcon {
-    cursor: pointer;
-    padding: 0 ($spacer / 2);
-  }
+interface IRefreshIconProps {
+  isRefreshing: boolean;
+  onRefresh: () => void;
 }
+
+const showInternalFeatures =
+  process.env.REALM_STUDIO_INTERNAL_FEATURES === 'true';
+
+export const RefreshIcon = ({ isRefreshing, onRefresh }: IRefreshIconProps) =>
+  showInternalFeatures ? (
+    <i
+      className={classNames(
+        'StateSizeHeader__RefreshIcon',
+        'fa',
+        'fa-refresh',
+        {
+          'StateSizeHeader__RefreshIcon--refreshing': isRefreshing,
+          'fa-spin': isRefreshing,
+        },
+      )}
+      onClick={onRefresh}
+    />
+  ) : null;

--- a/src/ui/ServerAdministration/RealmsTable/StateSizeHeader/StateSizeHeader.scss
+++ b/src/ui/ServerAdministration/RealmsTable/StateSizeHeader/StateSizeHeader.scss
@@ -16,9 +16,16 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import * as React from 'react';
-import { Badge } from 'reactstrap';
+@import "~realm-studio-styles/variables";
 
-export const MissingSizeBadge = () => (
-  <Badge title="Size is unknown. Refresh to update it.">?</Badge>
-);
+.StateSizeHeader {
+  &__RefreshIcon {
+    cursor: pointer;
+    padding: 0 ($spacer / 2);
+
+    &--refreshing {
+      color: $elephant;
+      cursor: progress;
+    }
+  }
+}

--- a/src/ui/ServerAdministration/RealmsTable/StateSizeHeader/StateSizeHeader.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/StateSizeHeader/StateSizeHeader.tsx
@@ -1,0 +1,67 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import * as React from 'react';
+import { Popover, PopoverBody } from 'reactstrap';
+
+import { RefreshIcon } from './RefreshIcon';
+
+import './StateSizeHeader.scss';
+
+// @see https://github.com/bvaughn/react-virtualized/blob/9.18.5/source/Table/defaultHeaderRenderer.js
+
+interface IStateSizeHeaderProps {
+  isPopoverOpen: boolean;
+  isRefreshing: boolean;
+  label: string;
+  labelElement?: HTMLElement;
+  onLabelRef: (labelElement: HTMLElement) => void;
+  onRefresh: () => void;
+  onTogglePopover: () => void;
+}
+
+export const StateSizeHeader = ({
+  isPopoverOpen,
+  isRefreshing,
+  label,
+  labelElement,
+  onLabelRef,
+  onRefresh,
+  onTogglePopover,
+}: IStateSizeHeaderProps) => (
+  <div className="ReactVirtualized__Table__headerTruncatedText">
+    <span ref={onLabelRef}>{label}</span>
+    <i
+      className="StateSizeHeader__QuestionIcon fa fa-question"
+      onClick={onTogglePopover}
+    />
+    {labelElement ? (
+      <Popover
+        isOpen={isPopoverOpen}
+        target={labelElement}
+        toggle={onTogglePopover}
+        placement="bottom"
+      >
+        <PopoverBody>
+          Recomputed every 30 minutes
+          <RefreshIcon onRefresh={onRefresh} isRefreshing={isRefreshing} />
+        </PopoverBody>
+      </Popover>
+    ) : null}
+  </div>
+);

--- a/src/ui/ServerAdministration/RealmsTable/StateSizeHeader/index.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/StateSizeHeader/index.tsx
@@ -24,11 +24,7 @@ import { StateSizeHeader } from './StateSizeHeader';
 // @see https://github.com/bvaughn/react-virtualized/blob/9.18.5/source/Table/defaultHeaderRenderer.js
 
 interface IStateSizeHeaderContainerProps extends TableHeaderProps {
-  isPopoverOpen: boolean;
   isRefreshing: boolean;
-  labelElement: HTMLElement;
-  onLabelRef: (labelElement: HTMLElement) => void;
-  onOpenPopover: () => void;
   onRefresh: () => void;
 }
 

--- a/src/ui/ServerAdministration/RealmsTable/StateSizeHeader/index.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/StateSizeHeader/index.tsx
@@ -16,37 +16,56 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import * as classNames from 'classnames';
 import * as React from 'react';
 import { TableHeaderProps } from 'react-virtualized';
 
-import './StateSizeHeader.scss';
+import { StateSizeHeader } from './StateSizeHeader';
 
 // @see https://github.com/bvaughn/react-virtualized/blob/9.18.5/source/Table/defaultHeaderRenderer.js
 
-interface IStateSizeHeaderProps extends TableHeaderProps {
-  onRefresh: () => void;
+interface IStateSizeHeaderContainerProps extends TableHeaderProps {
+  isPopoverOpen: boolean;
   isRefreshing: boolean;
+  labelElement: HTMLElement;
+  onLabelRef: (labelElement: HTMLElement) => void;
+  onOpenPopover: () => void;
+  onRefresh: () => void;
 }
 
-export const StateSizeHeader = ({
-  label,
-  isRefreshing,
-  onRefresh,
-}: IStateSizeHeaderProps) => (
-  <span className="ReactVirtualized__Table__headerTruncatedText">
-    {label}
-    <i
-      className={classNames(
-        'StateSizeHeader__RefreshIcon',
-        'fa',
-        'fa-refresh',
-        {
-          'StateSizeHeader__RefreshIcon--refreshing': isRefreshing,
-          'fa-spin': isRefreshing,
-        },
-      )}
-      onClick={onRefresh}
-    />
-  </span>
-);
+interface IStateSizeHeaderContainerState {
+  isPopoverOpen: boolean;
+  labelElement?: HTMLElement;
+}
+
+class StateSizeHeaderContainer extends React.Component<
+  IStateSizeHeaderContainerProps,
+  IStateSizeHeaderContainerState
+> {
+  public state: IStateSizeHeaderContainerState = {
+    isPopoverOpen: false,
+  };
+
+  public render() {
+    return (
+      <StateSizeHeader
+        isPopoverOpen={this.state.isPopoverOpen}
+        isRefreshing={this.props.isRefreshing}
+        label={this.props.label || '?'}
+        labelElement={this.state.labelElement}
+        onLabelRef={this.onLabelRef}
+        onTogglePopover={this.onTogglePopover}
+        onRefresh={this.props.onRefresh}
+      />
+    );
+  }
+
+  protected onLabelRef = (labelElement: HTMLElement) => {
+    this.setState({ labelElement });
+  };
+
+  protected onTogglePopover = () => {
+    this.setState({ isPopoverOpen: !this.state.isPopoverOpen });
+  };
+}
+
+export { StateSizeHeaderContainer as StateSizeHeader };

--- a/src/ui/ServerAdministration/RealmsTable/StateSizeHeader/index.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/StateSizeHeader/index.tsx
@@ -1,0 +1,52 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import * as classNames from 'classnames';
+import * as React from 'react';
+import { TableHeaderProps } from 'react-virtualized';
+
+import './StateSizeHeader.scss';
+
+// @see https://github.com/bvaughn/react-virtualized/blob/9.18.5/source/Table/defaultHeaderRenderer.js
+
+interface IStateSizeHeaderProps extends TableHeaderProps {
+  onRefresh: () => void;
+  isRefreshing: boolean;
+}
+
+export const StateSizeHeader = ({
+  label,
+  isRefreshing,
+  onRefresh,
+}: IStateSizeHeaderProps) => (
+  <span className="ReactVirtualized__Table__headerTruncatedText">
+    {label}
+    <i
+      className={classNames(
+        'StateSizeHeader__RefreshIcon',
+        'fa',
+        'fa-refresh',
+        {
+          'StateSizeHeader__RefreshIcon--refreshing': isRefreshing,
+          'fa-spin': isRefreshing,
+        },
+      )}
+      onClick={onRefresh}
+    />
+  </span>
+);

--- a/src/ui/ServerAdministration/RealmsTable/index.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/index.tsx
@@ -69,7 +69,9 @@ class RealmsTableContainer extends React.PureComponent<
       showPartialRealms: boolean,
       showSystemRealms: boolean,
     ) => {
-      let realms = adminRealm.objects<ros.IRealmFile>('RealmFile');
+      let realms = adminRealm
+        .objects<ros.IRealmFile>('RealmFile')
+        .sorted('createdAt');
 
       // Filter if a search string is specified
       if (searchString || searchString !== '') {

--- a/src/ui/ServerAdministration/ServerAdministration.tsx
+++ b/src/ui/ServerAdministration/ServerAdministration.tsx
@@ -73,6 +73,7 @@ const renderContent = ({
   onValidateCertificatesChange,
   user,
   validateCertificates,
+  serverVersion,
 }: IServerAdministrationProps) => {
   if (user && activeTab === Tab.GettingStarted) {
     return <GettingStarted serverUrl={user.server} />;
@@ -88,6 +89,7 @@ const renderContent = ({
         onValidateCertificatesChange={onValidateCertificatesChange}
         user={user}
         validateCertificates={validateCertificates}
+        serverVersion={serverVersion}
       />
     );
   } else if (user && adminRealm && activeTab === Tab.Users) {

--- a/src/ui/ServerAdministration/shared/FilterableTable/index.tsx
+++ b/src/ui/ServerAdministration/shared/FilterableTable/index.tsx
@@ -20,6 +20,7 @@ import * as classnames from 'classnames';
 import * as React from 'react';
 import {
   AutoSizer,
+  ColumnProps,
   Dimensions as IAutoSizerDimensions,
   Table,
 } from 'react-virtualized';
@@ -33,7 +34,7 @@ export const FilterableTableWrapper = ({
 }) => <div className="Table">{children}</div>;
 
 export interface IProps {
-  children: JSX.Element[];
+  children: Array<React.ReactElement<ColumnProps>>;
   elementIdProperty: string;
   elements: Realm.Results<any>;
   onElementDoubleClick?: (elementIdSelected: string) => void;

--- a/src/ui/ServerAdministration/shared/Sidebar/Sidebar.scss
+++ b/src/ui/ServerAdministration/shared/Sidebar/Sidebar.scss
@@ -74,6 +74,7 @@
     border-radius: $border-radius-lg;
     bottom: 1rem;
     color: $elephant;
+    cursor: pointer;
     display: flex;
     font-size: 1.5rem;
     height: $close-toggle-size;

--- a/src/ui/ServerAdministration/utils.tsx
+++ b/src/ui/ServerAdministration/utils.tsx
@@ -19,6 +19,8 @@
 import * as React from 'react';
 import * as ros from '../../services/ros';
 
+export { prettyBytes } from '../../utils';
+
 export const displayUser = (
   user: ros.IUser | null,
   fallback: string = 'nobody',

--- a/src/ui/ServerAdministration/utils.tsx
+++ b/src/ui/ServerAdministration/utils.tsx
@@ -19,7 +19,7 @@
 import * as React from 'react';
 import * as ros from '../../services/ros';
 
-export { prettyBytes } from '../../utils';
+export { wait, prettyBytes } from '../../utils';
 
 export const displayUser = (
   user: ros.IUser | null,

--- a/src/utils/pretty-bytes.ts
+++ b/src/utils/pretty-bytes.ts
@@ -16,13 +16,30 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-export * from './countdown';
-export * from './timeout';
-export * from './wait';
-export * from './range';
-export * from './promise-handle';
-export * from './renderer-process-directory';
-export * from './pretty-bytes';
+// Copied here from https://www.npmjs.com/package/pretty-bytes because that lib was not pre-transpiled
+const UNITS = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
-import * as menu from './menu';
-export { menu };
+export const prettyBytes = (num: number) => {
+  if (!Number.isFinite(num)) {
+    throw new TypeError(`Expected a finite number, got ${typeof num}: ${num}`);
+  }
+
+  const neg = num < 0;
+
+  if (neg) {
+    num = -num;
+  }
+
+  if (num < 1) {
+    return (neg ? '-' : '') + num + ' B';
+  }
+
+  const exponent = Math.min(
+    Math.floor(Math.log(num) / Math.log(1000)),
+    UNITS.length - 1,
+  );
+  const numStr = Number((num / Math.pow(1000, exponent)).toPrecision(3));
+  const unit = UNITS[exponent];
+
+  return (neg ? '-' : '') + numStr + ' ' + unit;
+};


### PR DESCRIPTION
This fixes #812 and https://github.com/realm/realm-studio-private/issues/2.

It can be tested with ROS running from https://github.com/realm/realm-object-server-private/pull/1113.

Whenever the Realms tab is loaded Studio asks the server to report the state size of all realms on the server. After that it requests the latest state size stats known by the server (these may not be fully up-to-date). These state sizes are used when showing the list of Realms. If the size of a Realm is has not been reported (yet) the loading dots will show in the table.

Here's a (rather long) gif showing the UI when new Realms are added to the server.

![realm-sizes-optimized-500](https://user-images.githubusercontent.com/1243959/42587441-0636fcbc-853b-11e8-9d44-51c51abacf57.gif)

Generating the sizes of 1000 very small Realms takes about 300 ms when running the server locally.