### PR TITLE
Upgrading to Realm 3.2.0

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,9 @@
 [Changes since {PREVIOUS_VERSION}](https://github.com/realm/realm-studio/compare/{PREVIOUS_VERSION}...{CURRENT_VERSION})
 
+### Breaking Changes
+
+- Cannot administer Realm Object Servers prior to version 3.23.1.
+
 ### Enhancements
 
 - Added TypeScript schema exporter ([#1185](https://github.com/realm/realm-studio/pull/1185))

--- a/package-lock.json
+++ b/package-lock.json
@@ -7695,9 +7695,9 @@
       "dev": true
     },
     "ignore-walk": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.2.tgz",
-      "integrity": "sha512-EXyErtpHbn75ZTsOADsfx6J/FPo6/5cjev46PXrcTpd8z3BoRkXgYu9/JVqrI7tusjmwCZutGeRJeU0Wo1e4Cw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
       "requires": {
         "minimatch": "^3.0.4"
       }
@@ -10162,31 +10162,20 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minipass": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.8.6.tgz",
-      "integrity": "sha512-lFG7d6g3+/UaFDCOtqPiKAC9zngWWsQZl1g5q6gaONqrjq61SX2xFqXMleQiFVyDpYwa018E9hmlAFY22PCb+A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
       }
     },
     "minizlib": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.1.tgz",
-      "integrity": "sha512-8AgjrT7C8U/HQWM+02YJHLPh4BypAhc5pFddr0nCcowNy1Hj0hmKPMq9WkjBMn0rtUg3ia30MkCexdd1pTiTIA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
       "requires": {
         "minipass": "^2.9.0"
-      },
-      "dependencies": {
-        "minipass": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        }
       }
     },
     "mississippi": {
@@ -11144,9 +11133,9 @@
       "dev": true
     },
     "npm-packlist": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
-      "integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.6.tgz",
+      "integrity": "sha512-u65uQdb+qwtGvEJh/DgQgW1Xg7sqeNbmxYyrvlNznaVTjV3E5P6F/EFjM+BVHXl7JJlsdG8A64M0XI8FI/IOlg==",
       "requires": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1"
@@ -12792,9 +12781,9 @@
       }
     },
     "realm": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-3.1.0.tgz",
-      "integrity": "sha512-Oa2aAfss/GrG3glWzTqsI1FTvMLzTZb0fLjO7w1zXnoF1rNsBc7sTlBzBBgow2nZZEfNxTFF/7mKS9BH03sllA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-3.2.0.tgz",
+      "integrity": "sha512-bAS16v0jVmmH2/o4kEdBETf+ywhIy9Bq4rXKBpGZ9egSBdlYBIOfO/dhDqeMaR+toEGrfMgvobDSiQYUgGiBBw==",
       "requires": {
         "command-line-args": "^4.0.6",
         "decompress": "^4.2.0",
@@ -14537,6 +14526,17 @@
                 "pac-resolver": "^3.0.0",
                 "raw-body": "^2.2.0",
                 "socks-proxy-agent": "^4.0.1"
+              },
+              "dependencies": {
+                "https-proxy-agent-snyk-fork": {
+                  "version": "git://github.com/snyk/node-https-proxy-agent.git#5e86ccb682d0c833c8daa25ee6f91c670161cd66",
+                  "from": "git://github.com/snyk/node-https-proxy-agent.git#fix/https-agent-vuln",
+                  "dev": true,
+                  "requires": {
+                    "agent-base": "^4.3.0",
+                    "debug": "^3.1.0"
+                  }
+                }
               }
             },
             "pac-resolver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5958,11 +5958,11 @@
       }
     },
     "fs-minipass": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "^2.6.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -7695,9 +7695,9 @@
       "dev": true
     },
     "ignore-walk": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.2.tgz",
+      "integrity": "sha512-EXyErtpHbn75ZTsOADsfx6J/FPo6/5cjev46PXrcTpd8z3BoRkXgYu9/JVqrI7tusjmwCZutGeRJeU0Wo1e4Cw==",
       "requires": {
         "minimatch": "^3.0.4"
       }
@@ -10162,20 +10162,31 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minipass": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.8.6.tgz",
+      "integrity": "sha512-lFG7d6g3+/UaFDCOtqPiKAC9zngWWsQZl1g5q6gaONqrjq61SX2xFqXMleQiFVyDpYwa018E9hmlAFY22PCb+A==",
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
       }
     },
     "minizlib": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.1.tgz",
+      "integrity": "sha512-8AgjrT7C8U/HQWM+02YJHLPh4BypAhc5pFddr0nCcowNy1Hj0hmKPMq9WkjBMn0rtUg3ia30MkCexdd1pTiTIA==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "^2.9.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        }
       }
     },
     "mississippi": {
@@ -10751,28 +10762,13 @@
       }
     },
     "needle": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
