### PR TITLE
Delete multiple realms

### DIFF
--- a/src/main/WindowManager.ts
+++ b/src/main/WindowManager.ts
@@ -150,8 +150,14 @@ export class WindowManager {
 
     window.on('closed', () => {
       const index = this.windows.findIndex(handle => handle.window === window);
-      const { processDir } = this.windows[index];
       if (index > -1) {
+        // Only read out the processDir if the window is still present
+        const { processDir } = this.windows[index];
+        // Wait a second for Windows to unlock the directory before deleting it
+        setTimeout(() => {
+          this.cleanupRendererProcessDirectory(processDir);
+        }, 1000);
+        // Remove the window
         this.windows.splice(index, 1);
       }
       // Loaded
@@ -159,10 +165,6 @@ export class WindowManager {
         category: 'ui.window',
         message: `Closed '${options.type}' window`,
       });
-      // Wait a second for Windows to unlock the directory
-      setTimeout(() => {
-        this.cleanupRendererProcessDirectory(processDir);
-      }, 1000);
     });
 
     return window;

--- a/src/services/ros/index.ts
+++ b/src/services/ros/index.ts
@@ -31,17 +31,23 @@ export interface IUser {
   metadata: IUserMetadataRow[];
 }
 
+export type User = IUser & Realm.Object;
+
 export interface IAccount {
   provider: string;
   providerId: string;
   user?: IUser[];
 }
 
+export type Account = IAccount & Realm.Object;
+
 export interface IUserMetadataRow {
   user?: IUser[];
   key: string;
   value?: string;
 }
+
+export type UserMetadataRow = IUserMetadataRow & Realm.Object;
 
 export type RealmType = 'reference' | 'partial' | 'full';
 
@@ -54,12 +60,16 @@ export interface IRealmFile {
   realmType?: RealmType;
 }
 
+export type RealmFile = IRealmFile & Realm.Object;
+
 export interface IPermission {
   user: IUser;
   mayRead: boolean;
   mayWrite: boolean;
   mayManage: boolean;
 }
+
+export type Permission = IPermission & Realm.Object;
 
 export enum AccessLevel {
   none,

--- a/src/ui/ServerAdministration/RealmsTable/RealmSidebar/MultipleRealmsSidebarCard.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmSidebar/MultipleRealmsSidebarCard.tsx
@@ -1,0 +1,62 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import * as React from 'react';
+import { Button, Card, CardBody, CardTitle, Progress } from 'reactstrap';
+
+import { IDeletionProgress, RealmFile } from '..';
+
+export const MultipleRealmsSidebarCard = ({
+  deletionProgress,
+  onRealmDeletion,
+  realms,
+}: {
+  deletionProgress?: IDeletionProgress;
+  onRealmDeletion: (...realms: RealmFile[]) => void;
+  realms: RealmFile[];
+}) => {
+  return (
+    <Card className="RealmSidebar__Card">
+      <CardBody className="RealmSidebar__Top">
+        <CardTitle className="RealmSidebar__Title">
+          {realms.length} Realms selected
+        </CardTitle>
+      </CardBody>
+      <CardBody className="RealmSidebar__Tables" />
+      <CardBody className="RealmSidebar__Progress">
+        {deletionProgress ? (
+          <Progress
+            animated={true}
+            max={deletionProgress.total}
+            value={deletionProgress.current}
+          />
+        ) : null}
+      </CardBody>
+      <CardBody className="RealmSidebar__Controls">
+        <Button
+          size="sm"
+          color="danger"
+          disabled={!!deletionProgress}
+          onClick={() => onRealmDeletion(...realms)}
+        >
+          Delete {realms.length} Realms
+        </Button>
+      </CardBody>
+    </Card>
+  );
+};

--- a/src/ui/ServerAdministration/RealmsTable/RealmSidebar/RealmSidebar.scss
+++ b/src/ui/ServerAdministration/RealmsTable/RealmSidebar/RealmSidebar.scss
@@ -34,4 +34,8 @@
     float: left;
     margin-right: $spacer / 2;
   }
+
+  &__Progress {
+    flex-grow: 0;
+  }
 }

--- a/src/ui/ServerAdministration/RealmsTable/RealmSidebar/RealmSidebar.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmSidebar/RealmSidebar.tsx
@@ -19,14 +19,17 @@
 import * as React from 'react';
 import * as Realm from 'realm';
 
