### PR TITLE
Updated the messaging in the greeting window

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,3 +8,4 @@
 
 ## Internals
 - Excluding the unpackaged directories when uploading to S3 (again). ([#1013](https://github.com/realm/realm-studio/pull/1013))
+- Updated the message in the greeting window to include a direct link for signing up via the users webbrowser. ([#1032](https://github.com/realm/realm-studio/pull/1032))

--- a/src/ui/Greeting/HistoryPanel/HistoryPanel.tsx
+++ b/src/ui/Greeting/HistoryPanel/HistoryPanel.tsx
@@ -24,15 +24,13 @@ const Empty = () => (
   <div className="Greeting__HistoryPanel__Empty">
     <p>Welcome to Realm Studio!</p>
     <p>
-      <a
-        href="https://realm.io/blog/realm-cloud-beta-waitlist/"
-        target="_blank"
-      >
-        Realm Cloud
-      </a>{' '}
-      is out of beta:{' '}
+      Sync your data and objects in real-time via Realm Cloud:{' '}
+      <a href="https://cloud.realm.io/login/sign-up" target="_blank">
+        Sign up (free trial)
+      </a>
+      {' or '}
       <a href="https://realm.io/pricing" target="_blank">
-        See options
+        view plans
       </a>
       .
     </p>


### PR DESCRIPTION
This updates the message on the greeting window to include a direct link for sign-up via cloud.realm.io.

![skaermbillede 2018-12-07 kl 11 34 45](https://user-images.githubusercontent.com/1243959/49642718-201f1d00-fa14-11e8-81b6-17936a5de50d.png)
