### PR TITLE
Cache Realms in Studio

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -16,9 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { ipcRenderer } from 'electron';
-import * as Realm from 'realm';
-
 export { ActionReceiver } from './ActionReceiver';
 export { ActionSender } from './ActionSender';
 export * from './transports';

--- a/src/actions/main/Sender.ts
+++ b/src/actions/main/Sender.ts
@@ -98,4 +98,8 @@ export class Sender extends ActionSender {
   public showServerAdministration(props: IServerAdministrationWindowProps) {
     return this.send(MainActions.ShowServerAdministration, props);
   }
+
+  public clearRendererCache() {
+    return this.send(MainActions.ClearRendererCache);
+  }
 }

--- a/src/main/Application.ts
+++ b/src/main/Application.ts
@@ -99,7 +99,7 @@ export class Application {
     ) => {
       return this.showServerAdministration(props);
     },
-    [MainActions.CleanRendererCache]: async () => {
+    [MainActions.ClearRendererCache]: async () => {
       await this.windowManager.closeAllWindows();
       await cleanupRendererDirectories();
       await this.showGreeting();

--- a/src/main/Application.ts
+++ b/src/main/Application.ts
@@ -35,7 +35,7 @@ import {
   IServerAdministrationWindowProps,
 } from '../windows/WindowProps';
 
-import { cleanupRendererDirectories } from '../utils';
+import { removeRendererDirectories } from '../utils';
 import { CertificateManager } from './CertificateManager';
 import { CloudManager, ICloudStatus } from './CloudManager';
 import { MainActions } from './MainActions';
@@ -101,7 +101,7 @@ export class Application {
     },
     [MainActions.ClearRendererCache]: async () => {
       await this.windowManager.closeAllWindows();
-      await cleanupRendererDirectories();
+      await removeRendererDirectories();
       await this.showGreeting();
     },
   };

--- a/src/main/MainActions.ts
+++ b/src/main/MainActions.ts
@@ -31,4 +31,5 @@ export enum MainActions {
   ShowOpenLocalRealm = 'show-open-local-realm',
   ShowRealmBrowser = 'show-realm-browser',
   ShowServerAdministration = 'show-server-administration',
+  ClearRendererCache = 'clear-renderer-cache',
 }

--- a/src/main/MainMenu.ts
+++ b/src/main/MainMenu.ts
@@ -24,7 +24,7 @@ import * as raas from '../services/raas';
 import { store } from '../store';
 import { showError } from '../ui/reusable/errors';
 
-const isDevelopment = process.env.NODE_ENV === 'development';
+const isDevelopment = process.env.NODE_ENV === 'development' || true;
 const showInternalFeatures =
   process.env.REALM_STUDIO_INTERNAL_FEATURES === 'true'; // Show features only relevant for Realm employees
 

--- a/src/main/MainMenu.ts
+++ b/src/main/MainMenu.ts
@@ -182,6 +182,12 @@ export const getDefaultMenuTemplate = (
             electronOrRemote.shell.openExternal('https://realm.io/docs');
           },
         },
+        {
+          label: 'Clear Cache',
+          click: () => {
+            main.cleanRendererCache();
+          },
+        },
       ],
     },
   ];

--- a/src/main/MainMenu.ts
+++ b/src/main/MainMenu.ts
@@ -185,7 +185,7 @@ export const getDefaultMenuTemplate = (
         {
           label: 'Clear Cache',
           click: () => {
-            main.cleanRendererCache();
+            main.clearRendererCache();
           },
         },
       ],

--- a/src/main/MainMenu.ts
+++ b/src/main/MainMenu.ts
@@ -24,8 +24,8 @@ import * as raas from '../services/raas';
 import { store } from '../store';
 import { showError } from '../ui/reusable/errors';
 
-const isDevelopment = process.env.NODE_ENV === 'development' || true;
 const showInternalFeatures =
