### PR TITLE
Checking validity before accessing parant and their lists

### DIFF
--- a/src/ui/RealmBrowser/Content/index.tsx
+++ b/src/ui/RealmBrowser/Content/index.tsx
@@ -202,6 +202,10 @@ class ContentContainer extends React.Component<
   }
 
   public componentDidCatch(error: Error) {
+    // Add some more explanation to some error messages
+    if (error.message === 'Access to invalidated List object') {
+      error.message = 'The parent object with the list got deleted';
+    }
     this.setState({ error });
   }
 

--- a/src/ui/RealmBrowser/LeftSidebar/ListFocus.tsx
+++ b/src/ui/RealmBrowser/LeftSidebar/ListFocus.tsx
@@ -29,19 +29,21 @@ interface IListFocusProps {
   onClassFocussed: ClassFocussedHandler;
 }
 
-export const ListFocus = ({ focus, onClassFocussed }: IListFocusProps) => {
-  return (
-    <div className={classNames('LeftSidebar__List')}>
-      <div className="LeftSidebar__List__Name">
-        <span className="LeftSidebar__List__Name__Text">
-          List of {focus.property.objectType}
-        </span>
-        <Badge color="primary">{focus.results.length}</Badge>
+export const ListFocus = ({ focus, onClassFocussed }: IListFocusProps) => (
+  <div className="LeftSidebar__List">
+    <div className="LeftSidebar__List__Name">
+      <span className="LeftSidebar__List__Name__Text">
+        List of {focus.property.objectType}
+      </span>
+      <Badge color="primary">
+        {focus.parent.isValid() ? focus.results.length : '?'}
+      </Badge>
+    </div>
+    <div className="LeftSidebar__List__Parent">
+      <div>
+        <strong>{focus.property.name}</strong> on
       </div>
-      <div className="LeftSidebar__List__Parent">
-        <div>
-          <strong>{focus.property.name}</strong> on
-        </div>
+      {focus.parent.isValid() ? (
         <div>
           {!focus.parent.objectSchema().primaryKey ? 'a ' : null}
           <span
@@ -54,7 +56,9 @@ export const ListFocus = ({ focus, onClassFocussed }: IListFocusProps) => {
             {displayObject(focus.parent, false)}
           </span>
         </div>
-      </div>
+      ) : (
+        <div>a deleted object</div>
+      )}
     </div>
-  );
-};
+  </div>
+);

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -487,8 +487,9 @@ class RealmBrowserContainer
         [key: string]: any;
       } = this.state.focus.parent;
       const schema = parent.objectSchema();
-      const id = schema.primaryKey ? parent[schema.primaryKey] : '?';
       const propertyName = this.state.focus.property.name;
+      const id =
+        parent.isValid() && schema.primaryKey ? parent[schema.primaryKey] : '?';
       return `list:${schema.name}[${id}]:${propertyName}`;
     } else {
       return 'null';


### PR DESCRIPTION
This fixes https://github.com/realm/realm-studio/issues/920 and https://github.com/realm/realm-studio/issues/921 by checking validity before accessing a parent object or its list properties when the Realm browser is focussed on a list.

After this PR, this is what it looks like when a user focusses on a list and the parent object gets deleted:

![skaermbillede 2018-09-03 kl 10 38 39](https://user-images.githubusercontent.com/1243959/44976562-de3e9080-af65-11e8-9fc2-5954178b3046.png)
