### PR TITLE
Resize sidebars only while opened

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,6 +5,7 @@
 
 ## Fixed
 - Fixed text rendering issue resulting in clipping of property name and types in the header of the browser window. It was only observed on Windows with high pixel density displays. ([#1059](https://github.com/realm/realm-studio/pull/1059), since v1.0.0)
+- Fixed an issue where sidebars got resized when a window got resized despite the sidebar being collapsed. ([#1060](https://github.com/realm/realm-studio/pull/1060), since v2.7.0)
 
 ## Internals
 - Fixed the Dockerfile used when testing PRs. ([#1057](https://github.com/realm/realm-studio/pull/1057))

--- a/src/ui/reusable/Sidebar/index.tsx
+++ b/src/ui/reusable/Sidebar/index.tsx
@@ -125,7 +125,7 @@ class SidebarContainer extends React.Component<
 
   private onWindowResize = (e: Event) => {
     // When a window got resized, the width of the sidebar might have been reduced
-    if (this.outerElement) {
+    if (this.outerElement && this.props.isOpen) {
       const rect = this.outerElement.getBoundingClientRect();
       // The window was resized to a point where the Sidebar could no longer maintain its width
       if (rect.width < this.state.width) {


### PR DESCRIPTION
This fixes #992 by checking that the sidebar is open before acting on window resizing.