### PR TITLE
Upgraded reactstrap and its types

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,7 @@
 - The automatic updating was broken on Windows, to solve this the updater, builder and electron was downgraded to the latest stable versions. ([#1004](https://github.com/realm/realm-studio/pull/1004))
 - When creating an object with a datetime value users were unable to choose an AM time, this got fixed by providing the correct format string to the date to string formatting method used. ([#1005](https://github.com/realm/realm-studio/pull/1005))
 - It was difficult to add property when class had many properties and no objects, this was fixed by transforming the AddColumn column into a button floating on-top-of the table header. ([#1008](https://github.com/realm/realm-studio/pull/1008))
+- Users were unable to scroll the modal dialog after adding an object to list when creating objects, this was fixed in the Reactstrap dependency which got updated. ([#1009](https://github.com/realm/realm-studio/pull/1009))
 
 ## Internal
 - Cleaned up the package.json by using semver instead of compare-versions and moved types to devDependencies. ([#1010](https://github.com/realm/realm-studio/pull/1010))

--- a/package-lock.json
+++ b/package-lock.json
@@ -305,12 +305,13 @@
       }
     },
     "@types/reactstrap": {
-      "version": "5.0.27",
-      "resolved": "https://registry.npmjs.org/@types/reactstrap/-/reactstrap-5.0.27.tgz",
-      "integrity": "sha512-V0xMn5Q4njrDdCqK+MJM6v90eto7ncyfsx4milkFYMCRq97gW+B2tfJ21bd5VM2qlOw+H9a2B3yhmvwsR32Maw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@types/reactstrap/-/reactstrap-6.4.2.tgz",
+      "integrity": "sha512-LPjgD+3BLgeEEJV6GHkktkK3h7XyyP4eeVGn2i6KRQZsdl5WPzYF2LCmxH25l3GZVuNoMbu+a4rkVTZsK+Rbag==",
       "dev": true,
       "requires": {
-        "@types/react": "16.7.6"
+        "@types/react": "16.7.6",
+        "popper.js": "1.14.5"
       }
     },
     "@types/semver": {

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "react-object-inspector": "^0.2.1",
     "react-sortable-hoc": "^0.6.8",
     "react-virtualized": "^9.20.1",
-    "reactstrap": "^6.3.1",
+    "reactstrap": "^6.5.0",
     "realm": "2.19.0",
     "semver": "^5.4.1",
     "uuid": "^3.1.0"
@@ -178,7 +178,7 @@
     "@types/react-dom": "^16.0.5",
     "@types/react-sortable-hoc": "^0.6.0",
     "@types/react-virtualized": "^9.18.7",
-    "@types/reactstrap": "^5.0.26",
+    "@types/reactstrap": "^6.4.2",
     "@types/semver": "^5.5.0",
     "@types/source-map-support": "^0.4.0",
     "@types/tmp": "0.0.33",


### PR DESCRIPTION
This fixes #916 by upgrading to the latest version of Reactstrap. Actually - it was already upgraded in the package-lock.json (because it got regenerated), but this updates the package.json and types as well.