### PR TITLE
Upgrade Realm JS and change working directory of main process

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,7 +4,7 @@
 - None
 
 ## Fixed
-- None
+- Fixed connecting to a server using an admin token (again). ([#1038](https://github.com/realm/realm-studio/pull/1038), since v3.0.0)
 
 ## Internals
 - None

--- a/package-lock.json
+++ b/package-lock.json
@@ -4871,7 +4871,7 @@
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "resolved": "http://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "requires": {
             "typical": "2.6.1"
@@ -12793,7 +12793,7 @@
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "resolved": "http://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "requires": {
             "typical": "2.6.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4871,7 +4871,7 @@
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "requires": {
             "typical": "2.6.1"
@@ -8091,13 +8091,13 @@
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "requires": {
         "safe-buffer": "5.1.2",
-        "yallist": "3.0.2"
+        "yallist": "3.0.3"
       }
     },
     "minizlib": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.1.tgz",
-      "integrity": "sha512-TrfjCjk4jLhcJyGMYymBH6oTXcWjYbUAXTHDbtnWHjZC25h0cdajHuPE1zxb4DVmu8crfh+HwH/WMuyLG0nHBg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.0.tgz",
+      "integrity": "sha512-vQhkoouK/oKRVuFJynustmW3wrqZEXOrfbVVirvOVeglH4TNvIkcqiyojlIbbZYYDJZSbEKEXmDudg+tyRkm6g==",
       "requires": {
         "minipass": "2.3.5"
       }
@@ -10792,9 +10792,9 @@
       }
     },
     "realm": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-2.19.1.tgz",