+import { IDeletionProgress, RealmFile } from '..';
 import * as ros from '../../../../services/ros';
 import { Sidebar } from '../../shared/Sidebar';
 
-import { RealmSidebarCard } from './RealmSidebarCard';
+import { MultipleRealmsSidebarCard } from './MultipleRealmsSidebarCard';
+import { SingleRealmSidebarCard } from './SingleRealmSidebarCard';
 
 import './RealmSidebar.scss';
 
 export const RealmSidebar = ({
+  deletionProgress,
   getRealmPermissions,
   getRealmStateSize,
   isOpen,
@@ -34,34 +37,34 @@ export const RealmSidebar = ({
   onRealmOpened,
   onRealmTypeUpgrade,
   onToggle,
-  realm,
+  realms,
 }: {
-  getRealmPermissions: (path: string) => Realm.Results<ros.IPermission>;
-  getRealmStateSize: (path: string) => number | undefined;
+  deletionProgress?: IDeletionProgress;
+  getRealmPermissions: (realm: RealmFile) => Realm.Results<ros.IPermission>;
+  getRealmStateSize: (realm: RealmFile) => number | undefined;
   isOpen: boolean;
-  onRealmDeletion: (path: string) => void;
-  onRealmOpened: (path: string) => void;
-  onRealmTypeUpgrade: (path: string) => void;
+  onRealmDeletion: (realm: RealmFile) => void;
+  onRealmOpened: (realm: RealmFile) => void;
+  onRealmTypeUpgrade: (realm: RealmFile) => void;
   onToggle: () => void;
-  realm?: ros.IRealmFile;
-}) => {
-  // We need this type-hax because we don't want the IRealmFile to have a isValid method when it gets created
-  const currentRealm = realm
-    ? ((realm as any) as ros.IRealmFile & Realm.Object)
-    : undefined;
-  return (
-    <Sidebar className="RealmSidebar" isOpen={isOpen} onToggle={onToggle}>
-      {currentRealm &&
-        currentRealm.isValid() && (
-          <RealmSidebarCard
-            onRealmDeletion={onRealmDeletion}
-            onRealmOpened={onRealmOpened}
-            onRealmTypeUpgrade={onRealmTypeUpgrade}
-            permissions={getRealmPermissions(currentRealm.path)}
-            realm={currentRealm}
-            stateSize={getRealmStateSize(currentRealm.path)}
-          />
-        )}
-    </Sidebar>
-  );
-};
+  realms: RealmFile[];
+}) => (
+  <Sidebar className="RealmSidebar" isOpen={isOpen} onToggle={onToggle}>
+    {realms.length === 1 ? (
+      <SingleRealmSidebarCard
+        onRealmDeletion={onRealmDeletion}
+        onRealmOpened={onRealmOpened}
+        onRealmTypeUpgrade={onRealmTypeUpgrade}
+        permissions={getRealmPermissions(realms[0])}
+        realm={realms[0]}
+        stateSize={getRealmStateSize(realms[0])}
+      />
+    ) : realms.length > 1 ? (
+      <MultipleRealmsSidebarCard
+        deletionProgress={deletionProgress}
+        onRealmDeletion={onRealmDeletion}
+        realms={realms}
+      />
+    ) : null}
+  </Sidebar>
+);

--- a/src/ui/ServerAdministration/RealmsTable/RealmSidebar/SingleRealmSidebarCard.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmSidebar/SingleRealmSidebarCard.tsx
@@ -20,13 +20,14 @@ import * as React from 'react';
 import { Button, Card, CardBody, CardText, CardTitle } from 'reactstrap';
 import * as Realm from 'realm';
 
+import { RealmFile } from '..';
 import * as ros from '../../../../services/ros';
 import { displayUser, prettyBytes, shortenRealmPath } from '../../utils';
 import { RealmTypeBadge } from '../RealmTypeBadge';
 
 import { PermissionsTable } from './PermissionsTable';
 
