### PR TITLE
Fixed text rendering on windows

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,7 +4,7 @@
 - Adding in-app messages from Realm to the Greeting window. ([#1056](https://github.com/realm/realm-studio/pull/1056))
 
 ## Fixed
-- None
+- Fixed text rendering issue resulting in clipping of property name and types in the header of the browser window. It was only observed on Windows with high pixel density displays. ([#1059](https://github.com/realm/realm-studio/pull/1059), since v1.0.0)
 
 ## Internals
 - Fixed the Dockerfile used when testing PRs. ([#1057](https://github.com/realm/realm-studio/pull/1057))

--- a/src/ui/RealmBrowser/RealmBrowser.scss
+++ b/src/ui/RealmBrowser/RealmBrowser.scss
@@ -175,7 +175,7 @@
       display: flex;
       flex-direction: column;
       justify-content: center;
-      line-height: 1rem;
+      line-height: 1.2rem;
       overflow: hidden;
       text-overflow: ellipsis;
     }


### PR DESCRIPTION
This fixes #1052 by changing the line height of the property name and type.

## Before

Notice the clipping of the g in "string".

<img width="508" alt="skaermbillede 2018-12-28 kl 13 13 38" src="https://user-images.githubusercontent.com/1243959/50515521-87753d80-0aa5-11e9-9147-28ed53e252d9.png">

## After
<img width="510" alt="skaermbillede 2018-12-28 kl 13 28 16" src="https://user-images.githubusercontent.com/1243959/50515527-90660f00-0aa5-11e9-8c96-96f6054dc9b4.png">
