### PR TITLE
Updated changelog and releasenotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,19 @@
-Release 3.0.4 (2018-11-12)
+# Release 3.0.4 (2018-11-12)
 
 [Changes since v3.0.3](https://github.com/realm/realm-studio/compare/v3.0.3...v3.0.4)
 
-# Enhancements
+## Enhancements
 - None
 
-# Bugfixes
+## Bugfixes
 - Addressed a crash happening when sorting the browsers table on a column with type list. This was fixed by disabling sorting on list properties (#984).
 
-# Internal
+## Internal
 - Moved sentry id to the title and using the bug template for the body (#983)
 - Building up release notes in this file as PRs are merged (#987)
 
+---
 
-At the moment, the project does not have a CHANGELOG.md.
+The project didn't use to have a CHANGELOG.md.
 
-Instead the notes for each release can be found on GitHub: https://github.com/realm/realm-studio/releases
-
-There's an issue about adding a changelog to the project: https://github.com/realm/realm-studio/issues/584
+The notes for previous releases can be found on GitHub: https://github.com/realm/realm-studio/releases

--- a/Jenkinsfile.prepare
+++ b/Jenkinsfile.prepare
@@ -34,7 +34,7 @@ jobWrapper {
       today = new Date().format('yyyy-MM-dd')
       // Append the release notes to the change log
       changeLog = readFile 'CHANGELOG.md'
-      changeLog = "Release ${nextVersion.substring(1)} (${today})\n\n${releaseNotes}\n\n${changeLog}"
+      changeLog = "# Release ${nextVersion.substring(1)} (${today})\n\n${releaseNotes}\n\n${changeLog}"
       writeFile file: 'CHANGELOG.md', text: changeLog
 
       // Restore the release notes from the template

--- a/docs/RELEASENOTES.template.md
+++ b/docs/RELEASENOTES.template.md
@@ -1,10 +1,10 @@
 [Changes since {PREVIOUS_VERSION}](https://github.com/realm/realm-studio/compare/{PREVIOUS_VERSION}...{CURRENT_VERSION})
 
-# Enhancements
+## Enhancements
 - None
 
-# Bugfixes
+## Bugfixes
 - None
 
-# Internal
+## Internal
 - None


### PR DESCRIPTION
Changes the markdown used to produce the changelog and releasenotes to use proper heading levels.