### PR TITLE
Using react-inspector instead of the deprecated react-object-inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,27 +20,25 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Pinning the WebPack version to 4.28.4 until [https://github.com/webpack/webpack/issues/8656](https://github.com/webpack/webpack/issues/8656) gets resolved + rebuilding the package-lock.json ([#1122](https://github.com/realm/realm-studio/issues/1122))
 
-
 ## Release 3.4.0 (2019-02-21)
 
 [Changes since v3.3.0](https://github.com/realm/realm-studio/compare/v3.3.0...v3.4.0)
 
 ### Enhancements
 
-* Added visual feedback when a query in the Realm Browser fails to parse. ([#1100](https://github.com/realm/realm-studio/pull/1100))
+- Added visual feedback when a query in the Realm Browser fails to parse. ([#1100](https://github.com/realm/realm-studio/pull/1100))
 
 ### Fixed
 
-* Fixed clicking "Open in Studio" on the Realm Cloud frontend, no longer yields an error. ([#1098](https://github.com/realm/realm-studio/pull/1098), since v3.1.3)
-* Fixed selecting objects while filtering or sorting the list of objects. ([1099](https://github.com/realm/realm-studio/pull/1099), since v2.1.1)
-* Fixed resizing columns in the Realm Browser. ([#1108](https://github.com/realm/realm-studio/issues/1108), since v3.1.0)
+- Fixed clicking "Open in Studio" on the Realm Cloud frontend, no longer yields an error. ([#1098](https://github.com/realm/realm-studio/pull/1098), since v3.1.3)
+- Fixed selecting objects while filtering or sorting the list of objects. ([1099](https://github.com/realm/realm-studio/pull/1099), since v2.1.1)
+- Fixed resizing columns in the Realm Browser. ([#1108](https://github.com/realm/realm-studio/issues/1108), since v3.1.0)
 
 ### Internals
 
-* Added a post-package test to ensure auto-updating functions. ([#1095](https://github.com/realm/realm-studio/pull/1095))
-* Updated all dependencies, including Electron to v4 and Realm JS to v2.23.0. ([#1095](https://github.com/realm/realm-studio/pull/1095))
-* Added a segfault handler which produces a stack trace when a segmentation fault occurs. ([#1082](https://github.com/realm/realm-studio/pull/1082))
-
+- Added a post-package test to ensure auto-updating functions. ([#1095](https://github.com/realm/realm-studio/pull/1095))
+- Updated all dependencies, including Electron to v4 and Realm JS to v2.23.0. ([#1095](https://github.com/realm/realm-studio/pull/1095))
+- Added a segfault handler which produces a stack trace when a segmentation fault occurs. ([#1082](https://github.com/realm/realm-studio/pull/1082))
 
 ## Release 3.3.0 (2019-01-07)
 
@@ -48,22 +46,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Enhancements
 
-* Added in-app messages from Realm to the Greeting window. ([#1056](https://github.com/realm/realm-studio/pull/1056))
-* Error dialogs now clearly separates the failed intent and the message from the throw exception. ([#1061](https://github.com/realm/realm-studio/pull/1061))
+- Added in-app messages from Realm to the Greeting window. ([#1056](https://github.com/realm/realm-studio/pull/1056))
+- Error dialogs now clearly separates the failed intent and the message from the throw exception. ([#1061](https://github.com/realm/realm-studio/pull/1061))
 
 ### Fixed
 
-* Fixed text rendering issue resulting in clipping of property name and types in the header of the browser window. It was only observed on Windows with high pixel density displays. ([#1059](https://github.com/realm/realm-studio/pull/1059), since v1.0.0)
-* Fixed an issue where sidebars got resized when a window got resized despite the sidebar being collapsed. ([#1060](https://github.com/realm/realm-studio/pull/1060), since v2.7.0)
-* Fixed potential issues from writing to partial Realms by opening them in a read-only mode. ([#1062](https://github.com/realm/realm-studio/pull/1062) & [#1063](https://github.com/realm/realm-studio/pull/1063), since v1.0.0)
-* Fixed the error shown when connecting to a Realm Cloud instance with an expired token. ([#1067](https://github.com/realm/realm-studio/pull/1067), since v1.18.1)
+- Fixed text rendering issue resulting in clipping of property name and types in the header of the browser window. It was only observed on Windows with high pixel density displays. ([#1059](https://github.com/realm/realm-studio/pull/1059), since v1.0.0)
+- Fixed an issue where sidebars got resized when a window got resized despite the sidebar being collapsed. ([#1060](https://github.com/realm/realm-studio/pull/1060), since v2.7.0)
+- Fixed potential issues from writing to partial Realms by opening them in a read-only mode. ([#1062](https://github.com/realm/realm-studio/pull/1062) & [#1063](https://github.com/realm/realm-studio/pull/1063), since v1.0.0)
+- Fixed the error shown when connecting to a Realm Cloud instance with an expired token. ([#1067](https://github.com/realm/realm-studio/pull/1067), since v1.18.1)
 
 ### Internals
 
-* Fixed the Dockerfile used when testing PRs. ([#1057](https://github.com/realm/realm-studio/pull/1057))
-* Removing all existing and future unused locals. ([#1058](https://github.com/realm/realm-studio/pull/1058))
-* Refactored singleton windows. ([#1066](https://github.com/realm/realm-studio/pull/1066))
-* Refactored the Jenkins CI pipeline. ([#1069](https://github.com/realm/realm-studio/pull/1069) & [#1073](https://github.com/realm/realm-studio/pull/1073))
+- Fixed the Dockerfile used when testing PRs. ([#1057](https://github.com/realm/realm-studio/pull/1057))
+- Removing all existing and future unused locals. ([#1058](https://github.com/realm/realm-studio/pull/1058))
+- Refactored singleton windows. ([#1066](https://github.com/realm/realm-studio/pull/1066))
+- Refactored the Jenkins CI pipeline. ([#1069](https://github.com/realm/realm-studio/pull/1069) & [#1073](https://github.com/realm/realm-studio/pull/1073))
 
 ## Release 3.2.0 (2018-12-21)
 
@@ -73,17 +71,17 @@ This version of Studio changes how Realm state and file size metrics (displayed 
 
 ### Enhancements
 
-* Showing connection state (disconnected, connecting or connected) in the server administration window. ([#1028](https://github.com/realm/realm-studio/pull/1028))
-* No longer waiting for the entire admin Realm to download before showing realms and users in the server administration window. ([#1028](https://github.com/realm/realm-studio/pull/1028))
+- Showing connection state (disconnected, connecting or connected) in the server administration window. ([#1028](https://github.com/realm/realm-studio/pull/1028))
+- No longer waiting for the entire admin Realm to download before showing realms and users in the server administration window. ([#1028](https://github.com/realm/realm-studio/pull/1028))
 
 ### Fixed
 
-* Fixed displaying Realm state and file size in the server administration window. ([#1028](https://github.com/realm/realm-studio/pull/1028))
-* Fixed process directory creation on initial startup. ([#1054](https://github.com/realm/realm-studio/pull/1054), since v3.1.2)
+- Fixed displaying Realm state and file size in the server administration window. ([#1028](https://github.com/realm/realm-studio/pull/1028))
+- Fixed process directory creation on initial startup. ([#1054](https://github.com/realm/realm-studio/pull/1054), since v3.1.2)
 
 ### Internals
 
-* None
+- None
 
 ## Release 3.1.3 (2018-12-17)
 
@@ -91,16 +89,16 @@ This version of Studio changes how Realm state and file size metrics (displayed 
 
 ### Enhancements
 
-* None
+- None
 
 ### Fixed
 
-* Fixed connecting to a server using an admin token (again²). ([#1050](https://github.com/realm/realm-studio/pull/1050), since v3.0.0)
+- Fixed connecting to a server using an admin token (again²). ([#1050](https://github.com/realm/realm-studio/pull/1050), since v3.0.0)
 
 ### Internals
 
-* Removed all use of Realm JS from the main process. ([#1049](https://github.com/realm/realm-studio/pull/1049))
-* Upgraded Realm JS to v2.21.1. ([#1050](https://github.com/realm/realm-studio/pull/1050))
+- Removed all use of Realm JS from the main process. ([#1049](https://github.com/realm/realm-studio/pull/1049))
+- Upgraded Realm JS to v2.21.1. ([#1050](https://github.com/realm/realm-studio/pull/1050))
 
 ## Release 3.1.2 (2018-12-11)
 
@@ -110,15 +108,15 @@ This version had a regression running on Windows and was therefore never release
 
 ### Enhancements
 
-* None
+- None
 
 ### Fixed
 
-* Fixed connecting to a server using an admin token (again). ([#1038](https://github.com/realm/realm-studio/pull/1038), since v3.0.0)
+- Fixed connecting to a server using an admin token (again). ([#1038](https://github.com/realm/realm-studio/pull/1038), since v3.0.0)
 
 ### Internals
 
-* None
+- None
 
 ## Release 3.1.1 (2018-12-07)
 
@@ -126,15 +124,15 @@ This version had a regression running on Windows and was therefore never release
 
 ### Enhancements
 
-* None
+- None
 
 ### Fixed
 
-* Fixed focussing classes with a missing object in the `__Class` table. It would show "Permissions for [name] class is missing". ([#1037](https://github.com/realm/realm-studio/pull/1037), since 3.1.0)
+- Fixed focussing classes with a missing object in the `__Class` table. It would show "Permissions for [name] class is missing". ([#1037](https://github.com/realm/realm-studio/pull/1037), since 3.1.0)
 
 ### Internals
 
-* None
+- None
 
 ## Release 3.1.0 (2018-12-07)
 
@@ -142,16 +140,16 @@ This version had a regression running on Windows and was therefore never release
 
 ### Enhancements
 
-* When browsing a reference Realm a permission sidebar appears in the browser. ([#946](https://github.com/realm/realm-studio/pull/946))
+- When browsing a reference Realm a permission sidebar appears in the browser. ([#946](https://github.com/realm/realm-studio/pull/946))
 
 ### Fixed
 
-* Fixed missing padding in the Realm browsers sidebar when a schema was missing. ([#1026](https://github.com/realm/realm-studio/pull/1026))
+- Fixed missing padding in the Realm browsers sidebar when a schema was missing. ([#1026](https://github.com/realm/realm-studio/pull/1026))
 
 ### Internals
 
-* Excluding the unpackaged directories when uploading to S3 (again). ([#1013](https://github.com/realm/realm-studio/pull/1013))
-* Updated the message in the greeting window to include a button for signing up for the Realm Cloud. ([#1032](https://github.com/realm/realm-studio/pull/1032) and [#1035](https://github.com/realm/realm-studio/pull/1035))
+- Excluding the unpackaged directories when uploading to S3 (again). ([#1013](https://github.com/realm/realm-studio/pull/1013))
+- Updated the message in the greeting window to include a button for signing up for the Realm Cloud. ([#1032](https://github.com/realm/realm-studio/pull/1032) and [#1035](https://github.com/realm/realm-studio/pull/1035))
 
 ## Release 3.0.7 (2018-11-16)
 
@@ -159,21 +157,21 @@ This version had a regression running on Windows and was therefore never release
 
 ### Enhancements
 
-* None
+- None
 
 ### Fixed
 
-* Fixed the automatic updating, which was was broken on Windows. ([#1004](https://github.com/realm/realm-studio/pull/1004))
-* Fixed choosing a PM timestamp when creating an object with a datetime value. ([#1005](https://github.com/realm/realm-studio/pull/1005))
-* Fixed adding a property when class had many properties and no objects. ([#1008](https://github.com/realm/realm-studio/pull/1008))
-* Fixed scrolling the modal dialog after adding an object to list when creating objects. ([#1009](https://github.com/realm/realm-studio/pull/1009))
-* Fixed the application menu, which was not updated until the user refocussed the window. ([#1011](https://github.com/realm/realm-studio/pull/1011))
+- Fixed the automatic updating, which was was broken on Windows. ([#1004](https://github.com/realm/realm-studio/pull/1004))
+- Fixed choosing a PM timestamp when creating an object with a datetime value. ([#1005](https://github.com/realm/realm-studio/pull/1005))
+- Fixed adding a property when class had many properties and no objects. ([#1008](https://github.com/realm/realm-studio/pull/1008))
+- Fixed scrolling the modal dialog after adding an object to list when creating objects. ([#1009](https://github.com/realm/realm-studio/pull/1009))
+- Fixed the application menu, which was not updated until the user refocussed the window. ([#1011](https://github.com/realm/realm-studio/pull/1011))
 
 ### Internal
 
-* Cleaned up the package.json by using semver instead of compare-versions and moved types to devDependencies. ([#1010](https://github.com/realm/realm-studio/pull/1010))
-* Excluding the unpackaged directories when uploading to S3. ([#1012](https://github.com/realm/realm-studio/pull/1012))
-* realm-js analytics have been disabled on the main process (similar to what we do for the renderer). ([#994](https://github.com/realm/realm-studio/issues/994))
+- Cleaned up the package.json by using semver instead of compare-versions and moved types to devDependencies. ([#1010](https://github.com/realm/realm-studio/pull/1010))
+- Excluding the unpackaged directories when uploading to S3. ([#1012](https://github.com/realm/realm-studio/pull/1012))
+- realm-js analytics have been disabled on the main process (similar to what we do for the renderer). ([#994](https://github.com/realm/realm-studio/issues/994))
 
 ## Release 3.0.6 (2018-11-14)
 
@@ -181,16 +179,16 @@ This version had a regression running on Windows and was therefore never release
 
 ### Enhancements
 
-* None
+- None
 
 ### Fixed
 
-* Windows are no longer rendering blank when connecting to a server on the Windows OS. ([#998](https://github.com/realm/realm-studio/pull/998))
+- Windows are no longer rendering blank when connecting to a server on the Windows OS. ([#998](https://github.com/realm/realm-studio/pull/998))
 
 ### Internal
 
-* Updated Webpack and dependant modules. ([#999](https://github.com/realm/realm-studio/pull/999))
-* Updated TS-lint, Prettier and fixed linting errors. ([#1000](https://github.com/realm/realm-studio/pull/1000))
+- Updated Webpack and dependant modules. ([#999](https://github.com/realm/realm-studio/pull/999))
+- Updated TS-lint, Prettier and fixed linting errors. ([#1000](https://github.com/realm/realm-studio/pull/1000))
 
 ## Release 3.0.5 (2018-11-13)
 
@@ -198,18 +196,18 @@ This version had a regression running on Windows and was therefore never release
 
 ### Enhancements
 
-* None
+- None
 
 ### Fixed
 
-* Fixed the getting started scene of the server administration window, which was missing a button for the React Native quick start guide and the iOS and Android URLs was rendering 404 errors. ([#963](https://github.com/realm/realm-studio/pull/963))
-* Fixed not showing the path-level permissions of a reference or partial Realm. ([#989](https://github.com/realm/realm-studio/pull/989))
-* Fixed Windows getting smaller on the Windows OS each time the window was opened. ([#991](https://github.com/realm/realm-studio/pull/991))
+- Fixed the getting started scene of the server administration window, which was missing a button for the React Native quick start guide and the iOS and Android URLs was rendering 404 errors. ([#963](https://github.com/realm/realm-studio/pull/963))
+- Fixed not showing the path-level permissions of a reference or partial Realm. ([#989](https://github.com/realm/realm-studio/pull/989))
+- Fixed Windows getting smaller on the Windows OS each time the window was opened. ([#991](https://github.com/realm/realm-studio/pull/991))
 
 ### Internal
 
-* Updated the changelog and releasenotes. ([#988](https://github.com/realm/realm-studio/pull/988))
-* Upgraded to Electron 3.0 + dependencies ([#935](https://github.com/realm/realm-studio/pull/935))
+- Updated the changelog and releasenotes. ([#988](https://github.com/realm/realm-studio/pull/988))
+- Upgraded to Electron 3.0 + dependencies ([#935](https://github.com/realm/realm-studio/pull/935))
 
 ## Release 3.0.4 (2018-11-12)
 
@@ -217,16 +215,16 @@ This version had a regression running on Windows and was therefore never release
 
 ### Enhancements
 
-* None
+- None
 
 ### Fixed
 
-* Fixed a crash when sorting a column with type list. ([#984](https://github.com/realm/realm-studio/pull/984))
+- Fixed a crash when sorting a column with type list. ([#984](https://github.com/realm/realm-studio/pull/984))
 
 ### Internal
 
-* Moved sentry id to the title and using the bug template for the body. ([#983](https://github.com/realm/realm-studio/pull/983))
-* Automated building up release notes in this file as PRs are merged. ([#987](https://github.com/realm/realm-studio/pull/987))
+- Moved sentry id to the title and using the bug template for the body. ([#983](https://github.com/realm/realm-studio/pull/983))
+- Automated building up release notes in this file as PRs are merged. ([#987](https://github.com/realm/realm-studio/pull/987))
 
 ---
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,12 +2,12 @@
 
 ### Enhancements
 
-* None
+- Improved how log entries are displayed in the server adminstration window: The timestamp now displays the date when the entry is not from the current day and the context object gets expanded initially. ([#1131](https://github.com/realm/realm-studio/issues/1131), since v1.20.0)
 
 ### Fixed
 
-* None
+- None
 
 ### Internals
 
-* None
+- Using `react-inspector` instead of the `react-object-inspector` package. ([#1131](https://github.com/realm/realm-studio/issues/1131))

--- a/docs/RELEASENOTES.template.md
+++ b/docs/RELEASENOTES.template.md
@@ -2,12 +2,12 @@
 
 ### Enhancements
 
-* None
+- None
 
 ### Fixed
 
-* None
+- None
 
 ### Internals
 
-* None
+- None

--- a/package-lock.json
+++ b/package-lock.json
@@ -1571,7 +1571,6 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "0.9.x"
       }
@@ -5232,8 +5231,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5257,15 +5255,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5281,20 +5277,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5425,8 +5418,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5440,7 +5432,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5457,7 +5448,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5466,15 +5456,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5495,7 +5483,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5584,8 +5571,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5599,7 +5585,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5695,8 +5680,7 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5738,7 +5722,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5760,7 +5743,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5809,15 +5791,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6513,8 +6493,7 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
       "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "hoist-non-react-statics": {
       "version": "3.3.0",
@@ -7321,6 +7300,11 @@
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
+    },
+    "is-dom": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/is-dom/-/is-dom-1.0.9.tgz",
+      "integrity": "sha1-SDgy1SlyBz3hK5/j9gMghw2oNw0="
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -11318,6 +11302,16 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
         }
+      }
+    },
+    "react-inspector": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-2.3.1.tgz",
+      "integrity": "sha512-tUUK7t3KWgZEIUktOYko5Ic/oYwvjEvQUFAGC1UeMeDaQ5za2yZFtItJa2RTwBJB//NxPr000WQK6sEbqC6y0Q==",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "is-dom": "^1.0.9",
+        "prop-types": "^15.6.1"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-draggable": "^3.2.1",
-    "react-object-inspector": "^0.2.1",
+    "react-inspector": "^2.3.1",
     "react-realm-context": "^0.1.0",
     "react-sortable-hoc": "^1.7.1",
     "react-virtualized": "^9.20.1",

--- a/src/ResizeObserver.d.ts
+++ b/src/ResizeObserver.d.ts
@@ -1,0 +1,97 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+// tslint:disable:max-classes-per-file
+
+// tslint:disable-next-line:interface-name
+interface Window {
+  ResizeObserver: ResizeObserver;
+}
+
+/**
+ * The ResizeObserver interface is used to observe changes to Element's content
+ * rect.
+ *
+ * It is modeled after MutationObserver and IntersectionObserver.
+ *
+ * The ResizeObserver interface reports changes to the content rectangle of an Element or the bounding box of an SVGElement. The content rectangle is the box in which content can be placed, meaning the border box minus the padding. (See The box model for an explanation of borders and padding.)
+ *
+ * ResizeObserver avoids infinite callback loops and cyclic dependencies that would be created by resizing in its own callback function. It does this by only processing elements deeper in the DOM in subsequent frames. Implementations should, if they follow the specification, invoke resize events before paint and after layout.
+ *
+ * @see https://gist.github.com/strothj/708afcf4f01dd04de8f49c92e88093c3
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
+ * @see https://github.com/Microsoft/TypeScript/issues/28502
+ */
+declare class ResizeObserver {
+  /**
+   * Adds target to the list of observed elements.
+   */
+  public observe: (target: Element) => void;
+
+  /**
+   * Removes target from the list of observed elements.
+   */
+  public unobserve: (target: Element) => void;
+
+  /**
+   * Clears both the observationTargets and activeTargets lists.
+   */
+  public disconnect: () => void;
+  public constructor(callback: ResizeObserverCallback);
+}
+
+/**
+ * This callback delivers ResizeObserver's notifications. It is invoked by a
+ * broadcast active observations algorithm.
+ */
+type ResizeObserverCallback = (
+  entries: ResizeObserverEntry[],
+  observer: ResizeObserver,
+) => void;
+
+declare class ResizeObserverEntry {
+  /**
+   * The Element whose size has changed.
+   */
+  public readonly target: Element;
+
+  /**
+   * Element's content rect when ResizeObserverCallback is invoked.
+   */
+  public readonly contentRect: DOMRectReadOnly;
+  /**
+   * @param target The Element whose size has changed.
+   */
+  public constructor(target: Element);
+}
+
+// tslint:disable-next-line:interface-name
+interface DOMRectReadOnly {
+  // static fromRect(other: DOMRectInit | undefined): DOMRectReadOnly;
+
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  readonly top: number;
+  readonly right: number;
+  readonly bottom: number;
+  readonly left: number;
+
+  toJSON: () => any;
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,6 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+// tslint:disable:max-classes-per-file
+
 declare module '*.svg' {
   const svg: {
     id: string;
@@ -31,28 +33,104 @@ declare module 'mixpanel-browser' {
   export = mixpanel;
 }
 
-declare module 'react-object-inspector' {
-  interface IObjectInpectorProps {
-    name?: string;
-    data: object;
-    /** initial paths of the nodes that are visible */
-    initialExpandedPaths?: string[];
-    depth?: number;
-    /** path is dot separated property names to reach the current node */
-    path?: string;
+declare module 'react-inspector' {
+  type NodeRenderer = (props: IConnectedTreeNodeProps) => React.ReactNode;
+
+  export interface ITreeNodeProps {
+    name: string;
+    data: any;
+    expanded: boolean;
+    shouldShowArrow: boolean;
+    shouldShowPlaceholder: boolean;
+    nodeRenderer: NodeRenderer;
+    onClick: React.MouseEventHandler;
   }
 
-  interface IObjectInpectorState {
+  export interface IConnectedTreeNodeProps {
+    name: string;
+    data: any;
+    expanded: boolean;
+    dataIterator: () => any;
+    nodeRenderer: NodeRenderer;
+    depth: number;
+    // This is not officially a prop of the ConnectedTreeNode, but it seems to be passed
+    isNonenumerable: boolean;
+  }
+
+  /**
+   * Like console.log. Consider this as a glorified version of <pre>JSON.stringify(data, null, 2)</pre>.
+   * @see https://www.npmjs.com/package/react-inspector#objectinspector-
+   */
+  export interface IObjectInpectorProps {
+    /**
+     * The Javascript object you would like to inspect
+     */
+    data: any;
+    /**
+     * Specify the optional name of the root node, default to undefined
+     * @see https://www.npmjs.com/package/react-inspector#name-proptypesstring--specify-the-optional-name-of-the-root-node-default-to-undefined
+     */
+    name?: string;
+    /**
+     * An integer specifying to which level the tree should be initially expanded.
+     * @see https://www.npmjs.com/package/react-inspector#expandlevel-proptypesnumber--an-integer-specifying-to-which-level-the-tree-should-be-initially-expanded
+     */
+    expandLevel?: number;
+    /**
+     * An array containing all the paths that should be expanded when the component is initialized,
+     * or a string of just one path.
+     * @see https://www.npmjs.com/package/react-inspector#expandpaths-proptypesoneoftypeproptypesstring-proptypesarray--an-array-containing-all-the-paths-that-should-be-expanded-when-the-component-is-initialized-or-a-string-of-just-one-path
+     */
+    expandPaths?: string[] | string;
+    /**
+     * Show non-enumerable properties.
+     * @see https://www.npmjs.com/package/react-inspector#shownonenumerable-proptypesbool--show-non-enumerable-properties
+     */
+    showNonenumerable?: boolean;
+    /**
+     * Sort object keys with optional compare function.
+     * @see https://www.npmjs.com/package/react-inspector#sortobjectkeys-proptypesoneoftypeproptypesbool-proptypesfunc--sort-object-keys-with-optional-compare-function
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Description
+     */
+    sortObjectKeys?: boolean | ((a: any, b: any) => number);
+    /**
+     * Use a custom nodeRenderer to render the object properties.
+     * @see https://www.npmjs.com/package/react-inspector#noderenderer-proptypesfunc--use-a-custom-noderenderer-to-render-the-object-properties-optional
+     */
+    nodeRenderer?: NodeRenderer;
+  }
+
+  /*
+  export interface IObjectInpectorState {
     expandedPaths: { [path: string]: boolean };
   }
+  */
 
-  class ObjectInspector<
-    P extends IObjectInpectorProps = IObjectInpectorProps,
-    S extends IObjectInpectorState = IObjectInpectorState
-  > extends React.Component<P, S> {
+  export class ObjectInspector<
+    P extends IObjectInpectorProps = IObjectInpectorProps
+  > extends React.Component<P, {}> {
     protected setExpanded(path: string, expanded: boolean): void;
   }
-  export = ObjectInspector;
+
+  export interface IObjectLabelProps {
+    name: string;
+    data: any;
+    /**
+     * Non enumerable object property will be dimmed
+     */
+    isNonenumerable: boolean;
+  }
+
+  /**
+   * Renders the object with a label.
+   * if isNonenumerable is specified, render the name dimmed
+   */
+  export class ObjectLabel extends React.Component<IObjectLabelProps> {}
+
+  export interface IObjectValueProps {
+    object: any;
+  }
+  export class ObjectValue extends React.Component<IObjectValueProps> {}
 }
 
 declare module 'memoize-one' {

--- a/src/module-wrappers/react-object-inspector.js
+++ b/src/module-wrappers/react-object-inspector.js
@@ -1,2 +1,0 @@
-const ReactObjectInspector = require('react-object-inspector');
-export { ReactObjectInspector };

--- a/src/ui/ServerAdministration/Log/Entry.tsx
+++ b/src/ui/ServerAdministration/Log/Entry.tsx
@@ -72,11 +72,7 @@ export const Entry = ({
         </div>
         {Object.keys(restOfContext).length > 0 ? (
           <div className="Log__Entry__Context">
-            <ContextInspector
-              data={context}
-              onUpdated={onResized}
-              name="context"
-            />
+            <ContextInspector context={context} onUpdated={onResized} />
           </div>
         ) : null}
       </div>

--- a/src/ui/ServerAdministration/Log/TimestampBadge.tsx
+++ b/src/ui/ServerAdministration/Log/TimestampBadge.tsx
@@ -23,6 +23,11 @@ import { Badge } from 'reactstrap';
 const calendarFormats = {
   // See https://momentjs.com/docs/#localized-formats
   sameDay: 'LTS',
+  nextDay: 'L LTS',
+  nextWeek: 'L LTS',
+  lastDay: 'L LTS',
+  lastWeek: 'L LTS',
+  sameElse: 'L LTS',
 };
 
 export interface ITimestampBadgeProps {


### PR DESCRIPTION
This fixes #1123 and #1079 by improving how log entries are displayed in the server adminstration window: The timestamp now displays the date when the entry is not from the current day and the context object gets expanded initially.

![Skærmbillede 2019-03-13 kl  12 41 13](https://user-images.githubusercontent.com/1243959/54281211-84b0c180-4599-11e9-9211-1c87a8905c77.png)
