### PR TITLE
Fix release build

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -139,11 +139,12 @@ def packageForLinuxAndWindows() {
 
 def packageForMac() {
   return {
-    node('macos') {
+    node('macos-cph-02.cph.realm') {
       checkoutAtVersion()
 
       def nodeVersion = readFile('.nvmrc').trim()
-      nvm(version: nodeVersion) {
+      def installDir = sh(returnStdout: true, script: 'brew --prefix nvm').trim()
+      nvm('version': nodeVersion, 'nvmInstallDir': installDir) {
         // Using via-nvm.sh wraps ensures the correct version of node and npm.
         sh './scripts/via-nvm.sh npm install --quiet'
 


### PR DESCRIPTION
Forces build to happen on the cph-02 node because cph-01 produces invalid binaries (crashes with framework missing, similar to what happened with Studio 2.6.0). Fixing these is tracked in https://github.com/realm/realm-studio/issues/958.

It also uses homebrew to discover the nvm install dir as relying on the env variable has proven unreliable.