### PR TITLE
Remove report realm state size

### DIFF
--- a/src/services/ros/realms.ts
+++ b/src/services/ros/realms.ts
@@ -167,18 +167,6 @@ export const getStats = async (
   );
 };
 
-export const reportRealmStateSize = async (
-  user: Realm.Sync.User,
-  path: string = '',
-) => {
-  return fetchAuthenticated(
-    user,
-    `/stats/report-realm-state-size/${path}`,
-    { method: 'POST' },
-    'Failed to report realm state size',
-  );
-};
-
 export const getSizes = async (user: Realm.Sync.User) => {
   const metrics = await getStats(user, 'ros_sync_realm_state_size');
   if (metrics.ros_sync_realm_state_size) {

--- a/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
@@ -42,13 +42,11 @@ export const RealmsTable = ({
   deletionProgress,
   getRealmPermissions,
   getRealmStateSize,
-  isFetchRealmSizes,
   onRealmClick,
   onRealmCreation,
   onRealmDeletion,
   onRealmOpened,
   onRealmsDeselection,
-  onRealmStateSizeRefresh,
   onRealmTypeUpgrade,
   onSearchStringChange,
   realms,
@@ -59,13 +57,11 @@ export const RealmsTable = ({
   deletionProgress?: IDeletionProgress;
   getRealmPermissions: (realm: RealmFile) => Realm.Results<IPermission>;
   getRealmStateSize: (realm: RealmFile) => number | undefined;
-  isFetchRealmSizes: boolean;
   onRealmClick: (e: React.MouseEvent<HTMLElement>, realm: RealmFile) => void;
   onRealmCreation: () => void;
   onRealmDeletion: (...realms: RealmFile[]) => void;
   onRealmOpened: (realm: RealmFile) => void;
   onRealmsDeselection: () => void;
-  onRealmStateSizeRefresh: () => void;
   onRealmTypeUpgrade: (realm: RealmFile) => void;
   onSearchStringChange: (query: string) => void;
   realms: Realm.Results<RealmFile>;
@@ -104,13 +100,7 @@ export const RealmsTable = ({
           dataKey="path"
           /* Don't show the size column if all sizes are unknown */
           width={realmStateSizes ? 100 : 0}
-          headerRenderer={props => (
-            <StateSizeHeader
-              {...props}
-              isRefreshing={isFetchRealmSizes}
-              onRefresh={onRealmStateSizeRefresh}
-            />
-          )}
+          headerRenderer={props => <StateSizeHeader {...props} />}
           cellRenderer={({ cellData }) =>
             realmStateSizes && typeof realmStateSizes[cellData] === 'number' ? (
               prettyBytes(realmStateSizes[cellData])

--- a/src/ui/ServerAdministration/RealmsTable/StateSizeHeader/StateSizeHeader.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/StateSizeHeader/StateSizeHeader.tsx
@@ -19,29 +19,23 @@
 import * as React from 'react';
 import { Popover, PopoverBody } from 'reactstrap';
 
-import { RefreshIcon } from './RefreshIcon';
-
 import './StateSizeHeader.scss';
 
 // @see https://github.com/bvaughn/react-virtualized/blob/9.18.5/source/Table/defaultHeaderRenderer.js
 
 interface IStateSizeHeaderProps {
   isPopoverOpen: boolean;
-  isRefreshing: boolean;
   label: string;
   labelElement?: HTMLElement;
   onLabelRef: (labelElement: HTMLElement) => void;
-  onRefresh: () => void;
   onTogglePopover: () => void;
 }
 
 export const StateSizeHeader = ({
   isPopoverOpen,
-  isRefreshing,
   label,
   labelElement,
   onLabelRef,
-  onRefresh,
   onTogglePopover,
 }: IStateSizeHeaderProps) => (
   <div className="ReactVirtualized__Table__headerTruncatedText">
@@ -57,10 +51,7 @@ export const StateSizeHeader = ({
         toggle={onTogglePopover}
         placement="bottom"
       >
-        <PopoverBody>
-          Recomputed every 30 minutes
-          <RefreshIcon onRefresh={onRefresh} isRefreshing={isRefreshing} />
-        </PopoverBody>
+        <PopoverBody>Recomputed every 30 minutes</PopoverBody>
       </Popover>
     ) : null}
   </div>

--- a/src/ui/ServerAdministration/RealmsTable/StateSizeHeader/index.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/StateSizeHeader/index.tsx
@@ -23,18 +23,13 @@ import { StateSizeHeader } from './StateSizeHeader';
 
 // @see https://github.com/bvaughn/react-virtualized/blob/9.18.5/source/Table/defaultHeaderRenderer.js
 
-interface IStateSizeHeaderContainerProps extends TableHeaderProps {
-  isRefreshing: boolean;
-  onRefresh: () => void;
-}
-
 interface IStateSizeHeaderContainerState {
   isPopoverOpen: boolean;
   labelElement?: HTMLElement;
 }
 
 class StateSizeHeaderContainer extends React.Component<
-  IStateSizeHeaderContainerProps,
+  TableHeaderProps,
   IStateSizeHeaderContainerState
 > {
   public state: IStateSizeHeaderContainerState = {
@@ -45,12 +40,10 @@ class StateSizeHeaderContainer extends React.Component<
     return (
       <StateSizeHeader
         isPopoverOpen={this.state.isPopoverOpen}
-        isRefreshing={this.props.isRefreshing}
         label={this.props.label || '?'}
         labelElement={this.state.labelElement}
         onLabelRef={this.onLabelRef}
         onTogglePopover={this.onTogglePopover}
-        onRefresh={this.props.onRefresh}
       />
     );
   }

--- a/src/ui/ServerAdministration/RealmsTable/index.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/index.tsx
@@ -171,7 +171,9 @@ class RealmsTableContainer extends React.PureComponent<
     // Fetch the realm sizes
     // TODO: Check the this.props.serverVersion before fetching using the semver library
     this.fetchRealmSizes().then(undefined, err => {
-      showError('Failed to fetch Realm sizes', err);
+      // Logging errors instead of showing them, because the user made no interaction
+      // tslint:disable-next-line:no-console
+      console.error('Failed to fetch Realm sizes', err);
     });
   }
 

--- a/src/ui/ServerAdministration/RealmsTable/index.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/index.tsx
@@ -135,13 +135,11 @@ class RealmsTableContainer extends React.PureComponent<
       <RealmsTable
         getRealmPermissions={this.getRealmPermissions}
         getRealmStateSize={this.getRealmStateSize}
-        isFetchRealmSizes={this.state.isFetchRealmSizes}
         onRealmCreation={this.onRealmCreation}
         onRealmDeletion={this.onRealmDeletion}
         onRealmOpened={this.onRealmOpened}
         onRealmsDeselection={this.onRealmsDeselection}
         onRealmClick={this.onRealmClick}
-        onRealmStateSizeRefresh={this.onRealmStateSizeRefresh}
         onRealmTypeUpgrade={this.onRealmTypeUpgrade}
         onSearchStringChange={this.onSearchStringChange}
         realms={realms}
@@ -265,13 +263,6 @@ class RealmsTableContainer extends React.PureComponent<
     }
   };
 
-  public onRealmStateSizeRefresh = () => {
-    // Fetch the realm sizes
-    this.fetchRealmSizes(true).then(undefined, err => {
-      showError('Failed to fetch Realm sizes', err);
-    });
-  };
-
   public onRealmsDeselection = () => {
     this.setState({ selectedRealms: [] });
   };
@@ -280,17 +271,10 @@ class RealmsTableContainer extends React.PureComponent<
     this.setState({ searchString });
   };
 
-  private async fetchRealmSizes(askServerToReport = false) {
+  private async fetchRealmSizes() {
     if (!this.state.isFetchRealmSizes) {
       try {
         this.setState({ isFetchRealmSizes: true });
-        if (askServerToReport) {
-          // Ask the server to recompute the realm sizes
-          await ros.realms.reportRealmStateSize(this.props.user);
-          // Wait half 200ms for the server to complete
-          // FIXME: This delay is a best guess - it could easily take longer time for the server to emit and process stats
-          await wait(1000);
-        }
         // Request the realm sizes from the server
         const sizes = await ros.realms.getSizes(this.props.user);
         // Update the state


### PR DESCRIPTION
This was an internal feature that was just recently added, removing it again because the API of ROS that it was using is being removed.