### PR TITLE
Implemented data exporting to JSON or local Realm

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,6 +3,7 @@
 ### Enhancements
 
 - Improved how log entries are displayed in the server adminstration window: The timestamp now displays the date when the entry is not from the current day and the context object gets expanded initially. ([#1131](https://github.com/realm/realm-studio/issues/1131), since v1.20.0)
+- Added a menu item to export data to JSON or a local Realm from the Realm Browser window. ([#1134](https://github.com/realm/realm-studio/pull/1134))
 
 ### Fixed
 

--- a/src/services/data-exporter/index.ts
+++ b/src/services/data-exporter/index.ts
@@ -1,0 +1,62 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2019 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import * as path from 'path';
+
+export interface IExportEngine {
+  export(realm: Realm, destinationPath: string): void;
+}
+
+export enum DataExportFormat {
+  JSON = 'json',
+  LocalRealm = 'local-realm',
+}
+
+export class DataExporter {
+  private readonly format: DataExportFormat;
+
+  constructor(format: DataExportFormat) {
+    this.format = format;
+  }
+
+  public suggestFilename(realm: Realm) {
+    const basename = path.basename(realm.path, '.realm');
+    if (this.format === DataExportFormat.JSON) {
+      return `${basename}.json`;
+    } else if (this.format === DataExportFormat.LocalRealm) {
+      return `${basename}.realm`;
+    } else {
+      throw new Error(`Unexpected format ${this.format}`);
+    }
+  }
+
+  public export(realm: Realm, destinationPath: string) {
+    const ExportEngine = engines[this.format];
+    const engine = new ExportEngine();
+    return engine.export(realm, destinationPath);
+  }
+}
+
+// Doing this last to prevent circular reference
+
+import { JSONExportEngine } from './json';
+import { LocalRealmExportEngine } from './local-realm';
+const engines = {
+  [DataExportFormat.JSON]: JSONExportEngine,
+  [DataExportFormat.LocalRealm]: LocalRealmExportEngine,
+};

--- a/src/services/data-exporter/json.ts
+++ b/src/services/data-exporter/json.ts
@@ -1,0 +1,102 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2019 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import * as fs from 'fs';
+import * as Realm from 'realm';
+
+import { IExportEngine } from '.';
+
+function serializeObject(object: { [key: string]: any } & Realm.Object) {
+  // This is an object reference
+  const objectSchema = object.objectSchema();
+  if (objectSchema.primaryKey) {
+    return object[objectSchema.primaryKey];
+  } else {
+    // Shallow copy the object
+    return RealmObjectToJSON.call(object);
+  }
+}
+
+function serializeValue(propertyName: string, value: any) {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  } else if (value instanceof Date) {
+    return value.toISOString();
+  } else if (value instanceof ArrayBuffer) {
+    return Buffer.from(value).toString('base64');
+  } else if (
+    typeof value === 'object' &&
+    typeof value.objectSchema === 'function'
+  ) {
+    return serializeObject(value);
+  } else if (typeof value === 'object' && typeof value.length === 'number') {
+    if (value.type === 'object') {
+      // A list of objects
+      return value.map((item: any) => {
+        if (typeof item === 'object') {
+          return serializeObject(item);
+        } else {
+          return item;
+        }
+      });
+    } else {
+      // A list of primitives
+      return [...value];
+    }
+  } else {
+    throw new Error(
+      `Failed to serialize '${propertyName}' field of type ${typeof value}`,
+    );
+  }
+}
+
+function RealmObjectToJSON(this: { [key: string]: any } & Realm.Object) {
+  const values: { [key: string]: any } = {};
+  for (const propertyName of Object.getOwnPropertyNames(this)) {
+    const value = this[propertyName];
+    if (propertyName === '_realm' || typeof value === 'function') {
+      continue; // Skip this property
+    } else {
+      values[propertyName] = serializeValue(propertyName, value);
+    }
+  }
+  return values;
+}
+
+export class JSONExportEngine implements IExportEngine {
+  public export(realm: Realm, destinationPath: string) {
+    const data: { [objectSchemaName: string]: any[] } = {};
+    for (const objectSchema of realm.schema) {
+      data[objectSchema.name] = [
+        ...realm.objects(objectSchema.name).snapshot(),
+      ].map((object: any) => {
+        return Object.defineProperty(object, 'toJSON', {
+          value: RealmObjectToJSON.bind(object),
+          enumerable: false,
+        });
+      });
+    }
+    // Write the stringified data to a file
+    fs.writeFileSync(destinationPath, JSON.stringify(data, null, 2));
+  }
+}

--- a/src/services/data-exporter/local-realm.ts
+++ b/src/services/data-exporter/local-realm.ts
@@ -15,3 +15,11 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////
+
+import { IExportEngine } from '.';
+
+export class LocalRealmExportEngine implements IExportEngine {
+  public export(realm: Realm, destinationPath: string) {
+    realm.writeCopyTo(destinationPath);
+  }
+}


### PR DESCRIPTION
This fixes #15 for JSON and another local Realm and part of #1092, by adding a menu item to save the data of a Realm to a JSON file or a local Realm.

<img width="231" alt="Skærmbillede 2019-03-28 kl  14 04 03" src="https://user-images.githubusercontent.com/1243959/55159883-5c60bf80-5162-11e9-8154-e6d2c9ae26da.png">
