### PR TITLE
Better error dialogs

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,7 @@
 
 ## Enhancements
 - Adding in-app messages from Realm to the Greeting window. ([#1056](https://github.com/realm/realm-studio/pull/1056))
+- Error dialogs now clearly separates the failed intent and the message from the throw exception. ([#1061](https://github.com/realm/realm-studio/pull/1061))
 
 ## Fixed
 - Fixed text rendering issue resulting in clipping of property name and types in the header of the browser window. It was only observed on Windows with high pixel density displays. ([#1059](https://github.com/realm/realm-studio/pull/1059), since v1.0.0)

--- a/src/ui/reusable/errors.ts
+++ b/src/ui/reusable/errors.ts
@@ -39,7 +39,8 @@ export const showError = (
   const messageOptions = {
     type: 'error',
     // Prepend the intent
-    message: message.length > 0 ? `${failedIntent}:\n${message}` : failedIntent,
+    message: failedIntent,
+    detail: message,
     title: failedIntent,
   };
   // Tell Sentry about this error

--- a/src/ui/reusable/errors.ts
+++ b/src/ui/reusable/errors.ts
@@ -46,9 +46,11 @@ export const showError = (
   // Tell Sentry about this error
   sentry.captureEvent({
     level: sentry.Severity.Debug,
-    // We don't want the message to wrap to the next line when reporting this to Sentry
-    message: message.length > 0 ? `${failedIntent}: ${message}` : failedIntent,
+    // Using the failedIntent as message to get more similar messages
+    message: failedIntent,
     tags: { type: 'user-error' },
+    // Sending along the message as extra context
+    extra: { message },
   });
   // Show a message box ...
   if (process.type === 'renderer') {


### PR DESCRIPTION
This improves the error dialog to provide a clear separation between failed intent and message from the exception thrown. It should also unify more user events on Sentry as these will now only have a message consisting of the failed intent.

## Before

![skaermbillede 2019-01-02 kl 09 56 05](https://user-images.githubusercontent.com/1243959/50585317-a9d7d400-0e74-11e9-9956-3f3da8dff03e.png)

## After

![skaermbillede 2019-01-02 kl 09 54 28](https://user-images.githubusercontent.com/1243959/50585320-ad6b5b00-0e74-11e9-873f-8bb033bccdda.png)

Disregard the icon being the generic Electron icon.
