### PR TITLE
Add progress labels when opening a Realm

### DIFF
--- a/src/ui/reusable/LoadingOverlay/LoadingOverlay.tsx
+++ b/src/ui/reusable/LoadingOverlay/LoadingOverlay.tsx
@@ -23,6 +23,7 @@ import { Button, Progress } from 'reactstrap';
 import { LoadingDots } from '../LoadingDots';
 import { ILoadingProgress } from './index';
 
+import { prettyBytes } from '../../../utils';
 import './LoadingOverlay.scss';
 
 /**
@@ -75,7 +76,10 @@ export const LoadingOverlay = ({
             className="LoadingOverlay__Progress"
             value={progress.transferred}
             max={progress.transferable}
-          />
+          >
+            {// tslint:disable-next-line: prettier
+            `${prettyBytes(progress.transferred || 0)} / ${prettyBytes(progress.transferable || 0)}`}
+          </Progress>
         )}
         {showDots ? <LoadingDots /> : null}
         {progress && progress.retry ? (


### PR DESCRIPTION
Adds labels to the Realm download bar:

<img width="970" alt="Screen Shot 2019-06-04 at 13 47 07" src="https://user-images.githubusercontent.com/2315687/58876758-470e9100-86cf-11e9-972d-94f08b01eb3a.png">
