### PR TITLE
Cleaning up the package.json (using semver instead of compare-versions)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,4 +8,4 @@
 - When creating an object with a datetime value users were unable to choose an AM time, this got fixed by providing the correct format string to the date to string formatting method used. ([#1005](https://github.com/realm/realm-studio/pull/1005))
 
 ## Internal
-- None
+- Cleaned up the package.json by using semver instead of compare-versions and moved types to devDependencies. ([#1010](https://github.com/realm/realm-studio/pull/1010))

--- a/package.json
+++ b/package.json
@@ -133,10 +133,8 @@
   },
   "dependencies": {
     "@sentry/electron": "^0.13.0",
-    "@types/compare-versions": "^3.0.0",
     "@types/papaparse": "^4.1.31",
     "classnames": "^2.2.5",
-    "compare-versions": "^3.4.0",
     "electron-store": "^2.0.0",
     "electron-updater": "3.2.3",
     "font-awesome": "^4.7.0",
@@ -158,6 +156,7 @@
     "react-virtualized": "^9.20.1",
     "reactstrap": "^6.3.1",
     "realm": "2.19.0",
+    "semver": "^5.4.1",
     "uuid": "^3.1.0"
   },
   "devDependencies": {
@@ -214,7 +213,6 @@
     "resolve-url-loader": "^2.3.0",
     "sass-lint": "^1.12.1",
     "sass-loader": "^6.0.7",
-    "semver": "^5.4.1",
     "simple-git": "^1.80.1",
     "source-map-support": "^0.5.0",
     "spectron": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
   },
   "dependencies": {
     "@sentry/electron": "^0.13.0",
-    "@types/papaparse": "^4.1.31",
     "classnames": "^2.2.5",
     "electron-store": "^2.0.0",
     "electron-updater": "3.2.3",
@@ -174,6 +173,7 @@
     "@types/mixpanel": "^2.13.0",
     "@types/mocha": "^2.2.43",
     "@types/node": "^8.0.46",
+    "@types/papaparse": "^4.1.31",
     "@types/react": "^16.3.14",
     "@types/react-dom": "^16.0.5",
     "@types/react-sortable-hoc": "^0.6.0",

--- a/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
@@ -104,7 +104,7 @@ export const RealmsTable = ({
         <Column
           label="Data Size"
           dataKey="path"
-          width={100}
+          width={shouldShowRealmSize ? 100 : 0}
           headerRenderer={props => <StateSizeHeader {...props} />}
           cellRenderer={({ cellData }) =>
             renderRealmSize(cellData, 'stateSize', realmSizes)

--- a/src/ui/ServerAdministration/RealmsTable/index.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/index.tsx
@@ -16,12 +16,12 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import * as compareVersions from 'compare-versions';
 import * as electron from 'electron';
 import * as _ from 'lodash';
 import memoize from 'memoize-one';
 import * as React from 'react';
 import * as Realm from 'realm';
+import * as semver from 'semver';
 
 import * as ros from '../../../services/ros';
 import { store } from '../../../store';
@@ -212,7 +212,7 @@ class RealmsTableContainer extends React.PureComponent<
   };
 
   public shouldShowRealmSize = (serverVersion?: string): boolean => {
-    return compareVersions(serverVersion || '0.0.0', '3.13.0') > -1;
+    return semver.gte(serverVersion || '0.0.0', '3.13.0');
   };
 
   public onRealmCreation = async () => {


### PR DESCRIPTION
The package had two dependencies to perform comparison of semantic versions, this PR merges the two, by using the most popular option.