### PR TITLE
Fixed AM/PM when creating an object with a datetime value

### DIFF
--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/types/DateControl.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/types/DateControl.tsx
@@ -24,7 +24,7 @@ import { parseDate } from '../../../parsers';
 
 import { IBaseControlProps } from './TypeControl';
 
-const DATETIME_LOCAL_FORMAT = 'YYYY-MM-DDThh:mm:ss.SSS';
+const DATETIME_LOCAL_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSS';
 
 export const DateControl = ({
   children,


### PR DESCRIPTION
This fixes #955 by changing the format string passed to moment when converting the datetime to a string passed to the input field.