-      "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
       "requires": {
-        "debug": "^2.1.2",
+        "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
         "sax": "^1.2.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "negotiator": {
@@ -10966,9 +10962,9 @@
       }
     },
     "node-machine-id": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.10.tgz",
-      "integrity": "sha512-6SVxo3Ic2Qc09z1rCJh3No7ubizPLszImsMQnZZWfzeOC6SYU4orN214++c3ikB8uaP/A6dwSlO88A3ohI5oNA=="
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
+      "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ=="
     },
     "node-object-hash": {
       "version": "1.4.2",
@@ -10977,9 +10973,9 @@
       "dev": true
     },
     "node-pre-gyp": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
-      "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz",
+      "integrity": "sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==",
       "requires": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -11148,9 +11144,9 @@
       "dev": true
     },
     "npm-packlist": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
-      "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
+      "integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
       "requires": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1"
@@ -12796,26 +12792,26 @@
       }
     },
     "realm": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-2.23.0.tgz",
-      "integrity": "sha512-ChCuhoRJR9yefXuC0MTKS6og6NTP9Wyyyubsk3GSXiYhgCf/IJ7E1Jtsoo6/bbpaSe3Q++5YFMnV4hX+KYP2Cg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-3.1.0.tgz",
+      "integrity": "sha512-Oa2aAfss/GrG3glWzTqsI1FTvMLzTZb0fLjO7w1zXnoF1rNsBc7sTlBzBBgow2nZZEfNxTFF/7mKS9BH03sllA==",
       "requires": {
         "command-line-args": "^4.0.6",
         "decompress": "^4.2.0",
         "deepmerge": "2.1.0",
-        "fs-extra": "^4.0.2",
+        "fs-extra": "^4.0.3",
         "https-proxy-agent": "^2.2.1",
-        "ini": "^1.3.4",
-        "nan": "^2.10.0",
-        "node-fetch": "^1.6.3",
+        "ini": "^1.3.5",
+        "nan": "^2.12.1",
+        "node-fetch": "^1.7.3",
         "node-machine-id": "^1.1.10",
-        "node-pre-gyp": "^0.11.0",
-        "progress": "^2.0.0",
-        "prop-types": "^15.5.10",
+        "node-pre-gyp": "^0.13.0",
+        "progress": "^2.0.3",
+        "prop-types": "^15.6.2",
         "request": "^2.88.0",
         "stream-counter": "^1.0.0",
         "sync-request": "^3.0.1",
-        "url-parse": "^1.2.0"
+        "url-parse": "^1.4.4"
       },
       "dependencies": {
         "fs-extra": {
@@ -16145,17 +16141,17 @@
       "dev": true
     },
     "tar": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.4",
-        "minizlib": "^1.1.1",
+        "minipass": "^2.8.6",
+        "minizlib": "^1.2.1",
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
+        "yallist": "^3.0.3"
       }
     },
     "tar-fs": {

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "react-sortable-hoc": "^1.10.1",
     "react-virtualized": "^9.21.1",
     "reactstrap": "^8.0.0",
-    "realm": "3.1.0",
+    "realm": "3.2.0",
     "semver": "^6.3.0",
     "subscriptions-transport-ws": "^0.9.16",
     "uuid": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "react-sortable-hoc": "^1.10.1",
     "react-virtualized": "^9.21.1",
     "reactstrap": "^8.0.0",
-    "realm": "2.23.0",
+    "realm": "3.1.0",
     "semver": "^6.3.0",
     "subscriptions-transport-ws": "^0.9.16",
     "uuid": "^3.3.3"

--- a/scripts/next-version.js
+++ b/scripts/next-version.js
@@ -5,8 +5,8 @@ const cp = require('child_process');
 const releaseNotesPath = path.resolve(__dirname, '../RELEASENOTES.md');
 const releaseNotes = fs.readFileSync(releaseNotesPath, 'utf8');
 
-const hasBreakingChanges = /## Breaking Changes/.test(releaseNotes);
-const hasNoEnhancements = /## Enhancements\n\n\* None/.test(releaseNotes);
+const hasBreakingChanges = /### Breaking Changes/.test(releaseNotes);
+const hasNoEnhancements = /### Enhancements\n\n\* None/.test(releaseNotes);
 if (hasBreakingChanges) {
   console.log('major');
 } else if (hasNoEnhancements) {


### PR DESCRIPTION
~This PR is against the `next-major` branch as Realm JS in this version cannot connect to version of ROS below v3.23.1.~ It remains to be tested, but there might be no issues in upgrading Realm JS, in regards to backwards compatibilities against earlier versions of ROS.