### PR TITLE
Column resizing fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [Changes since v3.2.0](https://github.com/realm/realm-studio/compare/v3.2.0...v3.3.0)
 
 ### Enhancements
+
 - Adding in-app messages from Realm to the Greeting window. ([#1056](https://github.com/realm/realm-studio/pull/1056))
 - Error dialogs now clearly separates the failed intent and the message from the throw exception. ([#1061](https://github.com/realm/realm-studio/pull/1061))
 
 ### Fixed
+
 - Fixed text rendering issue resulting in clipping of property name and types in the header of the browser window. It was only observed on Windows with high pixel density displays. ([#1059](https://github.com/realm/realm-studio/pull/1059), since v1.0.0)
 - Fixed an issue where sidebars got resized when a window got resized despite the sidebar being collapsed. ([#1060](https://github.com/realm/realm-studio/pull/1060), since v2.7.0)
 - Fixed potential issues from writing to partial Realms by opening them in a read-only mode. ([#1062](https://github.com/realm/realm-studio/pull/1062) & [#1063](https://github.com/realm/realm-studio/pull/1063), since v1.0.0)
 - Fixed the error shown when connecting to a Realm Cloud instance with an expired token. ([#1067](https://github.com/realm/realm-studio/pull/1067), since v1.18.1)
 
 ### Internals
+
 - Fixed the Dockerfile used when testing PRs. ([#1057](https://github.com/realm/realm-studio/pull/1057))
 - Removing all existing and future unused locals. ([#1058](https://github.com/realm/realm-studio/pull/1058))
 - Refactored singleton windows. ([#1066](https://github.com/realm/realm-studio/pull/1066))
 - Refactored the Jenkins CI pipeline. ([#1069](https://github.com/realm/realm-studio/pull/1069) & [#1073](https://github.com/realm/realm-studio/pull/1073))
-
 
 ## Release 3.2.0 (2018-12-21)
 
@@ -32,31 +34,35 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 This version of Studio changes how Realm state and file size metrics (displayed in the server administration window) are fetched from the server. Consequently server must be at least version 3.16.0 to display these sizes correctly.
 
 ### Enhancements
+
 - Showing connection state (disconnected, connecting or connected) in the server administration window. ([#1028](https://github.com/realm/realm-studio/pull/1028))
 - No longer waiting for the entire admin Realm to download before showing realms and users in the server administration window. ([#1028](https://github.com/realm/realm-studio/pull/1028))
 
 ### Fixed
+
 - Fixed displaying Realm state and file size in the server administration window. ([#1028](https://github.com/realm/realm-studio/pull/1028))
 - Fixed process directory creation on initial startup. ([#1054](https://github.com/realm/realm-studio/pull/1054), since v3.1.2)
 
 ### Internals
-- None
 
+- None
 
 ## Release 3.1.3 (2018-12-17)
 
 [Changes since v3.1.2](https://github.com/realm/realm-studio/compare/v3.1.2...v3.1.3)
 
 ### Enhancements
+
 - None
 
 ### Fixed
+
 - Fixed connecting to a server using an admin token (again²). ([#1050](https://github.com/realm/realm-studio/pull/1050), since v3.0.0)
 
 ### Internals
+
 - Removed all use of Realm JS from the main process. ([#1049](https://github.com/realm/realm-studio/pull/1049))
 - Upgraded Realm JS to v2.21.1. ([#1050](https://github.com/realm/realm-studio/pull/1050))
-
 
 ## Release 3.1.2 (2018-12-11)
 
@@ -65,52 +71,60 @@ This version had a regression running on Windows and was therefore never release
 [Changes since v3.1.1](https://github.com/realm/realm-studio/compare/v3.1.1...v3.1.2)
 
 ### Enhancements
+
 - None
 
 ### Fixed
+
 - Fixed connecting to a server using an admin token (again). ([#1038](https://github.com/realm/realm-studio/pull/1038), since v3.0.0)
 
 ### Internals
-- None
 
+- None
 
 ## Release 3.1.1 (2018-12-07)
 
 [Changes since v3.1.0](https://github.com/realm/realm-studio/compare/v3.1.0...v3.1.1)
 
 ### Enhancements
+
 - None
 
 ### Fixed
+
 - Fixed focussing classes with a missing object in the `__Class` table. It would show "Permissions for [name] class is missing". ([#1037](https://github.com/realm/realm-studio/pull/1037), since 3.1.0)
 
 ### Internals
-- None
 
+- None
 
 ## Release 3.1.0 (2018-12-07)
 
 [Changes since v3.0.7](https://github.com/realm/realm-studio/compare/v3.0.7...v3.1.0)
 
 ### Enhancements
+
 - When browsing a reference Realm a permission sidebar appears in the browser. ([#946](https://github.com/realm/realm-studio/pull/946))
 
 ### Fixed
+
 - Fixed missing padding in the Realm browsers sidebar when a schema was missing. ([#1026](https://github.com/realm/realm-studio/pull/1026))
 
 ### Internals
+
 - Excluding the unpackaged directories when uploading to S3 (again). ([#1013](https://github.com/realm/realm-studio/pull/1013))
 - Updated the message in the greeting window to include a button for signing up for the Realm Cloud. ([#1032](https://github.com/realm/realm-studio/pull/1032) and [#1035](https://github.com/realm/realm-studio/pull/1035))
-
 
 ## Release 3.0.7 (2018-11-16)
 
 [Changes since v3.0.6](https://github.com/realm/realm-studio/compare/v3.0.6...v3.0.7)
 
 ### Enhancements
+
 - None
 
 ### Fixed
+
 - Fixed the automatic updating, which was was broken on Windows. ([#1004](https://github.com/realm/realm-studio/pull/1004))
 - Fixed choosing a PM timestamp when creating an object with a datetime value. ([#1005](https://github.com/realm/realm-studio/pull/1005))
 - Fixed adding a property when class had many properties and no objects. ([#1008](https://github.com/realm/realm-studio/pull/1008))
@@ -118,54 +132,61 @@ This version had a regression running on Windows and was therefore never release
 - Fixed the application menu, which was not updated until the user refocussed the window. ([#1011](https://github.com/realm/realm-studio/pull/1011))
 
 ### Internal
+
 - Cleaned up the package.json by using semver instead of compare-versions and moved types to devDependencies. ([#1010](https://github.com/realm/realm-studio/pull/1010))
 - Excluding the unpackaged directories when uploading to S3. ([#1012](https://github.com/realm/realm-studio/pull/1012))
 - realm-js analytics have been disabled on the main process (similar to what we do for the renderer). ([#994](https://github.com/realm/realm-studio/issues/994))
-
 
 ## Release 3.0.6 (2018-11-14)
 
 [Changes since v3.0.5](https://github.com/realm/realm-studio/compare/v3.0.5...v3.0.6)
 
 ### Enhancements
+
 - None
 
 ### Fixed
+
 - Windows are no longer rendering blank when connecting to a server on the Windows OS. ([#998](https://github.com/realm/realm-studio/pull/998))
 
 ### Internal
+
 - Updated Webpack and dependant modules. ([#999](https://github.com/realm/realm-studio/pull/999))
 - Updated TS-lint, Prettier and fixed linting errors. ([#1000](https://github.com/realm/realm-studio/pull/1000))
-
 
 ## Release 3.0.5 (2018-11-13)
 
 [Changes since v3.0.4](https://github.com/realm/realm-studio/compare/v3.0.4...v3.0.5)
 
 ### Enhancements
+
 - None
 
 ### Fixed
+
 - Fixed the getting started scene of the server administration window, which was missing a button for the React Native quick start guide and the iOS and Android URLs was rendering 404 errors. ([#963](https://github.com/realm/realm-studio/pull/963))
 - Fixed not showing the path-level permissions of a reference or partial Realm. ([#989](https://github.com/realm/realm-studio/pull/989))
 - Fixed Windows getting smaller on the Windows OS each time the window was opened. ([#991](https://github.com/realm/realm-studio/pull/991))
 
 ### Internal
+
 - Updated the changelog and releasenotes. ([#988](https://github.com/realm/realm-studio/pull/988))
 - Upgraded to Electron 3.0 + dependencies ([#935](https://github.com/realm/realm-studio/pull/935))
-
 
 ## Release 3.0.4 (2018-11-12)
 
 [Changes since v3.0.3](https://github.com/realm/realm-studio/compare/v3.0.3...v3.0.4)
 
 ### Enhancements
+
 - None
 
 ### Fixed
+
 - Fixed a crash when sorting a column with type list. ([#984](https://github.com/realm/realm-studio/pull/984))
 
 ### Internal
+
 - Moved sentry id to the title and using the bug template for the body. ([#983](https://github.com/realm/realm-studio/pull/983))
 - Automated building up release notes in this file as PRs are merged. ([#987](https://github.com/realm/realm-studio/pull/987))
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,8 +8,10 @@
 
 - Fixed clicking "Open in Studio" on the Realm Cloud frontend, no longer yields an error. ([#1098](https://github.com/realm/realm-studio/pull/1098), since v3.1.3)
 - Fixed selecting objects while filtering or sorting the list of objects. ([1099](https://github.com/realm/realm-studio/pull/1099), since v2.1.1)
+- Fixed resizing columns in the Realm Browser. ([#1108](https://github.com/realm/realm-studio/issues/1108), since v3.1.0)
 
 ## Internals
+
 - Added a post-package test to ensure auto-updating functions. ([#1095](https://github.com/realm/realm-studio/pull/1095))
 - Updated all dependencies, including Electron to v4 and Realm JS to v2.23.0. ([#1095](https://github.com/realm/realm-studio/pull/1095))
 - Adding a segfault handler which produces a stack trace when a segmentation fault occurs. ([#1082](https://github.com/realm/realm-studio/pull/1082))

--- a/docs/RELEASENOTES.template.md
+++ b/docs/RELEASENOTES.template.md
@@ -1,10 +1,13 @@
 [Changes since {PREVIOUS_VERSION}](https://github.com/realm/realm-studio/compare/{PREVIOUS_VERSION}...{CURRENT_VERSION})
 
 ### Enhancements
+
 - None
 
 ### Fixed
+
 - None
 
 ### Internals
+
 - None

--- a/package-lock.json
+++ b/package-lock.json
@@ -5093,8 +5093,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5115,14 +5114,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5137,20 +5134,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5267,8 +5261,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5280,7 +5273,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5295,7 +5287,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5303,14 +5294,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5329,7 +5318,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5410,8 +5398,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5423,7 +5410,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5509,8 +5495,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5546,7 +5531,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5566,7 +5550,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5610,14 +5593,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -11488,8 +11469,8 @@
       "resolved": "https://registry.npmjs.org/segfault-handler/-/segfault-handler-1.0.1.tgz",
       "integrity": "sha512-3koBV3F0IPxTYacnoL7WoFlaMndXsXj62tiVbbW9Kzp3K+F9Y6GWW5XmKSv7j+7nf2M+qjNzc4W1iZoa8vocjw==",
       "requires": {
-        "bindings": "1.3.1",
-        "nan": "2.8.0"
+        "bindings": "^1.2.1",
+        "nan": "^2.0.9"
       },
       "dependencies": {
         "nan": {

--- a/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
@@ -168,23 +168,7 @@ export class HeaderCell extends React.Component<
     );
   }
 
-  protected onDrag: DraggableEventHandler = (e, data) => {
-    this.props.onWidthChanged(data.x + Math.ceil(HANDLE_WIDTH / 2));
-  };
-
-  protected onDragStart = () => {
-    this.setState({ isDragging: true });
-  };
-
-  protected onDragStop = () => {
-    this.setState({ isDragging: false });
-  };
-
-  protected onSortClick = () => {
-    this.props.onSortClick(this.props.property);
-  };
-
-  protected generateHandle(state: IHeaderCellState) {
+  private generateHandle(state: IHeaderCellState) {
     // This is rendered only when the state.isDragging is updated to avoid unnessesary renders
     this.handle = (
       <DraggableCore
@@ -196,8 +180,29 @@ export class HeaderCell extends React.Component<
           className={classNames('RealmBrowser__Table__HeaderHandle', {
             'RealmBrowser__Table__HeaderHandle--dragging': state.isDragging,
           })}
+          onClick={this.onHandleClick}
         />
       </DraggableCore>
     );
   }
+
+  private onDrag: DraggableEventHandler = (e, data) => {
+    this.props.onWidthChanged(data.x + Math.ceil(HANDLE_WIDTH / 2));
+  };
+
+  private onDragStart: DraggableEventHandler = e => {
+    this.setState({ isDragging: true });
+  };
+
+  private onDragStop: DraggableEventHandler = () => {
+    this.setState({ isDragging: false });
+  };
+
+  private onHandleClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // Prevent a click of the handle to trigger sorting
+  };
+
+  private onSortClick = (e: React.MouseEvent) => {
+    this.props.onSortClick(this.props.property);
+  };
 }

--- a/src/ui/RealmBrowser/focus.ts
+++ b/src/ui/RealmBrowser/focus.ts
@@ -63,7 +63,7 @@ export interface IPrimitiveListFocus extends IBaseListFocus {
 export type IListFocus = IObjectListFocus | IPrimitiveListFocus;
 export type Focus = IClassFocus | IListFocus;
 
-export const getClassName = (focus: Focus): string => {
+export function getClassName(focus: Focus): string {
   if (focus.kind === 'class') {
     return focus.className;
   } else if (focus.property.objectType) {
@@ -71,4 +71,22 @@ export const getClassName = (focus: Focus): string => {
   } else {
     throw new Error('Failed to get class named from focus');
   }
-};
+}
+
+export function generateKey(focus: Focus | null) {
+  if (focus && focus.kind === 'class') {
+    return `class:${focus.className}`;
+  } else if (focus && focus.kind === 'list') {
+    // The `[key: string]: any;` is needed because if Realm JS types
+    const parent: Realm.Object & {
+      [key: string]: any;
+    } = focus.parent;
+    const schema = parent.objectSchema();
+    const propertyName = focus.property.name;
+    const id =
+      parent.isValid() && schema.primaryKey ? parent[schema.primaryKey] : '?';
+    return `list:${schema.name}[${id}]:${propertyName}`;
+  } else {
+    return 'null';
+  }
+}

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -36,7 +36,7 @@ import {
 } from '../reusable/RealmLoadingComponent';
 
 import { Content, EditMode } from './Content';
-import { Focus, IClassFocus, IListFocus } from './focus';
+import { Focus, generateKey, IClassFocus, IListFocus } from './focus';
 import { isPrimitive } from './primitives';
 import { RealmBrowser } from './RealmBrowser';
 import * as schemaUtils from './schema-utils';
@@ -115,7 +115,7 @@ class RealmBrowserContainer
   }
 
   public render() {
-    const contentKey = this.generateContentKey();
+    const contentKey = generateKey(this.state.focus);
     return (
       <RealmBrowser
         classes={this.state.classes}
@@ -489,24 +489,6 @@ class RealmBrowserContainer
       throw new Error('Expected a property with a name property');
     }
   };
-
-  private generateContentKey() {
-    if (this.state.focus && this.state.focus.kind === 'class') {
-      return `class:${this.state.focus.className}`;
-    } else if (this.state.focus && this.state.focus.kind === 'list') {
-      // The `[key: string]: any;` is needed because if Realm JS types
-      const parent: Realm.Object & {
-        [key: string]: any;
-      } = this.state.focus.parent;
-      const schema = parent.objectSchema();
-      const propertyName = this.state.focus.property.name;
-      const id =
-        parent.isValid() && schema.primaryKey ? parent[schema.primaryKey] : '?';
-      return `list:${schema.name}[${id}]:${propertyName}`;
-    } else {
-      return 'null';
-    }
-  }
 
   private getSchemaLength = (name: string) => {
     if (this.realm) {


### PR DESCRIPTION
This fixes #1087 and #588 by
1. Preventing a click-through the resize handle.
2. Only generate the default column widths if the focus actually changes.
3. Use a cache to "restore" column widths when switching focus.