### PR TITLE
Moved AddColumnControl up from the HeaderGrid into the Table

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,6 +5,7 @@
 
 ## Bugfixes
 - The automatic updating was broken on Windows, to solve this the updater, builder and electron was downgraded to the latest stable versions. ([#1004](https://github.com/realm/realm-studio/pull/1004))
+- It was difficult to add property when class had many properties and no objects, this was fixed by transforming the AddColumn column into a button floating on-top-of the table header. ([#1008](https://github.com/realm/realm-studio/pull/1008))
 
 ## Internal
 - None

--- a/src/ui/RealmBrowser/Content/Table/AddColumnControl.tsx
+++ b/src/ui/RealmBrowser/Content/Table/AddColumnControl.tsx
@@ -16,12 +16,29 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-@import "variables/colors";
-@import "variables/fonts";
-@import "variables/sizes";
-@import "variables/timing";
+import * as classNames from 'classnames';
+import * as React from 'react';
+import { Button } from 'reactstrap';
 
-// Core bootstrap (v4.0.0) functions, variables and mixins
-@import "~bootstrap/scss/functions";
-@import "~bootstrap/scss/variables";
-@import "~bootstrap/scss/mixins";
+interface IAddColumnControlProps {
+  isHidden: boolean;
+  left: number;
+  onClick: () => void;
+}
+
+export const AddColumnControl = ({
+  isHidden,
+  left,
+  onClick,
+}: IAddColumnControlProps) => (
+  <div
+    className={classNames('RealmBrowser__Table__AddColumnControl', {
+      'RealmBrowser__Table__AddColumnControl--hidden': isHidden,
+    })}
+    style={{ left }}
+  >
+    <Button onClick={onClick} size="sm">
+      <i className="fa fa-plus" />
+    </Button>
+  </div>
+);

--- a/src/ui/RealmBrowser/Content/Table/ContentGrid.tsx
+++ b/src/ui/RealmBrowser/Content/Table/ContentGrid.tsx
@@ -65,7 +65,6 @@ export interface IContentGridProps extends Partial<GridProps> {
   highlight?: IHighlight;
   isSortable?: boolean;
   isSorting?: boolean;
-  onAddColumnEnabled: boolean;
   onCellChange?: CellChangeHandler;
   onCellClick?: CellClickHandler;
   onCellHighlighted?: CellHighlightedHandler;
@@ -108,13 +107,8 @@ export class ContentGrid extends React.PureComponent<IContentGridProps, {}> {
       highlight,
       onReorderingEnd,
       onReorderingStart,
-      onAddColumnEnabled,
       properties,
     } = this.props;
-
-    const columnCount = onAddColumnEnabled
-      ? properties.length + 1
-      : properties.length;
 
     // Create an object of props that will be passed to the container wrapping the grid
     const containerProps = {
@@ -131,7 +125,7 @@ export class ContentGrid extends React.PureComponent<IContentGridProps, {}> {
         cellRenderer={this.getCellRenderer}
         className="RealmBrowser__Table__ContentGrid"
         columnWidth={this.getColumnWidth}
-        columnCount={columnCount}
+        columnCount={properties.length}
         containerProps={containerProps}
         distance={5}
         onSortEnd={onReorderingEnd}
@@ -268,23 +262,11 @@ export class ContentGrid extends React.PureComponent<IContentGridProps, {}> {
   }
 
   private getColumnWidth = ({ index }: Index) => {
-    const { columnWidths, onAddColumnEnabled } = this.props;
-    if (onAddColumnEnabled && index === columnWidths.length) {
-      return 50;
-    } else {
-      return this.props.columnWidths[index];
-    }
+    return this.props.columnWidths[index];
   };
 
   private getCellRenderer = (cellProps: GridCellProps) => {
-    if (
-      this.props.onAddColumnEnabled &&
-      cellProps.columnIndex >= this.cellRenderers.length
-    ) {
-      return this.renderAddColumnCell(cellProps);
-    } else {
-      return this.cellRenderers[cellProps.columnIndex](cellProps);
-    }
+    return this.cellRenderers[cellProps.columnIndex](cellProps);
   };
 
   private renderAddColumnCell = ({

--- a/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
@@ -124,7 +124,9 @@ export class HeaderCell extends React.Component<
         style={style}
         className={classNames('RealmBrowser__Table__HeaderCell', {
           'RealmBrowser__Table__HeaderCell--sorting': isSorting,
+          'RealmBrowser__Table__HeaderCell--sortable': isSortable,
         })}
+        onClick={isSortable ? this.onSortClick : undefined}
         title={property.name || ''}
       >
         <div className="RealmBrowser__Table__HeaderProperty">
@@ -145,7 +147,6 @@ export class HeaderCell extends React.Component<
             className={classNames('RealmBrowser__Table__HeaderSort', {
               'RealmBrowser__Table__HeaderSort--active': isSorting,
             })}
-            onClick={this.onSortClick}
           >
             <i
               className={classNames('fa', {

--- a/src/ui/RealmBrowser/Content/Table/HeaderGrid.tsx
+++ b/src/ui/RealmBrowser/Content/Table/HeaderGrid.tsx
@@ -39,7 +39,6 @@ export interface IHeaderGridProps extends Partial<GridProps> {
   properties: IPropertyWithName[];
   sorting?: ISorting;
   width: number;
-  onAddColumnClick?: () => void;
 }
 
 export class HeaderGrid extends React.PureComponent<IHeaderGridProps, {}> {
@@ -56,23 +55,21 @@ export class HeaderGrid extends React.PureComponent<IHeaderGridProps, {}> {
   }
 
   public render() {
-    const { gridRef, height, onAddColumnClick, properties } = this.props;
-    const columnCount = onAddColumnClick
-      ? properties.length + 1
-      : properties.length;
+    const { gridRef, height, properties } = this.props;
     return (
       <Grid
         /* TODO: Omit the props that are irrellevant for the grid */
         {...this.props}
         className="RealmBrowser__Table__HeaderGrid"
         rowCount={1}
-        columnCount={columnCount}
+        columnCount={properties.length}
         columnWidth={this.getColumnWidth}
         cellRenderer={this.getCellRenderer}
         ref={gridRef}
         rowHeight={height}
         style={{
-          // TODO: Consider if this could be moved to the CSS
+          // This could be moved to the CSS,
+          // but it would require the use of the !important keyword
           overflowX: 'hidden',
         }}
       />
@@ -80,36 +77,12 @@ export class HeaderGrid extends React.PureComponent<IHeaderGridProps, {}> {
   }
 
   private getColumnWidth = ({ index }: Index) => {
-    const { columnWidths, onAddColumnClick } = this.props;
-    if (onAddColumnClick && index === columnWidths.length) {
-      return 50;
-    } else {
-      return this.props.columnWidths[index];
-    }
+    return this.props.columnWidths[index];
   };
 
   private getCellRenderer = (cellProps: GridCellProps) => {
-    if (
-      this.props.onAddColumnClick &&
-      cellProps.columnIndex >= this.cellRenderers.length
-    ) {
-      return this.renderAddColumnCell(cellProps);
-    } else {
-      return this.cellRenderers[cellProps.columnIndex](cellProps);
-    }
+    return this.cellRenderers[cellProps.columnIndex](cellProps);
   };
-
-  private renderAddColumnCell = (cellProps: GridCellProps) => (
-    <div
-      key={cellProps.key}
-      style={cellProps.style}
-      className="RealmBrowser__Table__HeaderCellControl RealmBrowser__Table__HeaderCellControl--borderless"
-      onClick={this.props.onAddColumnClick}
-      title="Click for add a new column"
-    >
-      <i className="fa fa-plus" />
-    </div>
-  );
 
   private generateRenderers(props: IHeaderGridProps) {
     const { properties } = props;

--- a/src/ui/RealmBrowser/Content/Table/Table.tsx
+++ b/src/ui/RealmBrowser/Content/Table/Table.tsx
@@ -40,6 +40,7 @@ import {
   rowHeights,
   RowMouseDownHandler,
 } from '.';
+import { AddColumnControl } from './AddColumnControl';
 import { ContentGrid } from './ContentGrid';
 import { HeaderGrid } from './HeaderGrid';
 import { MoreIndicator } from './MoreIndicator';
@@ -107,6 +108,7 @@ export const Table = ({
   const { height, width } = dimensions;
   const scrollBottom = rowHeights.header + scrollHeight - height - scrollTop;
   const scrollRight = scrollWidth - width - scrollLeft;
+  const totalColumnWidth = columnWidths.reduce((sum, w) => sum + w, 0);
 
   return (
     <div
@@ -125,7 +127,6 @@ export const Table = ({
         columnWidths={columnWidths}
         gridRef={gridHeaderRef}
         height={rowHeights.header}
-        onAddColumnClick={onAddColumnClick}
         onColumnWidthChanged={onColumnWidthChanged}
         onSortClick={onSortClick}
         overscanColumnCount={2}
@@ -135,7 +136,6 @@ export const Table = ({
         width={width}
       />
       <ContentGrid
-        className="RealmBrowser__Table__ValueGrid"
         columnWidths={columnWidths}
         dataVersion={dataVersion}
         editMode={editMode}
@@ -146,7 +146,6 @@ export const Table = ({
         highlight={highlight}
         isSortable={focus.kind === 'list' && !sorting}
         isSorting={isSorting}
-        onAddColumnEnabled={!!onAddColumnClick}
         onCellChange={onCellChange}
         onCellClick={onCellClick}
         onCellHighlighted={onCellHighlighted}
@@ -162,6 +161,16 @@ export const Table = ({
         rowHeight={rowHeights.content}
         width={width}
       />
+      {onAddColumnClick ? (
+        <AddColumnControl
+          isHidden={scrollLeft > 0 && scrollRight === 0}
+          onClick={onAddColumnClick}
+          left={Math.min(
+            totalColumnWidth - scrollLeft,
+            width - (29 + 2 * 16) /* button width + 2*padding */,
+          )}
+        />
+      ) : null}
     </div>
   );
 };

--- a/src/ui/RealmBrowser/RealmBrowser.scss
+++ b/src/ui/RealmBrowser/RealmBrowser.scss
@@ -99,10 +99,29 @@ $cell-border-color: mix($black, $white, 10%);
   &__Table {
     background: $white;
     flex: 1 0 0;
+    position: relative;
 
     &__HeaderGrid {
       background: $white;
-      overflow-x: hidden;
+    }
+
+    &__AddColumnControl {
+      align-items: center;
+      display: flex;
+      height: $realm-browser-header-height;
+      justify-content: flex-start;
+      padding: $spacer;
+      position: absolute;
+      right: 0;
+      top: 0;
+      transition: opacity $fast, margin-left $fast;
+      z-index: 1;
+
+      &--hidden {
+        margin-left: $spacer;
+        opacity: 0;
+        pointer-events: none;
+      }
     }
 
     &__Row {
@@ -137,7 +156,6 @@ $cell-border-color: mix($black, $white, 10%);
     }
 
     &__HeaderCell,
-    &__HeaderCellControl,
     &__Cell {
       border-bottom: 1px solid $cell-border-color;
       border-right: 1px solid $cell-border-color;
@@ -159,6 +177,10 @@ $cell-border-color: mix($black, $white, 10%);
       justify-content: space-between;
       padding: $cell-padding-y $cell-padding-x;
 
+      &--sortable {
+        cursor: pointer;
+      }
+
       &--sorting {
         border-top: $cell-header-border-size solid $primary;
       }
@@ -171,18 +193,6 @@ $cell-border-color: mix($black, $white, 10%);
       line-height: 1rem;
       overflow: hidden;
       text-overflow: ellipsis;
-    }
-
-    &__HeaderCellControl {
-      align-items: center;
-      color: $highlight-row-color;
-      cursor: pointer;
-      display: flex;
-      justify-content: center;
-
-      &:hover {
-        background: $highlight-row-bg;
-      }
     }
 
     &__HeaderName {
@@ -211,7 +221,6 @@ $cell-border-color: mix($black, $white, 10%);
 
     &__HeaderSort {
       color: $elephant;
-      cursor: pointer;
       flex-shrink: 0;
       font-size: 12px;
 

--- a/src/ui/RealmBrowser/index.test.tsx
+++ b/src/ui/RealmBrowser/index.test.tsx
@@ -19,7 +19,6 @@
 import * as assert from 'assert';
 import * as Electron from 'electron';
 import * as fs from 'fs';
-import { ITest } from 'mocha';
 import { resolve } from 'path';
 import { Application } from 'spectron';
 import * as fakeDialog from 'spectron-fake-dialog';
@@ -129,7 +128,6 @@ describe('<RealmBrowser /> via Spectron', function() {
           // Assert something about the header
           const headerCells = await app.client.elements(selectors.headerCell);
           // Assert that is has the same number of header cells as it has properties
-          // The cell to add a property only has class __HeaderCellControl
           assert.equal(
             headerCells.value.length,
             Object.keys(schema.properties).length,
@@ -151,11 +149,10 @@ describe('<RealmBrowser /> via Spectron', function() {
 
           // Assert something about the row that was just created
           it('creates a row in the table', async () => {
-            // +1 for the cell below the one that adds a property
             const cells = await app.client.elements(selectors.cell);
             assert.equal(
               cells.value.length,
-              Object.keys(schema.properties).length + 1,
+              Object.keys(schema.properties).length,
             );
           });
 

--- a/styles/variables/_timing.scss
+++ b/styles/variables/_timing.scss
@@ -16,12 +16,4 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-@import "variables/colors";
-@import "variables/fonts";
-@import "variables/sizes";
-@import "variables/timing";
-
-// Core bootstrap (v4.0.0) functions, variables and mixins
-@import "~bootstrap/scss/functions";
-@import "~bootstrap/scss/variables";
-@import "~bootstrap/scss/mixins";
+$fast: 100ms;


### PR DESCRIPTION
This fixes #1007 by transforming the AddColumn column into a button floating on-top-of the table header.

# When the table has a few properties

The button to add a column sticks to the table properties, so it's not alone all the way to the right.

<img width="460" alt="skaermbillede 2018-11-16 kl 09 42 34" src="https://user-images.githubusercontent.com/1243959/48612759-2cbad300-e98a-11e8-9885-d11611b99078.png">

# When the table has a lot of properties

If the user is not scrolled all the way to the right, the button overlays the header.

<img width="460" alt="skaermbillede 2018-11-16 kl 09 42 45" src="https://user-images.githubusercontent.com/1243959/48612793-42c89380-e98a-11e8-9af3-141147eea210.png">

If the user is scrolled all the way to the right, the button hides itself to allow the user to see the entire last column without obstructions.

<img width="460" alt="skaermbillede 2018-11-16 kl 09 42 51" src="https://user-images.githubusercontent.com/1243959/48612836-5ecc3500-e98a-11e8-805e-2c763a8ae095.png">

