### PR TITLE
Hide path-level permissions block for Query-based Realms

### DIFF
--- a/src/ui/ServerAdministration/RealmsTable/RealmSidebar/SingleRealmContent.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmSidebar/SingleRealmContent.tsx
@@ -51,12 +51,12 @@ export const SingleRealmContent = ({
   shouldShowRealmSize,
 }: ISingleRealmContentProps) => {
   const isSystemRealm = realm && realm.path.startsWith('/__');
+  const isFullRealm =
+    ['partial', 'reference'].indexOf(realm.realmType || '') === -1;
   // Determine if the Realm can be upgraded to a "reference" Realm,
   // It can if its defined and not already "partial" or "reference"
-  const canUpgradeType =
-    realm &&
-    !isSystemRealm &&
-    ['partial', 'reference'].indexOf(realm.realmType || '') === -1;
+  const canUpgradeType = realm && !isSystemRealm && isFullRealm;
+
   return (
     <React.Fragment>
       <SidebarTitle>
@@ -98,9 +98,11 @@ export const SingleRealmContent = ({
           Recalculate Sizes
         </Button>
       </SidebarBody>
-      <SidebarBody className="RealmSidebar__Tables">
-        {permissions ? <PermissionsTable permissions={permissions} /> : null}
-      </SidebarBody>
+      {isFullRealm ? (
+        <SidebarBody className="RealmSidebar__Tables">
+          {permissions ? <PermissionsTable permissions={permissions} /> : null}
+        </SidebarBody>
+      ) : null}
       {canUpgradeType ? (
         <SidebarBody grow={0} className="RealmSidebar__UpgradeTypeBlock">
           This Realm can be upgraded to a Reference Realm which will enable{' '}

--- a/src/ui/reusable/Sidebar/Sidebar.scss
+++ b/src/ui/reusable/Sidebar/Sidebar.scss
@@ -198,6 +198,7 @@
     flex-shrink: 0;
     justify-content: center;
     padding: 3 * $spacer / 4;
+    margin-top: auto;
 
     & > * {
       margin: $spacer / 4;


### PR DESCRIPTION
Previous behavior: The `User permissions` block was shown for all Realm types. This was confusing as the Path-level permissions are not applicable to Query-based Realms.

New behavior: Hide `User Permissions` for `Reference` and `Partial` type Realms. Also push the buttons to the bottom of the screen, always.

We might want to consider showing the Realm-level permissions for `Partial` Realms in this block, but doing that is outside the scope of this PR.

---
![image](https://user-images.githubusercontent.com/406066/48352040-0f38f100-e68c-11e8-8a8c-004d73c0a3c1.png)

![image](https://user-images.githubusercontent.com/406066/48352058-1bbd4980-e68c-11e8-805c-2c27dd6bb424.png)

![image](https://user-images.githubusercontent.com/406066/48352067-22e45780-e68c-11e8-8653-0cba7038fb0f.png)

![image](https://user-images.githubusercontent.com/406066/48352077-2972cf00-e68c-11e8-81cf-da06f18cfd2e.png)

