### PR TITLE
Indicate whether a property is primary key in the browser

### DIFF
--- a/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
@@ -46,6 +46,7 @@ export const getPropertyDisplayed = (property: Realm.ObjectSchemaProperty) => {
     getPropertyType(property),
     property.optional ? '?' : '',
     property.type === 'list' ? '[]' : '',
+    property.isPrimaryKey ? ' (Primary Key)' : '',
   ].join('');
 };
 

--- a/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
@@ -41,7 +41,7 @@ const getPropertyType = (property: Realm.ObjectSchemaProperty) => {
   }
 };
 
-export const getPropertyDisplayed = (property: Realm.ObjectSchemaProperty) => {
+export const getPropertyDisplayed = (property: IPropertyWithName) => {
   return [
     getPropertyType(property),
     property.optional ? '?' : '',

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -46,6 +46,7 @@ import * as schemaUtils from './schema-utils';
 export interface IPropertyWithName extends Realm.ObjectSchemaProperty {
   name: string | null;
   readOnly: boolean;
+  isPrimaryKey: boolean;
 }
 
 export type EditModeChangeHandler = (editMode: EditMode) => void;
@@ -581,7 +582,7 @@ class RealmBrowserContainer
     // Determine the properties
     if (property.type === 'list' && property.objectType) {
       const properties: IPropertyWithName[] = [
-        { name: '#', type: 'int', readOnly: true },
+        { name: '#', type: 'int', readOnly: true, isPrimaryKey: false },
       ];
       if (isPrimitive(property.objectType)) {
         return properties.concat([
@@ -589,6 +590,7 @@ class RealmBrowserContainer
             name: null,
             type: property.objectType,
             readOnly: false,
+            isPrimaryKey: false,
           },
         ]);
       } else {

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -623,6 +623,7 @@ class RealmBrowserContainer
         return {
           name: propertyName,
           readOnly: false,
+          isPrimaryKey: objectSchema.primaryKey === propertyName,
           ...property,
         };
       } else {


### PR DESCRIPTION
<img width="957" alt="screenshot 2018-10-26 at 13 28 20" src="https://user-images.githubusercontent.com/2315687/47563915-96b00180-d923-11e8-8d9e-7f95d29da877.png">

This will append `(Primary Key)` to the type of the property if it's a primary key.