### PR TITLE
Read-Only partial realms

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -11,3 +11,4 @@
 ## Internals
 - Fixed the Dockerfile used when testing PRs. ([#1057](https://github.com/realm/realm-studio/pull/1057))
 - Removing all existing and future unused locals. ([#1058](https://github.com/realm/realm-studio/pull/1058))
+- Ensuring users open partial Realms in a read-only mode. ([#1062](https://github.com/realm/realm-studio/pull/1062))

--- a/src/ui/RealmBrowser/Content/index.tsx
+++ b/src/ui/RealmBrowser/Content/index.tsx
@@ -130,7 +130,7 @@ export interface IReadWriteContentContainerProps
   onCommitTransaction: () => void;
   onRealmChanged: () => void;
   permissionSidebar: boolean;
-  readOnly: false;
+  readOnly: boolean;
   realm: Realm;
 }
 

--- a/src/ui/RealmBrowser/LeftSidebar/LeftSidebar.scss
+++ b/src/ui/RealmBrowser/LeftSidebar/LeftSidebar.scss
@@ -25,10 +25,11 @@
   padding-bottom: 0;
 
   &__Header {
-    align-items: baseline;
+    align-items: center;
     border-bottom: 1px solid $dove;
     color: $elephant;
     display: flex;
+    flex-basis: 2.5rem;
     flex-shrink: 0;
     font-size: .9rem;
     font-weight: bold;
@@ -159,10 +160,11 @@
     }
   }
 
-  &__HiddenClassesHint {
+  &__HiddenClassesHint,
+  &__ReadOnlyHint {
     color: $elephant;
     font-size: .75rem;
-    margin: 0 ($spacer / 2);
+    margin: $spacer / 2;
     overflow: hidden;
     text-align: center;
     text-overflow: ellipsis;

--- a/src/ui/RealmBrowser/LeftSidebar/LeftSidebar.tsx
+++ b/src/ui/RealmBrowser/LeftSidebar/LeftSidebar.tsx
@@ -48,6 +48,7 @@ export interface ILeftSidebarProps {
   onClassFocussed: ClassFocussedHandler;
   onToggle: () => void;
   progress: ILoadingProgress;
+  readOnly: boolean;
   toggleAddClass: () => void;
 }
 
@@ -61,6 +62,7 @@ export const LeftSidebar = ({
   onClassFocussed,
   onToggle,
   progress,
+  readOnly,
   toggleAddClass,
 }: ILeftSidebarProps) => (
   <Sidebar
@@ -73,9 +75,11 @@ export const LeftSidebar = ({
   >
     <div className="LeftSidebar__Header">
       <span>Classes</span>
-      <Button size="sm" onClick={toggleAddClass}>
-        <i className="fa fa-plus" />
-      </Button>
+      {readOnly ? null : (
+        <Button size="sm" onClick={toggleAddClass}>
+          <i className="fa fa-plus" />
+        </Button>
+      )}
     </div>
     <div className="LeftSidebar__Classes">
       {classes && classes.length > 0 ? (
@@ -121,6 +125,9 @@ export const LeftSidebar = ({
         <p className="LeftSidebar__HiddenClassesHint">
           Hiding {hiddenClassCount} system classes
         </p>
+      ) : null}
+      {readOnly ? (
+        <p className="LeftSidebar__ReadOnlyHint">Opened as "Read Only"</p>
       ) : null}
     </div>
   </Sidebar>

--- a/src/ui/RealmBrowser/LeftSidebar/index.tsx
+++ b/src/ui/RealmBrowser/LeftSidebar/index.tsx
@@ -38,6 +38,7 @@ interface ILeftSidebarContainerProps {
   onClassFocussed: ClassFocussedHandler;
   onToggle: () => void;
   progress: ILoadingProgress;
+  readOnly?: boolean;
   toggleAddClass: () => void;
 }
 
@@ -85,6 +86,7 @@ class LeftSidebarContainer extends React.Component<
         onClassFocussed={this.props.onClassFocussed}
         onToggle={this.props.onToggle}
         progress={this.props.progress}
+        readOnly={this.props.readOnly || false}
         toggleAddClass={this.props.toggleAddClass}
       />
     );

--- a/src/ui/RealmBrowser/RealmBrowser.tsx
+++ b/src/ui/RealmBrowser/RealmBrowser.tsx
@@ -108,6 +108,7 @@ export const RealmBrowser = ({
         onToggle={onLeftSidebarToggle}
         progress={progress}
         toggleAddClass={toggleAddClass}
+        readOnly={editMode === EditMode.Disabled}
       />
 
       <div className="RealmBrowser__Wrapper">
@@ -128,7 +129,7 @@ export const RealmBrowser = ({
             onRealmChanged={onRealmChanged}
             permissionSidebar={true}
             progress={progress}
-            readOnly={false}
+            readOnly={editMode === EditMode.Disabled}
             realm={realm}
             ref={contentRef}
           />

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -284,10 +284,6 @@ class RealmBrowserContainer
       throw new Error('onRealmLoaded was called without a realm sat');
     }
     if (this.props.readOnly) {
-      // Pause the sync session
-      if (this.realm.syncSession) {
-        this.realm.syncSession.pause();
-      }
       // Monkey-patch the write function to ensure no-one writes to the Realm
       this.realm.write = () => {
         throw new Error('Realm was opened as read-only');

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -123,7 +123,7 @@ class RealmBrowserContainer
         contentRef={this.contentRef}
         dataVersion={this.state.dataVersion}
         dataVersionAtBeginning={this.state.dataVersionAtBeginning}
-        editMode={this.state.editMode}
+        editMode={this.props.readOnly ? EditMode.Disabled : this.state.editMode}
         focus={this.state.focus}
         getClassFocus={this.getClassFocus}
         getSchemaLength={this.getSchemaLength}
@@ -282,6 +282,16 @@ class RealmBrowserContainer
   protected onRealmLoaded = () => {
     if (!this.realm) {
       throw new Error('onRealmLoaded was called without a realm sat');
+    }
+    if (this.props.readOnly) {
+      // Pause the sync session
+      if (this.realm.syncSession) {
+        this.realm.syncSession.pause();
+      }
+      // Monkey-patch the write function to ensure no-one writes to the Realm
+      this.realm.write = () => {
+        throw new Error('Realm was opened as read-only');
+      };
     }
     const firstSchemaName =
       this.realm.schema.length > 0 ? this.realm.schema[0].name : undefined;

--- a/src/windows/RealmBrowserWindow.tsx
+++ b/src/windows/RealmBrowserWindow.tsx
@@ -25,6 +25,7 @@ import { IWindow } from './Window';
 
 export interface IRealmBrowserWindowProps {
   realm: RealmToLoad;
+  readOnly?: boolean;
   import?: {
     format: ImportFormat;
     paths: string[];


### PR DESCRIPTION
This fixes #1031 by adding a warning when opening partial Realms from the server and opening the browser in a "Read-Only" mode where no classes, properties nor objects can be created, the permissions sidebar and editing data is disabled. If for some reason some UI is not disabled correctly it also monkey-patches the `write` method of the Realm to ensure nothing writes to it.

## Dialog

![skaermbillede 2019-01-02 kl 10 26 39](https://user-images.githubusercontent.com/1243959/50587908-0a204300-0e80-11e9-9f22-7fa45f67eec5.png)

Note how the user can choose to not show this warning again.

## The browser opening a partial Realm in read-only mode

![skaermbillede 2019-01-02 kl 11 10 12](https://user-images.githubusercontent.com/1243959/50587931-2328f400-0e80-11e9-81a7-e3ccf78d5413.png)

Note the hint in the left sidebar, telling the user that it's: Opened as "Read Only"