+  process.env.NODE_ENV === 'development' ||
   process.env.REALM_STUDIO_INTERNAL_FEATURES === 'true'; // Show features only relevant for Realm employees
 
 function generateCloudEndpointItems(
@@ -98,9 +98,9 @@ export const getDefaultMenuTemplate = (
     {
       label: 'View',
       submenu: [
-        { role: 'reload', visible: isDevelopment },
-        { role: 'toggledevtools', visible: isDevelopment },
-        { type: 'separator', visible: isDevelopment },
+        { role: 'reload', visible: showInternalFeatures },
+        { role: 'toggledevtools', visible: showInternalFeatures },
+        { type: 'separator', visible: showInternalFeatures },
         {
           label: `Show partial Realms`,
           type: 'checkbox',

--- a/src/main/WindowManager.ts
+++ b/src/main/WindowManager.ts
@@ -220,7 +220,7 @@ export class WindowManager {
       // Deleting these folders are not obvious side-effects, so let's log that
       // tslint:disable-next-line:no-console
       console.log(`Removing abandoned renderer directory ${rendererPath}`);
-      fs.removeSync(rendererPath);
+      // fs.removeSync(rendererPath);
     }
   }
 
@@ -244,7 +244,7 @@ export class WindowManager {
 
   private cleanupRendererProcessDirectory(rendererPath: string) {
     try {
-      fs.removeSync(rendererPath);
+      // fs.removeSync(rendererPath);
     } catch (err) {
       // Deleting these folders are not obvious side-effects, so let's log if it fails
       // tslint:disable-next-line:no-console

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -18,6 +18,7 @@
 
 import './services/mixpanel';
 
+import * as electron from 'electron';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
@@ -25,14 +26,26 @@ import { changeRendererProcessDirectory } from './utils/renderer-process-directo
 
 const isDevelopment = process.env.NODE_ENV === 'development';
 
+let windowType = 'unknown';
+try {
+  if (document.location !== null) {
+    const params = new URL(document.location.href).searchParams.get('options');
+    if (params !== null) {
+      const deserialized = JSON.parse(params) as { type: string };
+      if (deserialized.type) {
+        windowType = deserialized.type;
+      }
+    }
+  }
+} catch {
+  // Just ignore
+}
+
+changeRendererProcessDirectory(windowType);
+
 // Don't report Realm JS analytics data
 // @see https://github.com/realm/realm-js/blob/master/lib/submit-analytics.js#L28
 process.env.REALM_DISABLE_ANALYTICS = 'true';
-
-// Create and change working directory to avoid conflicts of opening two realms twice
-// FIXME: see https://github.com/realm/realm-js/issues/818
-// This needs to happen before realm is loaded
-changeRendererProcessDirectory();
 
 import '../styles/index.scss';
 

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -29,7 +29,7 @@ const isDevelopment = process.env.NODE_ENV === 'development';
 // @see https://github.com/realm/realm-js/blob/master/lib/submit-analytics.js#L28
 process.env.REALM_DISABLE_ANALYTICS = 'true';
 
-// Create and change working directory to aviod conflicts of opening two realms twice
+// Create and change working directory to avoid conflicts of opening two realms twice
 // FIXME: see https://github.com/realm/realm-js/issues/818
 // This needs to happen before realm is loaded
 changeRendererProcessDirectory();

--- a/src/services/ros/realms.ts
+++ b/src/services/ros/realms.ts
@@ -64,31 +64,46 @@ export const getUrl = (user: Realm.Sync.User, realmPath: string) => {
   return url.toString();
 };
 
-export const open = async (
-  user: Realm.Sync.User,
-  realmPath: string,
-  encryptionKey?: Uint8Array,
-  ssl: ISslConfiguration = { validateCertificates: true },
-  progressCallback?: Realm.Sync.ProgressNotificationCallback,
-  schema?: Realm.ObjectSchema[],
-): Promise<Realm> => {
-  const url = getUrl(user, realmPath);
+export const open = async (params: {
+  user: Realm.Sync.User;
+  realmPath: string;
+  encryptionKey?: Uint8Array;
+  ssl: ISslConfiguration;
+  progressCallback?: Realm.Sync.ProgressNotificationCallback;
+  schema?: Realm.ObjectSchema[];
+}): Promise<Realm> => {
+  const ssl = params.ssl || { validateCertificates: true };
+  const url = getUrl(params.user, params.realmPath);
 
-  const realm = Realm.open({
-    encryptionKey,
-    schema,
+  let clientResetOcurred = false;
+  const realmPromise = Realm.open({
+    encryptionKey: params.encryptionKey,
+    schema: params.schema,
     sync: {
       url,
-      user,
-      error: ssl.errorCallback || defaultSyncErrorCallback,
+      user: params.user,
+      error: (session, error) => {
+        if (error.name === 'ClientReset') {
+          clientResetOcurred = true;
+        } else {
+          (ssl.errorCallback || defaultSyncErrorCallback)(session, error);
+        }
+      },
       validate_ssl: ssl.validateCertificates,
       ssl_trust_certificate_path: ssl.certificatePath,
       _disableQueryBasedSyncUrlChecks: true,
     },
   });
 
-  if (progressCallback) {
-    realm.progress(progressCallback);
+  if (params.progressCallback) {
+    realmPromise.progress(params.progressCallback);
+  }
+
+  const realm = await realmPromise;
+  if (clientResetOcurred) {
+    realm.close();
+    Realm.Sync.initiateClientReset(realm.path);
+    return open(params);
   }
 
   return realm;

--- a/src/ui/RealmBrowser/Content/Table/rowCellRangeRenderer.tsx
+++ b/src/ui/RealmBrowser/Content/Table/rowCellRangeRenderer.tsx
@@ -154,9 +154,7 @@ export const cellRangeRenderer = (
       continue;
     }
 
-    if (process.env.NODE_ENV !== 'production') {
-      warnAboutMissingStyle(parent, renderedCell);
-    }
+    warnAboutMissingStyle(parent, renderedCell);
 
     renderedCells.push(renderedCell);
   }
@@ -274,9 +272,7 @@ export const rowCellRangeRenderer = (rowRenderer: GridRowRenderer) => (
       continue;
     }
 
-    if (process.env.NODE_ENV !== 'production') {
-      warnAboutMissingStyle(parent, renderedRow);
-    }
+    warnAboutMissingStyle(parent, renderedRow);
 
     renderedRows.push(renderedRow);
   }
@@ -285,26 +281,26 @@ export const rowCellRangeRenderer = (rowRenderer: GridRowRenderer) => (
 };
 
 function warnAboutMissingStyle(parent: any, renderedCell: any) {
-  if (process.env.NODE_ENV !== 'production') {
-    if (renderedCell) {
-      // If the direct child is a CellMeasurer, then we should check its child
-      // See issue #611
-      if (renderedCell.type && renderedCell.type.__internalCellMeasurerFlag) {
-        renderedCell = renderedCell.props.children;
-      }
+  if (process.env.NODE_ENV === 'production' || !renderedCell) {
+    return;
+  }
 
-      if (
-        renderedCell &&
-        renderedCell.props &&
-        renderedCell.props.style === undefined &&
-        parent.__warnedAboutMissingStyle !== true
-      ) {
-        parent.__warnedAboutMissingStyle = true;
-        // tslint:disable-next-line:no-console
-        console.warn(
-          'Rendered cell should include style property for positioning.',
-        );
-      }
-    }
+  // If the direct child is a CellMeasurer, then we should check its child
+  // See issue #611
+  if (renderedCell.type && renderedCell.type.__internalCellMeasurerFlag) {
+    renderedCell = renderedCell.props.children;
+  }
+
+  if (
+    renderedCell &&
+    renderedCell.props &&
+    renderedCell.props.style === undefined &&
+    parent.__warnedAboutMissingStyle !== true
+  ) {
+    parent.__warnedAboutMissingStyle = true;
+    // tslint:disable-next-line:no-console
+    console.warn(
+      'Rendered cell should include style property for positioning.',
+    );
   }
 }

--- a/src/ui/ServerAdministration/index.tsx
+++ b/src/ui/ServerAdministration/index.tsx
@@ -397,12 +397,11 @@ class ServerAdministrationContainer
       if (!this.state.user) {
         throw new Error('Cannot open realm without a user');
       }
-      const newRealm = await ros.realms.open(
-        this.state.user,
-        newRealmFile.path,
-        undefined,
-        { validateCertificates: this.props.validateCertificates },
-      );
+      const newRealm = await ros.realms.open({
+        user: this.state.user,
+        realmPath: newRealmFile.path,
+        ssl: { validateCertificates: this.props.validateCertificates },
+      });
       // Import the data
       importer.importInto(newRealm);
       // Open the Realm browser in "import mode"

--- a/src/ui/reusable/RealmLoadingComponent/index.tsx
+++ b/src/ui/reusable/RealmLoadingComponent/index.tsx
@@ -92,7 +92,7 @@ export abstract class RealmLoadingComponent<
         );
 
         // tslint:disable-next-line:no-console
-        console.log(`Realm opened: ${realm.path}`);
+        console.log(`Realm opened: ${this.realm.path}`);
 
         // Register change listeners
         this.realm.addListener('change', this.onRealmChanged);
@@ -202,30 +202,33 @@ export abstract class RealmLoadingComponent<
         // Other errors, propagate it.
         throw error;
       }
-    } else if (realm && realm.mode === realms.RealmLoadingMode.Synced) {
-      const props = (realm as any) as realms.ISyncedRealmToLoad;
+    }
+
+    if (realm && realm.mode === realms.RealmLoadingMode.Synced) {
       const user =
-        props.authentication instanceof Realm.Sync.User
-          ? props.authentication
-          : await users.authenticate(props.authentication);
-      const realmPromise = realms.open(
+        realm.authentication instanceof Realm.Sync.User
+          ? realm.authentication
+          : await users.authenticate(realm.authentication);
+      const realmPromise = realms.open({
         user,
-        realm.path,
-        realm.encryptionKey,
+        realmPath: realm.path,
+        encryptionKey: realm.encryptionKey,
         ssl,
-        this.progressChanged,
+        progressCallback: this.progressChanged,
         schema,
-      );
+      });
       // Save a wrapping promise so this can be cancelled
       return new Promise<Realm>((resolve, reject) => {
         this.cancellations.push(() => reject({ wasCancelled: true }));
         realmPromise.then(resolve, reject);
       });
-    } else if (!realm) {
-      throw new Error(`Called without a realm to load`);
-    } else {
-      throw new Error('Unexpected mode');
     }
+
+    if (!realm) {
+      throw new Error(`Called without a realm to load`);
+    }
+
+    throw new Error('Unexpected mode');
   }
 
   private progressChanged = (transferred: number, transferable: number) => {

--- a/src/ui/reusable/RealmLoadingComponent/index.tsx
+++ b/src/ui/reusable/RealmLoadingComponent/index.tsx
@@ -90,6 +90,10 @@ export abstract class RealmLoadingComponent<
           schema,
           schemaVersion,
         );
+
+        // tslint:disable-next-line:no-console
+        console.log(`Realm opened: ${realm.path}`);
+
         // Register change listeners
         this.realm.addListener('change', this.onRealmChanged);
         this.onRealmLoaded();

--- a/src/utils/renderer-process-directory.ts
+++ b/src/utils/renderer-process-directory.ts
@@ -28,7 +28,7 @@ const rendererPattern = /^renderer-\d+$/;
 // Call this with `process.pid.toString()`
 export const getRendererProcessDirectory = (pid: number) => {
   const pidString = pid.toString();
-  return resolve(userDataPath, `renderer-${pidString}`);
+  return resolve(userDataPath, 'renderer');
 };
 
 export const getRendererProcessDirectories = () => {
@@ -47,11 +47,14 @@ export const changeRendererProcessDirectory = () => {
   // Get the process dir
   const processDir = getRendererProcessDirectory(process.pid);
   // Remove the directory if it already exists
-  if (fs.existsSync(processDir)) {
-    fs.removeSync(processDir);
+  if (!fs.existsSync(processDir)) {
+    // Create the directory
+    fs.mkdirSync(processDir);
   }
-  // Create the directory
-  fs.mkdirSync(processDir);
+
   // Change to it
   process.chdir(processDir);
+
+  // tslint:disable-next-line:no-console
+  console.log(`Process dir: ${processDir}`);
 };

--- a/src/utils/renderer-process-directory.ts
+++ b/src/utils/renderer-process-directory.ts
@@ -43,7 +43,7 @@ export const changeRendererProcessDirectory = (type: string) => {
   process.chdir(processDir);
 };
 
-export const cleanupRendererDirectories = () => {
+export const removeRendererDirectories = () => {
   const directories = fs
     .readdirSync(userDataPath)
     .filter(name => rendererPattern.test(name))


### PR DESCRIPTION
This changes the renderer behavior to use persistent directory names, allowing it to avoid redownloading the Realms every time a browser window is opened. Additionally, windows are now reused and opening a Realm twice will not open a new window.

![studio 2](https://user-images.githubusercontent.com/2315687/47711734-3cba7f00-dc36-11e8-8d15-427d30f92263.gif)

Finally, a new option to clear the cache is added to the `Help` menu.

<img width="598" alt="screenshot 2018-10-30 at 11 21 11" src="https://user-images.githubusercontent.com/2315687/47711662-04b33c00-dc36-11e8-8eaa-63dee7735e7b.png">


CM:
For reviewers. On Mac cached files are being stored in: `~/Library/Application Support/Realm Studio/`
