### PR TITLE
Revert "Update realm-js to 2.28.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3244,7 +3244,7 @@
     },
     "deepmerge": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/deepmerge/-/deepmerge-2.1.0.tgz",
       "integrity": "sha512-Q89Z26KAfA3lpPGhbF6XMfYAm3jIV3avViy6KOJ2JLzFbeWHOvPQUu5aSJIWXap3gDZC2y1eF5HXEPI2wGqgvw=="
     },
     "default-gateway": {
@@ -5221,9 +5221,9 @@
       }
     },
     "fs-minipass": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
-      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "requires": {
         "minipass": "^2.2.1"
       }
@@ -6013,7 +6013,7 @@
     },
     "get-stream": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
       "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
       "requires": {
         "object-assign": "^4.0.1",
@@ -9526,13 +9526,28 @@
       "optional": true
     },
     "needle": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
-      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+      "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
       "requires": {
-        "debug": "^3.2.6",
+        "debug": "^2.1.2",
         "iconv-lite": "^0.4.4",
         "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "negotiator": {
@@ -9725,9 +9740,9 @@
       }
     },
     "node-machine-id": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
-      "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ=="
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.10.tgz",
+      "integrity": "sha512-6SVxo3Ic2Qc09z1rCJh3No7ubizPLszImsMQnZZWfzeOC6SYU4orN214++c3ikB8uaP/A6dwSlO88A3ohI5oNA=="
     },
     "node-object-hash": {
       "version": "1.4.2",
@@ -11444,26 +11459,26 @@
       }
     },
     "realm": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-2.28.1.tgz",
-      "integrity": "sha512-2p/KMpqGXkcLopXyiAGyLUd8SyrBRwjjcy1gjI6KbD+/FaW8AaONaeOiF9c/kYc5kQ7xM2tJEOw1iBtoUihHXA==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-2.23.0.tgz",
+      "integrity": "sha512-ChCuhoRJR9yefXuC0MTKS6og6NTP9Wyyyubsk3GSXiYhgCf/IJ7E1Jtsoo6/bbpaSe3Q++5YFMnV4hX+KYP2Cg==",
       "requires": {
         "command-line-args": "^4.0.6",
         "decompress": "^4.2.0",
         "deepmerge": "2.1.0",
-        "fs-extra": "^4.0.3",
+        "fs-extra": "^4.0.2",
         "https-proxy-agent": "^2.2.1",
-        "ini": "^1.3.5",
-        "nan": "^2.12.1",
-        "node-fetch": "^1.7.3",
+        "ini": "^1.3.4",
+        "nan": "^2.10.0",
+        "node-fetch": "^1.6.3",
         "node-machine-id": "^1.1.10",
         "node-pre-gyp": "^0.11.0",
-        "progress": "^2.0.3",
-        "prop-types": "^15.6.2",
+        "progress": "^2.0.0",
+        "prop-types": "^15.5.10",
         "request": "^2.88.0",
         "stream-counter": "^1.0.0",
         "sync-request": "^3.0.1",
-        "url-parse": "^1.4.4"
+        "url-parse": "^1.2.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -13499,17 +13514,17 @@
       "dev": true
     },
     "tar": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
-      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.5",
-        "minizlib": "^1.2.1",
+        "minipass": "^2.3.4",
+        "minizlib": "^1.1.1",
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.3"
+        "yallist": "^3.0.2"
       }
     },
     "tar-fs": {

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "react-sortable-hoc": "^1.8.3",
     "react-virtualized": "^9.20.1",
     "reactstrap": "^7.1.0",
-    "realm": "2.28.1",
+    "realm": "2.23.0",
     "semver": "^5.7.0",
     "subscriptions-transport-ws": "^0.9.16",
     "uuid": "^3.1.0"


### PR DESCRIPTION
Reverts realm/realm-studio#1150

Updating to 2.28.1 breaks deep linking due to https://github.com/realm/realm-js/issues/2406.