### PR TITLE
Fixed various packaging issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3572,20 +3572,20 @@
       "dev": true
     },
     "electron": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-4.0.5.tgz",
-      "integrity": "sha512-UWFH6SrzNtzfvusGUFYxXDrgsUEbtBXkH/66hpDWxjA2Ckt7ozcYIujZpshbr7LPy8kV3ZRxIvoyCMdaS5DkVQ==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-3.0.15.tgz",
+      "integrity": "sha512-Bp1CwnYaIWXNL9ZjgEaLlEkVEGpjJMupcAnxyCe00C2ZhQT9gY+RJaPzkrZC+J/Gc4MvvLtJcy/Hvsc+MTkfNg==",
       "dev": true,
       "requires": {
-        "@types/node": "^10.12.18",
+        "@types/node": "^8.0.24",
         "electron-download": "^4.1.0",
         "extract-zip": "^1.0.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.12.26",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.26.tgz",
-          "integrity": "sha512-nMRqS+mL1TOnIJrL6LKJcNZPB8V3eTfRo9FQA2b5gDvrHurC8XbSA86KNe0dShlEL7ReWJv/OU9NL7Z0dnqWTg==",
+          "version": "8.10.40",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.40.tgz",
+          "integrity": "sha512-RRSjdwz63kS4u7edIwJUn8NqKLLQ6LyqF/X4+4jp38MBT3Vwetewi2N4dgJEshLbDwNgOJXNYoOwzVZUSSLhkQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,11 @@
         ]
       }
     ],
+    "fileAssociations": {
+      "ext": "realm",
+      "name": "Realm",
+      "isPackage": true
+    },
     "publish": [
       {
         "provider": "s3",
@@ -85,11 +90,9 @@
         "path": "downloads/realm-studio"
       }
     ],
-    "fileAssociations": {
-      "ext": "realm",
-      "name": "Realm",
-      "isPackage": true
-    }
+    "npmArgs": [
+      "--fallback-to-build=false"
+    ]
   },
   "scripts": {
     "build": "webpack --mode production --config=configs/webpack.js",

--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
     "react-virtualized": "^9.20.1",
     "reactstrap": "^7.1.0",
     "realm": "2.23.0",
-    "segfault-handler": "^1.0.1",
     "semver": "^5.4.1",
     "uuid": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "copy-webpack-plugin": "^4.5.1",
     "css-loader": "^2.1.0",
     "devtron": "^1.4.0",
-    "electron": "4.0.5",
+    "electron": "3.0.15",
     "electron-builder": "20.38.5",
     "electron-download": "^4.1.1",
     "electron-publisher-s3": "^20.17.2",

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -25,9 +25,6 @@ import * as ReactDOM from 'react-dom';
 // This is needed to prevent Realm JS from writing to directories it doesn't have access to
 import './utils/process-directories';
 
-import * as SegfaultHandler from 'segfault-handler';
-SegfaultHandler.registerHandler('crash.log');
-
 const isDevelopment = process.env.NODE_ENV === 'development';
 
 // Don't report Realm JS analytics data


### PR DESCRIPTION
Because of https://github.com/electron-userland/electron-builder/issues/3706 Electron is downgraded to v3 and to prevent Realm JS being built from source `--fallback-to-build=false` was introduced when installing-app-deps (fixing #1111).

https://github.com/realm/realm-studio/pull/1082 was reverted because it caused a crash on Ubuntu 18.04.