### PR TITLE
Initial application menu update fixed

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,6 +8,7 @@
 - When creating an object with a datetime value users were unable to choose an AM time, this got fixed by providing the correct format string to the date to string formatting method used. ([#1005](https://github.com/realm/realm-studio/pull/1005))
 - It was difficult to add property when class had many properties and no objects, this was fixed by transforming the AddColumn column into a button floating on-top-of the table header. ([#1008](https://github.com/realm/realm-studio/pull/1008))
 - Users were unable to scroll the modal dialog after adding an object to list when creating objects, this was fixed in the Reactstrap dependency which got updated. ([#1009](https://github.com/realm/realm-studio/pull/1009))
+- The top application menu was not updated until the user refocussed the window, this was fixed by rearranging when the menu got updated initially. ([#1011](https://github.com/realm/realm-studio/pull/1011))
 
 ## Internal
 - Cleaned up the package.json by using semver instead of compare-versions and moved types to devDependencies. ([#1010](https://github.com/realm/realm-studio/pull/1010))

--- a/src/windows/WindowComponent.tsx
+++ b/src/windows/WindowComponent.tsx
@@ -73,8 +73,7 @@ export abstract class WindowComponent extends React.Component
       category: 'ui.window',
       message: `Opened '${this.options.type}' window`,
     });
-    // Generate the menu now and whenever the window gets focus
-    this.updateMenu();
+    // Generate the menu whenever the window gets focus
     window.addEventListener('focus', this.onFocussed);
 
     this.CurrentWindow.getComponent().then(CurrentWindowComponent => {
@@ -101,6 +100,8 @@ export abstract class WindowComponent extends React.Component
     if (element && typeof element.generateMenu === 'function') {
       // The window component has a method to generate a menu
       this.menuGenerator = element;
+      // With the menuGenerator present - we can ask for the menu to be updated initially
+      this.updateMenu();
     }
   };
 


### PR DESCRIPTION
This fixes #947 by generating the application menu when menuGenerator is available - instead of component mount.