### PR TITLE
Adding padding to the placeholder text when no schema exists

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,7 +4,7 @@
 - None
 
 ## Fixed
-- None
+- Fixed missing padding in the Realm browsers sidebar when a schema was missing ([#1026](https://github.com/realm/realm-studio/pull/1026))
 
 ## Internals
 - Excluding the unpackaged directories when uploading to S3 (again). ([#1013](https://github.com/realm/realm-studio/pull/1013))

--- a/src/ui/RealmBrowser/LeftSidebar/LeftSidebar.scss
+++ b/src/ui/RealmBrowser/LeftSidebar/LeftSidebar.scss
@@ -57,6 +57,7 @@
       &::before {
         color: $elephant;
         content: "This Realm has no classes defined";
+        padding: $spacer;
         text-align: center;
       }
     }


### PR DESCRIPTION
This fixes an unreported issue with the UI when opening an empty Realm with the browser.