### PR TITLE
Add a more comprehensive system user filter criteria

### DIFF
--- a/src/ui/ServerAdministration/UsersTable/index.tsx
+++ b/src/ui/ServerAdministration/UsersTable/index.tsx
@@ -79,7 +79,7 @@ class UsersTableContainer extends React.Component<
       // Filter out System users if needed
       if (showSystemUsers === false) {
         users = users.filtered(
-          "NOT userId == '__admin' AND NOT userId BEGINSWITH 'system-accessibility'",
+          "NOT userId == '__admin' AND NOT accounts.provider BEGINSWITH 'jwt/central'",
         );
       }
       return users;


### PR DESCRIPTION
This will filter out `realm-admin` when created by the cloud as well. 

Fixes https://github.com/realm/raas/issues/884