### PR TITLE
Implemented an option to hide system classes

### DIFF
--- a/src/main/MainMenu.ts
+++ b/src/main/MainMenu.ts
@@ -128,6 +128,15 @@ export const getDefaultMenuTemplate = (
             updateMenu();
           },
         },
+        {
+          label: `Show system classes`,
+          type: 'checkbox',
+          checked: store.shouldShowSystemClasses(),
+          click: async () => {
+            await store.toggleShowSystemClasses();
+            updateMenu();
+          },
+        },
         { type: 'separator' },
         { role: 'resetzoom' },
         { role: 'zoomin' },

--- a/src/store.ts
+++ b/src/store.ts
@@ -21,10 +21,13 @@
 
 import { ElectronStore } from './module-wrappers/electron-store';
 
+type RemovalCallback = () => void;
+
 class RealmStudioStore {
   public readonly KEY_SHOW_PARTIAL_REALMS = 'realmlist.show-partial-realms';
   public readonly KEY_SHOW_SYSTEM_REALMS = 'realmlist.show-system-realms';
   public readonly KEY_SHOW_SYSTEM_USERS = 'userlist.show-system-users';
+  public readonly KEY_SHOW_SYSTEM_CLASSES = 'browser.show-system-classes';
 
   private store = new ElectronStore();
 
@@ -43,6 +46,11 @@ class RealmStudioStore {
     this.store.set(this.KEY_SHOW_SYSTEM_USERS, !currentValue);
   }
 
+  public toggleShowSystemClasses() {
+    const currentValue = this.store.get(this.KEY_SHOW_SYSTEM_CLASSES, false);
+    this.store.set(this.KEY_SHOW_SYSTEM_CLASSES, !currentValue);
+  }
+
   public shouldShowPartialRealms(): boolean {
     return this.store.get(this.KEY_SHOW_PARTIAL_REALMS, false);
   }
@@ -53,6 +61,10 @@ class RealmStudioStore {
 
   public shouldShowSystemUsers(): boolean {
     return this.store.get(this.KEY_SHOW_SYSTEM_USERS, false);
+  }
+
+  public shouldShowSystemClasses(): boolean {
+    return this.store.get(this.KEY_SHOW_SYSTEM_CLASSES, false);
   }
 
   // Subclassing ElectronStore results in
@@ -68,8 +80,10 @@ class RealmStudioStore {
   public onDidChange(
     key: string,
     callback: (newValue: any, oldValue: any) => void,
-  ): void {
-    this.store.onDidChange(key, callback);
+  ) {
+    const removalCallback = this.store.onDidChange(key, callback);
+    // The store actually returns a function that can be called to remove the listener
+    return (removalCallback as any) as RemovalCallback;
   }
 
   public delete(key: string) {

--- a/src/ui/RealmBrowser/AddPropertyModal/index.tsx
+++ b/src/ui/RealmBrowser/AddPropertyModal/index.tsx
@@ -27,7 +27,7 @@ export interface IAddPropertyModalProps {
   isOpen: boolean;
   isPropertyNameAvailable: (name: string) => boolean;
   onAddProperty: (name: string, type: Realm.PropertyType) => void;
-  schemas: Realm.ObjectSchema[];
+  classes: Realm.ObjectSchema[];
   toggle: () => void;
 }
 
@@ -67,7 +67,7 @@ class AddPropertyModalContainer extends React.Component<
     };
   }
 
-  public componentWillReceiveProps(props: IAddPropertyModalProps) {
+  public componentWillReceiveProps() {
     this.generateTypeOptions();
   }
 
@@ -122,7 +122,7 @@ class AddPropertyModalContainer extends React.Component<
       disabled: false,
       show: true,
     }));
-    const classes = this.getClassesTypes(this.props.schemas);
+    const classes = this.getClassesTypes(this.props.classes);
     const classTypeHeader = {
       value: 'Link Types',
       disabled: true,
@@ -156,8 +156,8 @@ class AddPropertyModalContainer extends React.Component<
     return `${propertyType}${optionalMarker}${listMarker}`;
   };
 
