### PR TITLE
Fix custom auth not sending data string

### DIFF
--- a/src/services/ros/users.ts
+++ b/src/services/ros/users.ts
@@ -39,7 +39,7 @@ export const authenticate = async (
     const options = credentials.options as any;
     realmCredentials = Realm.Sync.Credentials.custom(
       options.provider,
-      options.providerToken || options.data,
+      options.providerToken || options.data || '',
       options.userInfo || options.user_info || {},
     );
   } else {


### PR DESCRIPTION
Fixes https://forum.realm.io/t/ream-studio-3-0-1-param-1-must-be-of-type-string/2125