### PR TITLE
Assorted dev experience improvements:

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,3 +19,4 @@
 // Constants that can be used from either the main or render processes.
 export const CLOUD_PROTOCOL = 'x-realm-cloud';
 export const STUDIO_PROTOCOL = 'x-realm-studio';
+export const OPEN_ROS_ACTION = 'connect-to-ros';

--- a/src/main/MainMenu.ts
+++ b/src/main/MainMenu.ts
@@ -24,7 +24,7 @@ import * as raas from '../services/raas';
 import { store } from '../store';
 import { showError } from '../ui/reusable/errors';
 
-const showInternalFeatures =
+const enableTogglingInternalFeatures =
   process.env.NODE_ENV === 'development' ||
   process.env.REALM_STUDIO_INTERNAL_FEATURES === 'true'; // Show features only relevant for Realm employees
 
@@ -48,6 +48,7 @@ function generateCloudEndpointItems(
 export const getDefaultMenuTemplate = (
   updateMenu: () => void,
 ): electron.MenuItemConstructorOptions[] => {
+  const showInternalFeatures = store.shouldShowInternalFeatures();
   const electronOrRemote = electron.remote || electron;
   const template: electron.MenuItemConstructorOptions[] = [
     {
@@ -98,42 +99,52 @@ export const getDefaultMenuTemplate = (
     {
       label: 'View',
       submenu: [
+        {
+          label: 'Show Internal Realm features',
+          visible: showInternalFeatures || enableTogglingInternalFeatures,
+          type: 'checkbox',
+          checked: showInternalFeatures,
+          click: () => {
+            store.toggleShowInternalFeatures();
+            updateMenu();
+          },
+        },
         { role: 'reload', visible: showInternalFeatures },
         { role: 'toggledevtools', visible: showInternalFeatures },
         { type: 'separator', visible: showInternalFeatures },
         {
-          label: `Show partial Realms`,
+          label: 'Show partial Realms',
           type: 'checkbox',
           checked: store.shouldShowPartialRealms(),
-          click: async () => {
-            await store.toggleShowPartialRealms();
+          click: () => {
+            store.toggleShowPartialRealms();
             updateMenu();
           },
         },
         {
-          label: `Show system Realms`,
+          label: 'Show system Realms',
           type: 'checkbox',
           checked: store.shouldShowSystemRealms(),
-          click: async () => {
-            await store.toggleShowSystemRealms();
+          click: () => {
+            store.toggleShowSystemRealms();
             updateMenu();
           },
         },
         {
-          label: `Show system users`,
+          label: 'Show system users',
           type: 'checkbox',
           checked: store.shouldShowSystemUsers(),
-          click: async () => {
-            await store.toggleShowSystemUsers();
+          click: () => {
+            store.toggleShowSystemUsers();
             updateMenu();
           },
         },
         {
-          label: `Show system classes and properties`,
+          label: 'Show system classes and properties',
           type: 'checkbox',
           checked: store.shouldShowSystemClasses(),
-          click: async () => {
-            await store.toggleShowSystemClasses();
+          click: () => {
+            store.toggleShowSystemClasses();
             updateMenu();
           },
         },
@@ -186,6 +197,15 @@ export const getDefaultMenuTemplate = (
           label: 'Clear Cache',
           click: () => {
             main.clearRendererCache();
+          },
+        },
+        {
+          label: 'Open Cache folder',
+          visible: showInternalFeatures,
+          click: () => {
+            electronOrRemote.shell.openItem(
+              electronOrRemote.app.getPath('userData'),
+            );
           },
         },
       ],

--- a/src/store.ts
+++ b/src/store.ts
@@ -31,28 +31,34 @@ class RealmStudioStore {
   public readonly KEY_SHOW_SYSTEM_REALMS = 'realmlist.show-system-realms';
   public readonly KEY_SHOW_SYSTEM_USERS = 'userlist.show-system-users';
   public readonly KEY_SHOW_SYSTEM_CLASSES = 'browser.show-system-classes';
+  public readonly KEY_SHOW_INTERNAL_FEATURES = 'general.show-internal-features';
   public readonly KEY_WINDOW_OPTIONS = 'window-options';
 
   private store = new ElectronStore();
 
   public toggleShowPartialRealms() {
-    const currentValue = this.store.get(this.KEY_SHOW_PARTIAL_REALMS, false);
+    const currentValue = this.shouldShowPartialRealms();
     this.store.set(this.KEY_SHOW_PARTIAL_REALMS, !currentValue);
   }
 
   public toggleShowSystemRealms() {
-    const currentValue = this.store.get(this.KEY_SHOW_SYSTEM_REALMS, false);
+    const currentValue = this.shouldShowSystemRealms();
     this.store.set(this.KEY_SHOW_SYSTEM_REALMS, !currentValue);
   }
 
   public toggleShowSystemUsers() {
-    const currentValue = this.store.get(this.KEY_SHOW_SYSTEM_USERS, false);
+    const currentValue = this.shouldShowSystemUsers();
     this.store.set(this.KEY_SHOW_SYSTEM_USERS, !currentValue);
   }
 
   public toggleShowSystemClasses() {
-    const currentValue = this.store.get(this.KEY_SHOW_SYSTEM_CLASSES, false);
+    const currentValue = this.shouldShowSystemClasses();
     this.store.set(this.KEY_SHOW_SYSTEM_CLASSES, !currentValue);
+  }
+
+  public toggleShowInternalFeatures() {
+    const currentValue = this.shouldShowInternalFeatures();
+    this.store.set(this.KEY_SHOW_INTERNAL_FEATURES, !currentValue);
   }
 
   public shouldShowPartialRealms(): boolean {
@@ -69,6 +75,10 @@ class RealmStudioStore {
 
   public shouldShowSystemClasses(): boolean {
     return this.store.get(this.KEY_SHOW_SYSTEM_CLASSES, false);
+  }
+
+  public shouldShowInternalFeatures(): boolean {
+    return this.store.get(this.KEY_SHOW_INTERNAL_FEATURES, false);
   }
 
   // Window option related methods


### PR DESCRIPTION
- Persist whether a user is Realm employee to avoid having to run studio with magic env variables
- Add an option to open the cache folder to make it easier to inspect client Realms
- Expose a way to connect to ROS from a custom url.

For the custom url, the format is:
`x-realm-studio://connect-to-ros?url=ROS-URL&credentials=JSON_SERIALIZED_CREDENTIALS`.

For example:

`x-realm-studio://connect-to-ros?url=https%3A%2F%2Ffoo-bar.cloud.realm.io%2F&credentials=%7B%0A%20%20%20%20%22kind%22%3A%20%22jwt%22%2C%0A%20%20%20%20%22providerName%22%3A%20%22jwt%22%2C%0A%20%20%20%20%22token%22%3A%20%22some-long-token%22%0A%7D`

Decoding, we can see the two parameters:
- url: `https://foo-bar.cloud.realm.io/` 
- credentials: 
  ```
  {
      "kind": "jwt",
      "providerName": "jwt",
      "token": "some-long-token"
  }
  ```