-  private getClassesTypes = (schemas: Realm.ObjectSchema[]): string[] =>
-    schemas.map(schema => schema.name);
+  private getClassesTypes = (classes: Realm.ObjectSchema[]): string[] =>
+    classes.map(c => c.name);
 }
 
 export { AddPropertyModalContainer as AddPropertyModal };

--- a/src/ui/RealmBrowser/LeftSidebar/LeftSidebar.scss
+++ b/src/ui/RealmBrowser/LeftSidebar/LeftSidebar.scss
@@ -39,11 +39,14 @@
     text-transform: uppercase;
   }
 
-  &__SchemaList {
+  &__Classes {
     flex-grow: 1;
     margin: 0 (-$spacer / 2);
     overflow-x: hidden;
     overflow-y: auto;
+  }
+
+  &__ClassList {
     padding: 0;
 
     &--empty {
@@ -53,13 +56,13 @@
 
       &::before {
         color: $elephant;
-        content: "This Realm has no schemas defined";
+        content: "This Realm has no classes defined";
         text-align: center;
       }
     }
   }
 
-  &__Schema {
+  &__Class {
     flex-direction: column;
     list-style: none;
 
@@ -125,5 +128,15 @@
       cursor: pointer;
       text-decoration: underline;
     }
+  }
+
+  &__HiddenClassesHint {
+    color: $elephant;
+    font-size: .75rem;
+    margin: 0 ($spacer / 2);
+    overflow: hidden;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }

--- a/src/ui/RealmBrowser/LeftSidebar/LeftSidebar.tsx
+++ b/src/ui/RealmBrowser/LeftSidebar/LeftSidebar.tsx
@@ -1,0 +1,123 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import * as classNames from 'classnames';
+import * as React from 'react';
+import { Badge, Button, FormGroup, Input, Label } from 'reactstrap';
+
+import { ClassFocussedHandler } from '..';
+import { ILoadingProgress, Sidebar } from '../../reusable';
+import { Focus, IListFocus } from '../focus';
+
+import { ListFocus } from './ListFocus';
+
+import './LeftSidebar.scss';
+
+export const isSelected = (focus: Focus | null, schemaName: string) => {
+  if (focus && focus.kind === 'class') {
+    return focus.className === schemaName;
+  } else if (focus && focus.kind === 'list') {
+    return focus.parent.objectSchema().name === schemaName;
+  } else {
+    return false;
+  }
+};
+
+export interface ILeftSidebarProps {
+  classes: Realm.ObjectSchema[];
+  className?: string;
+  focus: Focus | null;
+  getSchemaLength: (className: string) => number;
+  hiddenClassCount: number;
+  isOpen: boolean;
+  onClassFocussed: ClassFocussedHandler;
+  onToggle: () => void;
+  progress: ILoadingProgress;
+  toggleAddClass: () => void;
+}
+
+export const LeftSidebar = ({
+  classes,
+  className,
+  focus,
+  getSchemaLength,
+  hiddenClassCount,
+  isOpen,
+  onClassFocussed,
+  onToggle,
+  progress,
+  toggleAddClass,
+}: ILeftSidebarProps) => (
+  <Sidebar
+    className={className}
+    contentClassName="LeftSidebar"
+    isOpen={isOpen}
+    onToggle={onToggle}
+    position="left"
+    minimumWidth={120}
+  >
+    <div className="LeftSidebar__Header">
+      <span>Classes</span>
+      <Button size="sm" onClick={toggleAddClass}>
+        <i className="fa fa-plus" />
+      </Button>
+    </div>
+    <div className="LeftSidebar__Classes">
+      {classes && classes.length > 0 ? (
+        <ul className="LeftSidebar__ClassList">
+          {classes.map(schema => {
+            const selected = isSelected(focus, schema.name);
+            const schemaClass = classNames('LeftSidebar__Class__Info', {
+              'LeftSidebar__Class__Info--selected': selected,
+            });
+            return (
+              <li
+                key={schema.name}
+                className="LeftSidebar__Class"
+                title={schema.name}
+              >
+                <div
+                  className={schemaClass}
+                  onClick={() => onClassFocussed(schema.name)}
+                >
+                  <span className="LeftSidebar__Class__Name">
+                    {schema.name}
+                  </span>
+                  <Badge color="primary">{getSchemaLength(schema.name)}</Badge>
+                </div>
+                {selected && focus && focus.kind === 'list' ? (
+                  <ListFocus
+                    focus={focus as IListFocus}
+                    onClassFocussed={onClassFocussed}
+                  />
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      ) : progress.status === 'done' ? (
+        <div className="LeftSidebar__ClassList--empty" />
+      ) : null}
+      {hiddenClassCount > 0 ? (
+        <p className="LeftSidebar__HiddenClassesHint">
+          Hiding {hiddenClassCount} system classes
+        </p>
+      ) : null}
+    </div>
+  </Sidebar>
+);

--- a/src/ui/RealmBrowser/RealmBrowser.tsx
+++ b/src/ui/RealmBrowser/RealmBrowser.tsx
@@ -33,6 +33,7 @@ import { NoFocusPlaceholder } from './NoFocusPlaceholder';
 import './RealmBrowser.scss';
 
 export interface IRealmBrowserProps {
+  classes: Realm.ObjectSchema[];
   contentKey: string;
   contentRef: (instance: Content | null) => void;
   createObjectSchema?: Realm.ObjectSchema;
@@ -60,9 +61,8 @@ export interface IRealmBrowserProps {
   onRealmChanged: () => void;
   progress: ILoadingProgress;
   realm?: Realm;
-  schemas: Realm.ObjectSchema[];
-  toggleAddSchema: () => void;
-  toggleAddSchemaProperty: () => void;
+  toggleAddClass: () => void;
+  toggleAddClassProperty: () => void;
 }
 
 export const RealmBrowser = ({
@@ -92,13 +92,14 @@ export const RealmBrowser = ({
   onRealmChanged,
   progress,
   realm,
-  schemas,
-  toggleAddSchema,
-  toggleAddSchemaProperty,
+  classes,
+  toggleAddClass,
+  toggleAddClassProperty,
 }: IRealmBrowserProps) => {
   return (
     <div className="RealmBrowser">
       <LeftSidebar
+        classes={classes}
         className="RealmBrowser__LeftSidebar"
         focus={focus}
         getSchemaLength={getSchemaLength}
@@ -106,8 +107,7 @@ export const RealmBrowser = ({
         onClassFocussed={onClassFocussed}
         onToggle={onLeftSidebarToggle}
         progress={progress}
-        schemas={schemas}
-        toggleAddSchema={toggleAddSchema}
+        toggleAddClass={toggleAddClass}
       />
       <div className="RealmBrowser__Wrapper">
         {focus && realm ? (
@@ -119,7 +119,7 @@ export const RealmBrowser = ({
             focus={focus}
             getClassFocus={getClassFocus}
             key={contentKey}
-            onAddColumnClick={toggleAddSchemaProperty}
+            onAddColumnClick={toggleAddClassProperty}
             onCancelTransaction={onCancelTransaction}
             onClassFocussed={onClassFocussed}
             onCommitTransaction={onCommitTransaction}
@@ -140,7 +140,7 @@ export const RealmBrowser = ({
         isOpen={isAddClassOpen}
         isClassNameAvailable={isClassNameAvailable}
         onAddClass={onAddClass}
-        toggle={toggleAddSchema}
+        toggle={toggleAddClass}
       />
 
       {focus && focus.kind === 'class' ? (
@@ -149,8 +149,8 @@ export const RealmBrowser = ({
           isOpen={isAddPropertyOpen}
           isPropertyNameAvailable={isPropertyNameAvailable}
           onAddProperty={onAddProperty}
-          schemas={schemas}
-          toggle={toggleAddSchemaProperty}
+          classes={classes}
+          toggle={toggleAddClassProperty}
         />
       ) : null}
 

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -72,8 +72,8 @@ export interface IRealmBrowserState extends IRealmLoadingComponentState {
   isAddPropertyOpen: boolean;
   isEncryptionDialogVisible: boolean;
   isLeftSidebarOpen: boolean;
-  // The schemas are only supposed to be used to produce a list of schemas in the sidebar
-  schemas: Realm.ObjectSchema[];
+  // The classes are only supposed to be used to produce a list of classes in the sidebar
+  classes: Realm.ObjectSchema[];
 }
 
 class RealmBrowserContainer
@@ -93,7 +93,7 @@ class RealmBrowserContainer
     isEncryptionDialogVisible: false,
     isLeftSidebarOpen: true,
     progress: { status: 'idle' },
-    schemas: [],
+    classes: [],
   };
 
   private contentInstance: Content | null = null;
@@ -115,6 +115,7 @@ class RealmBrowserContainer
     const contentKey = this.generateContentKey();
     return (
       <RealmBrowser
+        classes={this.state.classes}
         contentKey={contentKey}
         contentRef={this.contentRef}
         dataVersion={this.state.dataVersion}
@@ -141,9 +142,8 @@ class RealmBrowserContainer
         onRealmChanged={this.onRealmChanged}
         progress={this.state.progress}
         realm={this.realm}
-        schemas={this.state.schemas}
-        toggleAddSchema={this.toggleAddSchema}
-        toggleAddSchemaProperty={this.toggleAddSchemaProperty}
+        toggleAddClass={this.toggleAddClass}
+        toggleAddClassProperty={this.toggleAddClassProperty}
       />
     );
   }
@@ -280,7 +280,7 @@ class RealmBrowserContainer
     const firstSchemaName =
       this.realm.schema.length > 0 ? this.realm.schema[0].name : undefined;
     this.setState({
-      schemas: this.realm.schema,
+      classes: this.realm.schema,
     });
     if (firstSchemaName) {
       this.onClassFocussed(firstSchemaName);
@@ -322,10 +322,10 @@ class RealmBrowserContainer
   };
 
   private isClassNameAvailable = (name: string): boolean => {
-    return !this.state.schemas.find(schema => schema.name === name);
+    return !this.state.classes.find(schema => schema.name === name);
   };
 
-  private toggleAddSchema = () => {
+  private toggleAddClass = () => {
     this.setState({
       isAddClassOpen: !this.state.isAddClassOpen,
     });
@@ -338,7 +338,7 @@ class RealmBrowserContainer
     );
   };
 
-  private toggleAddSchemaProperty = () => {
+  private toggleAddClassProperty = () => {
     this.setState({
       isAddPropertyOpen: !this.state.isAddPropertyOpen,
     });
@@ -349,7 +349,7 @@ class RealmBrowserContainer
       try {
         // The schema version needs to be bumped for local realms
         const nextSchemaVersion = this.realm.schemaVersion + 1;
-        const cleanedSchema = schemaUtils.cleanUpSchema(this.state.schemas);
+        const cleanedSchema = schemaUtils.cleanUpSchema(this.state.classes);
         const modifiedSchema = [...cleanedSchema, schema];
         // Close the current Realm
         this.realm.close();
@@ -376,7 +376,7 @@ class RealmBrowserContainer
       try {
         const focusedClassName = this.state.focus.className;
         const nextSchemaVersion = this.realm.schemaVersion + 1;
-        const cleanedSchema = schemaUtils.cleanUpSchema(this.state.schemas);
+        const cleanedSchema = schemaUtils.cleanUpSchema(this.state.classes);
         const modifiedSchema = schemaUtils.addProperty(
           cleanedSchema,
           this.state.focus.className,
@@ -657,7 +657,7 @@ class RealmBrowserContainer
     const basename = path.basename(this.props.realm.path, '.realm');
     remote.dialog.showSaveDialog(
       {
-        defaultPath: `${basename}-schemas`,
+        defaultPath: `${basename}-classes`,
         message: `Select a directory to store the ${language} schema files`,
       },
       selectedPath => {


### PR DESCRIPTION
This PR fixes https://github.com/realm/realm-studio/issues/772 by adding an option to show system classes (classes with names that start with "__") from the list of classes when browsing a Realm, the default behaviour will be that these are hidden.

<img width="912" alt="skaermbillede 2018-09-03 kl 17 35 34" src="https://user-images.githubusercontent.com/1243959/44994687-19f64c00-afa0-11e8-9614-05b6a301e38d.png">

When the classes are hidden a small hint will be shown to limit confusions that may arise if the user doesn't know that this feature exists at all.

The setting can be changed from the "view" menu in the application menu:

<img width="273" alt="skaermbillede 2018-09-03 kl 17 35 55" src="https://user-images.githubusercontent.com/1243959/44994714-372b1a80-afa0-11e8-9829-b466c02f1ca6.png">