-export const RealmSidebarCard = ({
+export const SingleRealmSidebarCard = ({
   onRealmDeletion,
   onRealmOpened,
   onRealmTypeUpgrade,
@@ -34,10 +35,10 @@ export const RealmSidebarCard = ({
   realm,
   stateSize,
 }: {
-  onRealmDeletion: (path: string) => void;
-  onRealmOpened: (path: string) => void;
-  onRealmTypeUpgrade: (path: string) => void;
-  realm: ros.IRealmFile;
+  onRealmDeletion: (realm: RealmFile) => void;
+  onRealmOpened: (realm: RealmFile) => void;
+  onRealmTypeUpgrade: (realm: RealmFile) => void;
+  realm: RealmFile;
   permissions: Realm.Results<ros.IPermission>;
   stateSize?: number;
 }) => {
@@ -89,27 +90,19 @@ export const RealmSidebarCard = ({
         </CardBody>
       ) : null}
       <CardBody className="RealmSidebar__Controls">
-        <Button
-          size="sm"
-          color="primary"
-          onClick={() => onRealmOpened(realm.path)}
-        >
+        <Button size="sm" color="primary" onClick={() => onRealmOpened(realm)}>
           Open
         </Button>
         {canUpgradeType ? (
           <Button
             size="sm"
             color="secondary"
-            onClick={() => onRealmTypeUpgrade(realm.path)}
+            onClick={() => onRealmTypeUpgrade(realm)}
           >
             Upgrade
           </Button>
         ) : null}
-        <Button
-          size="sm"
-          color="danger"
-          onClick={() => onRealmDeletion(realm.path)}
-        >
+        <Button size="sm" color="danger" onClick={() => onRealmDeletion(realm)}>
           Delete
         </Button>
       </CardBody>

--- a/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
@@ -24,58 +24,67 @@ import { IPermission, IRealmFile } from '../../../services/ros';
 import {
   FilterableTable,
   FilterableTableWrapper,
+  IFilterableTableProps,
 } from '../shared/FilterableTable';
 import { FloatingControls } from '../shared/FloatingControls';
 import { displayUser, prettyBytes } from '../utils';
 
+import { IDeletionProgress, RealmFile } from '.';
 import { MissingSizeBadge } from './MissingSizeBadge';
 import { RealmSidebar } from './RealmSidebar';
 import { StateSizeHeader } from './StateSizeHeader';
 
+const FilterableRealmTable: React.ComponentType<
+  IFilterableTableProps<RealmFile>
+> = FilterableTable;
+
 export const RealmsTable = ({
-  getRealmFromId,
+  deletionProgress,
   getRealmPermissions,
   getRealmStateSize,
   isFetchRealmSizes,
+  onRealmClick,
   onRealmCreation,
   onRealmDeletion,
   onRealmOpened,
-  onRealmSelected,
+  onRealmsDeselection,
   onRealmStateSizeRefresh,
   onRealmTypeUpgrade,
   onSearchStringChange,
   realms,
   realmStateSizes,
   searchString,
-  selectedRealmPath,
+  selectedRealms,
 }: {
-  getRealmFromId: (path: string) => IRealmFile | undefined;
-  getRealmPermissions: (path: string) => Realm.Results<IPermission>;
-  getRealmStateSize: (path: string) => number | undefined;
+  deletionProgress?: IDeletionProgress;
+  getRealmPermissions: (realm: RealmFile) => Realm.Results<IPermission>;
+  getRealmStateSize: (realm: RealmFile) => number | undefined;
   isFetchRealmSizes: boolean;
+  onRealmClick: (e: React.MouseEvent<HTMLElement>, realm: RealmFile) => void;
   onRealmCreation: () => void;
-  onRealmDeletion: (path: string) => void;
-  onRealmOpened: (path: string) => void;
-  onRealmSelected: (path: string | null) => void;
+  onRealmDeletion: (...realms: RealmFile[]) => void;
+  onRealmOpened: (realm: RealmFile) => void;
+  onRealmsDeselection: () => void;
   onRealmStateSizeRefresh: () => void;
-  onRealmTypeUpgrade: (path: string) => void;
+  onRealmTypeUpgrade: (realm: RealmFile) => void;
   onSearchStringChange: (query: string) => void;
-  realms: Realm.Results<IRealmFile>;
+  realms: Realm.Results<RealmFile>;
   realmStateSizes?: { [path: string]: number };
   searchString: string;
-  selectedRealmPath: string | null;
+  selectedRealms: RealmFile[];
 }) => {
   return (
     <FilterableTableWrapper>
-      <FilterableTable
-        elementIdProperty="path"
+      <FilterableRealmTable
         elements={realms}
+        onElementClick={onRealmClick}
         onElementDoubleClick={onRealmOpened}
-        onElementSelected={onRealmSelected}
+        onElementsDeselection={onRealmsDeselection}
         onSearchStringChange={onSearchStringChange}
         searchPlaceholder="Search Realms"
         searchString={searchString}
-        selectedIdPropertyValue={selectedRealmPath}
+        selectedElements={selectedRealms}
+        isElementsEqual={(a, b) => a.path === b.path}
       >
         <Column label="Path" dataKey="path" width={500} />
         <Column
@@ -110,25 +119,22 @@ export const RealmsTable = ({
             )
           }
         />
-      </FilterableTable>
+      </FilterableRealmTable>
 
-      <FloatingControls isOpen={selectedRealmPath === null}>
+      <FloatingControls isOpen={selectedRealms.length === 0}>
         <Button onClick={onRealmCreation}>Create new Realm</Button>
       </FloatingControls>
 
       <RealmSidebar
+        deletionProgress={deletionProgress}
         getRealmPermissions={getRealmPermissions}
         getRealmStateSize={getRealmStateSize}
-        isOpen={selectedRealmPath !== null}
+        isOpen={selectedRealms.length > 0}
         onRealmDeletion={onRealmDeletion}
         onRealmOpened={onRealmOpened}
         onRealmTypeUpgrade={onRealmTypeUpgrade}
-        onToggle={() => onRealmSelected(null)}
-        realm={
-          selectedRealmPath !== null
-            ? getRealmFromId(selectedRealmPath)
-            : undefined
-        }
+        onToggle={() => onRealmsDeselection()}
+        realms={selectedRealms}
       />
     </FilterableTableWrapper>
   );

--- a/src/ui/ServerAdministration/ServerAdministration.tsx
+++ b/src/ui/ServerAdministration/ServerAdministration.tsx
@@ -18,7 +18,7 @@
 
 import * as React from 'react';
 
-import { ros } from '../../services';
+import { RealmFile } from '../../services/ros';
 import { ILoadingProgress, LoadingOverlay } from '../reusable/LoadingOverlay';
 
 import { CreateRealmDialog } from './CreateRealmDialog';
@@ -46,7 +46,7 @@ interface IServerAdministrationProps {
   adminRealm?: Realm;
   adminRealmChanges: number;
   adminRealmProgress: ILoadingProgress;
-  createRealm: () => Promise<ros.IRealmFile>;
+  createRealm: () => Promise<RealmFile>;
   isCloudTenant: boolean;
   isCreateRealmOpen: boolean;
   isCreatingRealm: boolean;

--- a/src/ui/ServerAdministration/index.tsx
+++ b/src/ui/ServerAdministration/index.tsx
@@ -81,7 +81,7 @@ class ServerAdministrationContainer
   /* A single promise that resolves when the server is available */
   protected availabilityPromise?: Promise<string | undefined>;
   /* A promise handle that gets returned when a user calls createRealm */
-  protected createRealmPromiseHandle?: IPromiseHandle<ros.IRealmFile>;
+  protected createRealmPromiseHandle?: IPromiseHandle<ros.RealmFile>;
   /* A list of object schemas to use when creating the next Realm */
   protected createRealmSchema?: Realm.ObjectSchema[];
 
@@ -488,7 +488,7 @@ class ServerAdministrationContainer
         // If we are waiting for the realm to be created - hang on to the path
         if (this.createRealmPromiseHandle) {
           // Because we awaited creation - the admin Realm has most probably synced already
-          const newRealmFile = this.realm.objectForPrimaryKey<ros.IRealmFile>(
+          const newRealmFile = this.realm.objectForPrimaryKey<ros.RealmFile>(
             'RealmFile',
             serverPath,
           );

--- a/src/ui/ServerAdministration/shared/FilterableTable/FilterableTable.scss
+++ b/src/ui/ServerAdministration/shared/FilterableTable/FilterableTable.scss
@@ -21,6 +21,7 @@
 .Table {
   display: flex;
   flex-grow: 1;
+  user-select: none;
 
   &__content {
     display: flex;


### PR DESCRIPTION
This fixes #846 by implementing a command+click and shift+click to select individual or ranges of Realms and deleting these by issuing multiple requests to ROSs "delete realm" endpoint.

![delete-multiple-realms 1](https://user-images.githubusercontent.com/1243959/44212125-cfd13600-a16a-11e8-87cf-30e5f3735317.gif)
