### PR TITLE
Highlight cells only when getting focus and not already highlighted

### DIFF
--- a/src/ui/RealmBrowser/Content/Table/Cell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/Cell.tsx
@@ -137,7 +137,9 @@ export const Cell = ({
       onFocus={() => {
         // When the cell gets focussed (could happen by clicking or tabbing)
         // - ensure it also gets highlighted
-        onHighlighted();
+        if (!isHighlighted) {
+          onHighlighted();
+        }
       }}
       style={style}
     >


### PR DESCRIPTION
This fixes #960 by ensuring a cell does not get highlighted when it gains focus, if its already highlighted (potentially as a part of a highlight selecting multiple rows).