### PR TITLE
Moved sentry id to the title and using the bug template for the body

### DIFF
--- a/src/windows/SentryErrorBoundary/ErrorOverlay.tsx
+++ b/src/windows/SentryErrorBoundary/ErrorOverlay.tsx
@@ -27,8 +27,8 @@ interface IErrorOverlayProps {
 }
 
 export const ErrorOverlay = ({ error, info, eventId }: IErrorOverlayProps) => {
-  const body = encodeURIComponent(`Sentry ID: ${eventId}`);
-  const gitHubUrl = `https://github.com/realm/realm-studio/issues/new?body=${body}`;
+  const title = encodeURIComponent(`[add title here] (Sentry ID: ${eventId})`);
+  const gitHubUrl = `https://github.com/realm/realm-studio/issues/new?template=bug_report.md&title=${title}`;
   return (
     <div className="ErrorOverlay">
       <p className="ErrorOverlay__Introduction">


### PR DESCRIPTION
To help prevent issues created from the Sentry error boundary with limited information (like https://github.com/realm/realm-studio/issues/977#issue-377681577), this PR changes the URL which the user is set to, so the issue is created from the standard bug template.

Unfortunately it's not possible to combine a template with the ID in the body, so it moved to the title of the issue.

![skaermbillede 2018-11-12 kl 09 02 53](https://user-images.githubusercontent.com/1243959/48334193-13e4b180-e65a-11e8-83d7-cb324b95c2e6.png)
