### PR TITLE
Refactoring singleton windows

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -12,3 +12,4 @@
 ## Internals
 - Fixed the Dockerfile used when testing PRs. ([#1057](https://github.com/realm/realm-studio/pull/1057))
 - Removing all existing and future unused locals. ([#1058](https://github.com/realm/realm-studio/pull/1058))
+- Refactored singleton windows. ([#1066](https://github.com/realm/realm-studio/pull/1066))

--- a/src/windows/RealmBrowserWindow.tsx
+++ b/src/windows/RealmBrowserWindow.tsx
@@ -19,7 +19,11 @@
 import { URL } from 'url';
 
 import { ImportFormat } from '../services/data-importer';
-import { ISyncedRealmToLoad, RealmToLoad } from '../utils/realms';
+import {
+  ISyncedRealmToLoad,
+  RealmLoadingMode,
+  RealmToLoad,
+} from '../utils/realms';
 
 import { IWindow } from './Window';
 
@@ -57,6 +61,14 @@ export const RealmBrowserWindow: IWindow = {
       // TODO: Fix the props for this to include a type
       m => m.RealmBrowser as any,
     ),
+  getSingletonKey: (props: IRealmBrowserWindowProps) => {
+    const { realm } = props;
+    if (realm.mode === RealmLoadingMode.Synced) {
+      return `${realm.user.server}:${realm.path}`;
+    } else {
+      return realm.path;
+    }
+  },
   getTrackedProperties: (props: IRealmBrowserWindowProps) => ({
     mode: props.realm.mode,
   }),

--- a/src/windows/ServerAdministrationWindow.tsx
+++ b/src/windows/ServerAdministrationWindow.tsx
@@ -40,6 +40,8 @@ export const ServerAdministrationWindow: IWindow = {
       // TODO: Fix the props for this to include a type
       m => m.ServerAdministration as any,
     ),
+  getSingletonKey: (props: IServerAdministrationWindowProps) =>
+    props.user.server,
   getTrackedProperties: (props: IServerAdministrationWindowProps) => ({
     url: props.user.server,
   }),

--- a/src/windows/Window.tsx
+++ b/src/windows/Window.tsx
@@ -29,6 +29,7 @@ export interface IWindow {
   getWindowOptions(
     props: WindowProps,
   ): Partial<Electron.BrowserWindowConstructorOptions>;
+  getSingletonKey?(props: WindowProps): string | undefined;
   getTrackedProperties(props: WindowProps): { [key: string]: string };
 }
 
@@ -71,4 +72,14 @@ export function getWindowOptions({
 }: WindowOptions): IWindowConstructorOptions {
   const WindowClass = getWindowClass(type);
   return WindowClass.getWindowOptions(props);
+}
+
+export function getSingletonKey({
+  type,
+  props,
+}: WindowOptions): string | undefined {
+  const WindowClass = getWindowClass(type);
+  return WindowClass.getSingletonKey
+    ? WindowClass.getSingletonKey(props)
+    : undefined;
 }


### PR DESCRIPTION
This moves generating singleton keys (known as `uniqueId` before) into the individual window types to make the window manager less aware of the individual types of windows.