### PR TITLE
Fixing "Open in Studio"

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,11 +1,14 @@
 [Changes since {PREVIOUS_VERSION}](https://github.com/realm/realm-studio/compare/{PREVIOUS_VERSION}...{CURRENT_VERSION})
 
 ## Enhancements
+
 - None
 
 ## Fixed
-- None
+
+- Clicking "Open in Studio" on the Realm Cloud frontend, no longer yields an error. ([#1098](https://github.com/realm/realm-studio/pull/1098))
 
 ## Internals
+
 - Added a post-package test to ensure auto-updating functions. ([#1095](https://github.com/realm/realm-studio/pull/1095))
 - Updated all dependencies, including Electron to v4 and Realm JS to v2.23.0. ([#1095](https://github.com/realm/realm-studio/pull/1095))

--- a/configs/webpack.main.js
+++ b/configs/webpack.main.js
@@ -9,48 +9,52 @@ module.exports = (env, argv) => {
   const baseConfig = require('./webpack.base.js')(env, argv);
 
   return merge(baseConfig, {
-    devServer: isDevelopment ? {
-      hot: true,
-      inline: true
-    } : {},
-    entry: isDevelopment ? [
-      'webpack/hot/poll?1000',
-      './src/main.ts'
-    ] : [
-      './src/main.ts',
-    ],
+    devServer: isDevelopment
+      ? {
+          hot: true,
+          inline: true,
+        }
+      : {},
+    entry: isDevelopment
+      ? ['webpack/hot/poll?1000', './src/main.ts']
+      : ['./src/main.ts'],
     module: {
       rules: [
         {
           test: /\.tsx?$/,
-          use: 'awesome-typescript-loader'
-        }, {
+          use: 'awesome-typescript-loader',
+        },
+        {
           test: /\.html$/,
-          use: 'file-loader'
-        }, {
+          use: 'file-loader',
+        },
+        {
           test: /\.(scss|svg|png)$/,
-          use: 'null-loader'
-        }, {
+          use: 'null-loader',
+        },
+        {
           test: /\.md$/,
-          use: 'file-loader'
-        }
-      ]
+          use: 'file-loader',
+        },
+      ],
     },
     output: {
       filename: 'main.bundle.js',
       // See https://github.com/webpack/hot-node-example#real-app
-      libraryTarget: 'commonjs2'
+      libraryTarget: 'commonjs2',
     },
     plugins: [
       // Prevent the windows from loading the UI components
       new webpack.IgnorePlugin(/\/ui/, /\/src\/windows$/),
-      // Prevent the main bundle from requiring Realm JS, as this does not 
-      new webpack.IgnorePlugin(/realm$/),
-    ].concat(isDevelopment ? [
-      new Visualizer({
-        filename: './main.statistics.html',
-      }),
-    ] : []),
+    ].concat(
+      isDevelopment
+        ? [
+            new Visualizer({
+              filename: './main.statistics.html',
+            }),
+          ]
+        : []
+    ),
     target: 'electron-main',
     watch: isDevelopment,
   });

--- a/src/services/ros/users.ts
+++ b/src/services/ros/users.ts
@@ -16,6 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import * as Realm from 'realm';
+
 import { IServerCredentials } from '.';
 
 export const authenticate = async (


### PR DESCRIPTION
This PR removes the ignoring of Realm JS when imported into the main process, because it's convenient to have access to the authentication methods.