-      "integrity": "sha512-bW6U09BhJ6ikGcEs0h9QzbwqpbzRBV0l4Vor1liu1hb2rGv5OGbbvOv8ASXZGVXNCKqoifok3g67TSGSMtqR9Q==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-2.21.0.tgz",
+      "integrity": "sha512-2XxkVogKOObhwBUcP7NPvyA9kU/HIeopVbAGgKanJWYw5z09J+I+q1CN2gCVR5EC4+H55Ht4loEhjDud5+LEYQ==",
       "requires": {
         "command-line-args": "4.0.7",
         "decompress": "4.2.0",
@@ -12719,10 +12719,10 @@
         "chownr": "1.1.1",
         "fs-minipass": "1.2.5",
         "minipass": "2.3.5",
-        "minizlib": "1.1.1",
+        "minizlib": "1.2.0",
         "mkdirp": "0.5.1",
         "safe-buffer": "5.1.2",
-        "yallist": "3.0.2"
+        "yallist": "3.0.3"
       }
     },
     "tar-fs": {
@@ -12793,7 +12793,7 @@
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "requires": {
             "typical": "2.6.1"
@@ -14448,9 +14448,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     },
     "yargs": {
       "version": "12.0.2",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "react-sortable-hoc": "^0.6.8",
     "react-virtualized": "^9.20.1",
     "reactstrap": "^6.5.0",
-    "realm": "2.19.1",
+    "realm": "2.21.0",
     "semver": "^5.4.1",
     "uuid": "^3.1.0"
   },

--- a/src/actions/transports/MainTransport.ts
+++ b/src/actions/transports/MainTransport.ts
@@ -43,12 +43,17 @@ export class MainTransport extends Transport {
   }
 
   public sendResponse(requestId: string, result: any, success: boolean) {
-    this.webContents.send(
-      Transport.RESPONSE_EVENT_NAME,
-      requestId,
-      result,
-      success,
-    );
+    if (this.webContents.isDestroyed) {
+      // tslint:disable-next-line:no-console
+      console.info(`Skipped responding to a distroyed window (${requestId})`);
+    } else {
+      this.webContents.send(
+        Transport.RESPONSE_EVENT_NAME,
+        requestId,
+        result,
+        success,
+      );
+    }
   }
 
   private onRequestMessage = (

--- a/src/actions/transports/MainTransport.ts
+++ b/src/actions/transports/MainTransport.ts
@@ -43,7 +43,7 @@ export class MainTransport extends Transport {
   }
 
   public sendResponse(requestId: string, result: any, success: boolean) {
-    if (this.webContents.isDestroyed) {
+    if (this.webContents.isDestroyed()) {
       // tslint:disable-next-line:no-console
       console.info(`Skipped responding to a distroyed window (${requestId})`);
     } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,8 @@
 process.env.REALM_DISABLE_ANALYTICS = 'true';
 
 import './sentry';
+import { changeMainProcessDirectory } from './utils/process-directories';
+changeMainProcessDirectory();
 
 import { app } from 'electron';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,8 +21,8 @@
 process.env.REALM_DISABLE_ANALYTICS = 'true';
 
 import './sentry';
-import { changeMainProcessDirectory } from './utils/process-directories';
-changeMainProcessDirectory();
+// This is needed to prevent Realm JS from writing to directories it doesn't have access to
+import './utils/process-directories';
 
 import { app } from 'electron';
 

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -21,26 +21,10 @@ import './services/mixpanel';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-import { changeRendererProcessDirectory } from './utils/process-directories';
+// This is needed to prevent Realm JS from writing to directories it doesn't have access to
+import './utils/process-directories';
 
 const isDevelopment = process.env.NODE_ENV === 'development';
-
-let windowType = 'unknown';
-try {
-  if (document.location !== null) {
-    const params = new URL(document.location.href).searchParams.get('options');
-    if (params !== null) {
-      const deserialized = JSON.parse(params) as { type: string };
-      if (deserialized.type) {
-        windowType = deserialized.type;
-      }
-    }
-  }
-} catch {
-  // Just ignore
-}
-
-changeRendererProcessDirectory(windowType);
 
 // Don't report Realm JS analytics data
 // @see https://github.com/realm/realm-js/blob/master/lib/submit-analytics.js#L28

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -18,11 +18,10 @@
 
 import './services/mixpanel';
 
-import * as electron from 'electron';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-import { changeRendererProcessDirectory } from './utils/renderer-process-directory';
+import { changeRendererProcessDirectory } from './utils/process-directories';
 
 const isDevelopment = process.env.NODE_ENV === 'development';
 

--- a/src/services/ros/realms.ts
+++ b/src/services/ros/realms.ts
@@ -40,7 +40,7 @@ export interface IRealmToLoad {
 
 export interface ISyncedRealmToLoad extends IRealmToLoad {
   mode: RealmLoadingMode.Synced;
-  user: Realm.Sync.SerializedUser;
+  user: Realm.Sync.SerializedUser | Realm.Sync.SerializedTokenUser;
   validateCertificates: boolean;
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -21,7 +21,7 @@ export * from './timeout';
 export * from './wait';
 export * from './range';
 export * from './promise-handle';
-export * from './renderer-process-directory';
+export * from './process-directories';
 export * from './pretty-bytes';
 
 import * as menu from './menu';

--- a/src/utils/process-directories.ts
+++ b/src/utils/process-directories.ts
@@ -19,36 +19,46 @@
 import * as assert from 'assert';
 import * as electron from 'electron';
 import * as fs from 'fs-extra';
-import * as path from 'path';
+import { resolve } from 'path';
 
 const app = electron.app || electron.remote.app;
 const userDataPath = app.getPath('userData');
 const rendererPattern = /^renderer-.+$/;
 
-export const changeRendererProcessDirectory = (type: string) => {
+function changeProcessDirectory(relativePath: string) {
+  const path = resolve(userDataPath, relativePath);
+  // Remove the directory if it already exists
+  if (!fs.existsSync(path)) {
+    // Create the directory
+    fs.mkdirSync(path);
+  }
+  // Change to it
+  process.chdir(path);
+}
+
+export function changeRendererProcessDirectory(type: string) {
   assert.equal(
     process.type,
     'renderer',
     'This should only be called from a renderer process',
   );
-  // Get the process dir
-  const processDir = path.resolve(userDataPath, `renderer-${type}`);
-  // Remove the directory if it already exists
-  if (!fs.existsSync(processDir)) {
-    // Create the directory
-    fs.mkdirSync(processDir);
-  }
+  return changeProcessDirectory(`renderer-${type}`);
+}
 
-  // Change to it
-  process.chdir(processDir);
-};
+export function changeMainProcessDirectory() {
+  assert.equal(
+    process.type,
+    'browser',
+    'This should only be called from a main process',
+  );
+  return changeProcessDirectory(`main`);
+}
 
-export const removeRendererDirectories = () => {
+export function removeRendererDirectories() {
   const directories = fs
     .readdirSync(userDataPath)
     .filter(name => rendererPattern.test(name))
-    .map(name => path.resolve(userDataPath, name))
+    .map(name => resolve(userDataPath, name))
     .map(directory => fs.remove(directory));
-
   return Promise.all(directories);
-};
+}

--- a/src/windows/ServerAdministrationWindow.tsx
+++ b/src/windows/ServerAdministrationWindow.tsx
@@ -19,7 +19,7 @@
 import { IWindow } from './Window';
 
 export interface IServerAdministrationWindowProps {
-  user: Realm.Sync.SerializedUser;
+  user: Realm.Sync.SerializedUser | Realm.Sync.SerializedTokenUser;
   isCloudTenant?: boolean;
   validateCertificates: boolean;
 }

--- a/src/windows/WindowComponent.tsx
+++ b/src/windows/WindowComponent.tsx
@@ -23,7 +23,6 @@ if (process.type === 'browser') {
 
 import * as sentry from '@sentry/electron';
 import { remote } from 'electron';
-import * as querystring from 'querystring';
 import * as React from 'react';
 
 import { mixpanel } from '../services/mixpanel';
@@ -35,7 +34,7 @@ import {
 } from './MenuGenerator';
 import { SentryErrorBoundary } from './SentryErrorBoundary';
 import { getWindowClass, InnerWindowComponent } from './Window';
-import { WindowOptions, WindowType } from './WindowOptions';
+import { getWindowOptions, WindowType } from './WindowOptions';
 
 // TODO: Consider if we can have the window not show before a connection has been established.
 
@@ -43,17 +42,6 @@ interface ITrackedProperties {
   type: WindowType;
   [name: string]: string;
 }
-
-const getWindowOptions = (): WindowOptions => {
-  // Strip away the "?" of the location.search
-  const queryString = location.search.substr(1);
-  const query = querystring.parse<{ options?: string }>(queryString);
-  if (query && typeof query.options === 'string') {
-    return JSON.parse(query.options);
-  } else {
-    throw new Error('Expected "options" in the query parameters');
-  }
-};
 
 export abstract class WindowComponent extends React.Component
   implements IMenuGeneratorProps {

--- a/src/windows/WindowOptions.ts
+++ b/src/windows/WindowOptions.ts
@@ -16,6 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import * as qs from 'querystring';
+
 import {
   ICloudAuthenticationWindowProps,
   IConnectToServerWindowProps,
@@ -71,3 +73,14 @@ export type WindowOptions =
   | IGreetingWindowOptions
   | IRealmBrowserWindowOptions
   | IServerAdministrationWindowOptions;
+
+export function getWindowOptions(): WindowOptions {
+  // Strip away the "?" of the location.search
+  const queryString = location.search.substr(1);
+  const query = qs.parse<{ options?: string }>(queryString);
+  if (query && typeof query.options === 'string') {
+    return JSON.parse(query.options);
+  } else {
+    throw new Error('Expected "options" in the query parameters');
+  }
+}


### PR DESCRIPTION
This (re)upgrades Realm JS to 2.21.0 containing the fix for (de)serialization of an admin token user, fixing #1030. It also ensures that the main process change directory to a folder to where it has write access before requiring Realm JS to ensure Studio doesn't crash.