### PR TITLE
Visual feedback when filtering in the browser fails

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-- None
+- Adding visual feedback when a query in the Realm Browser fails to parse. ([#1100](https://github.com/realm/realm-studio/pull/1100))
 
 ## Fixed
 

--- a/src/ui/RealmBrowser/Content/Content.tsx
+++ b/src/ui/RealmBrowser/Content/Content.tsx
@@ -78,6 +78,7 @@ interface IBaseContentProps {
   onResetHighlight: () => void;
   onSortingChange: SortingChangeHandler;
   query: string;
+  queryError?: Error | undefined;
   sorting?: ISorting;
 }
 
@@ -127,6 +128,7 @@ export const Content = ({
   onRowMouseDown,
   onSortingChange,
   query,
+  queryError,
   sorting,
   ...props
 }: IContentProps) =>
@@ -142,6 +144,7 @@ export const Content = ({
         onQueryChange={onQueryChange}
         onQueryHelp={onQueryHelp}
         query={query}
+        queryError={queryError}
         readOnly={props.readOnly}
       />
 

--- a/src/ui/RealmBrowser/Content/TopBar.tsx
+++ b/src/ui/RealmBrowser/Content/TopBar.tsx
@@ -30,6 +30,7 @@ interface ITopBarProps {
   onQueryChange: QueryChangeHandler;
   onQueryHelp: () => void;
   query: string;
+  queryError: Error | undefined;
   readOnly: boolean;
 }
 
@@ -39,6 +40,7 @@ export const TopBar = ({
   onQueryChange,
   onQueryHelp,
   query,
+  queryError,
   readOnly,
 }: ITopBarProps) => {
   const className = getClassName(focus);
@@ -49,6 +51,7 @@ export const TopBar = ({
         onQueryChange={onQueryChange}
         onQueryHelp={onQueryHelp}
         query={query}
+        queryError={queryError}
         placeholder="Enter a query to filter the list"
       />
       {!readOnly ? (

--- a/src/ui/reusable/QuerySearch/QuerySearch.tsx
+++ b/src/ui/reusable/QuerySearch/QuerySearch.tsx
@@ -17,22 +17,41 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import * as React from 'react';
-import { Button, Input, InputGroup, InputGroupAddon } from 'reactstrap';
+import {
+  Button,
+  Input,
+  InputGroup,
+  InputGroupAddon,
+  Popover,
+  PopoverBody,
+} from 'reactstrap';
 
 export interface IQuerySearchProps {
   onQueryChange: (query: string) => void;
   onQueryHelp?: () => void;
+  onQueryBlur?: React.EventHandler<React.FocusEvent>;
+  onQueryFocus?: React.EventHandler<React.FocusEvent>;
   query: string;
+  queryError?: Error;
   placeholder: string;
   className?: string;
+  inputRef: (inputElement: HTMLInputElement) => void;
+  inputElement: HTMLElement | undefined;
+  isPopoverOpen: boolean;
 }
 
 export const QuerySearch = ({
   onQueryChange,
   onQueryHelp,
+  onQueryBlur,
+  onQueryFocus,
   query,
+  queryError,
   placeholder,
   className,
+  inputRef,
+  inputElement,
+  isPopoverOpen,
 }: IQuerySearchProps) => (
   <section className={className}>
     <InputGroup size="sm">
@@ -40,8 +59,12 @@ export const QuerySearch = ({
         onChange={e => {
           onQueryChange(e.target.value);
         }}
+        onFocus={onQueryFocus}
+        onBlur={onQueryBlur}
         placeholder={placeholder}
         value={query}
+        invalid={!!queryError}
+        innerRef={inputRef}
       />
       {onQueryHelp && (
         <InputGroupAddon addonType="append">
@@ -51,5 +74,15 @@ export const QuerySearch = ({
         </InputGroupAddon>
       )}
     </InputGroup>
+    {inputElement && (
+      <Popover
+        isOpen={!!queryError && isPopoverOpen}
+        target={inputElement}
+        placement="bottom-start"
+        hideArrow={true}
+      >
+        <PopoverBody>{queryError ? queryError.message : null}</PopoverBody>
+      </Popover>
+    )}
   </section>
 );

--- a/src/ui/reusable/QuerySearch/index.tsx
+++ b/src/ui/reusable/QuerySearch/index.tsx
@@ -1,0 +1,76 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import * as React from 'react';
+
+import { QuerySearch } from './QuerySearch';
+
+export interface IQuerySearchContainerProps {
+  onQueryChange: (query: string) => void;
+  onQueryHelp?: () => void;
+  query: string;
+  queryError?: Error;
+  placeholder: string;
+  className?: string;
+}
+
+interface IQuerySearchContainerState {
+  inputElement?: HTMLInputElement;
+  isPopoverOpen: boolean;
+}
+
+class QuerySearchContainer extends React.Component<
+  IQuerySearchContainerProps,
+  IQuerySearchContainerState
+> {
+  public state: IQuerySearchContainerState = {
+    isPopoverOpen: false,
+  };
+
+  public render() {
+    return (
+      <QuerySearch
+        className={this.props.className}
+        onQueryChange={this.props.onQueryChange}
+        onQueryHelp={this.props.onQueryHelp}
+        onQueryFocus={this.onQueryFocus}
+        onQueryBlur={this.onQueryBlur}
+        query={this.props.query}
+        queryError={this.props.queryError}
+        placeholder={this.props.placeholder}
+        inputRef={this.inputRef}
+        inputElement={this.state.inputElement}
+        isPopoverOpen={this.state.isPopoverOpen}
+      />
+    );
+  }
+
+  private inputRef = (inputElement: HTMLInputElement) => {
+    this.setState({ inputElement });
+  };
+
+  private onQueryFocus = () => {
+    this.setState({ isPopoverOpen: true });
+  };
+
+  private onQueryBlur = () => {
+    this.setState({ isPopoverOpen: false });
+  };
+}
+
+export { QuerySearchContainer as QuerySearch };


### PR DESCRIPTION
This fixes #210 by adding some visual feedback when calling `filtered` on the collection throws an error

<img width="1160" alt="skaermbillede 2019-02-20 kl 12 18 23" src="https://user-images.githubusercontent.com/1243959/53089567-3ade3980-350d-11e9-98e0-12fc9712cd6d.png">
