### PR TITLE
Object level permission when filtered or sorted

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- None
+- Fixed displaying object level permissions for the correct object when the table of objects were filtered or sorted. ([#1180](https://github.com/realm/realm-studio/pull/1180))
 
 ### Internals
 

--- a/src/ui/RealmBrowser/Content/Content.tsx
+++ b/src/ui/RealmBrowser/Content/Content.tsx
@@ -181,6 +181,7 @@ export const Content = ({
             isOpen={isPermissionSidebarOpen}
             onToggle={onPermissionSidebarToggle}
             focus={focus}
+            filteredSortedResults={filteredSortedResults}
             highlight={highlight}
             realm={props.realm}
           />

--- a/src/ui/RealmBrowser/Content/PermissionSidebar/ObjectPermissionSidebar.tsx
+++ b/src/ui/RealmBrowser/Content/PermissionSidebar/ObjectPermissionSidebar.tsx
@@ -44,6 +44,7 @@ interface IObjectPermissionSidebarProps {
   ) => void;
   onRoleClick: (role: IRole) => void;
   realmPermissions: Permissions | null;
+  filteredSortedResults: Realm.Collection<any>;
 }
 
 export const ObjectPermissionSidebar = ({
@@ -58,6 +59,7 @@ export const ObjectPermissionSidebar = ({
   onRoleClick,
   onToggle,
   realmPermissions,
+  filteredSortedResults,
 }: IObjectPermissionSidebarProps) => (
   <Sidebar
     className={className}
@@ -72,7 +74,7 @@ export const ObjectPermissionSidebar = ({
       }
       hasPermissionProperty={hasPermissionProperty}
       objects={Array.from(highlight.rows.values()).map(
-        index => focus.results[index],
+        index => filteredSortedResults[index],
       )}
       onPermissionChange={onPermissionChange}
       onRoleClick={onRoleClick}

--- a/src/ui/RealmBrowser/Content/PermissionSidebar/index.tsx
+++ b/src/ui/RealmBrowser/Content/PermissionSidebar/index.tsx
@@ -41,6 +41,7 @@ interface IPermissionSidebarContainerProps {
   onToggle?: () => void;
   highlight?: IHighlight;
   focus: Focus;
+  filteredSortedResults: Realm.Collection<any>;
   // TODO: Use the Realm react context to access the Realm
   realm: Realm;
 }
@@ -81,6 +82,7 @@ class PermissionSidebarContainer extends React.Component<
             className={this.props.className}
             classPermissions={classPermissions}
             focus={this.props.focus}
+            filteredSortedResults={this.props.filteredSortedResults}
             getObjectPermissions={this.getObjectPermissions}
             hasPermissionProperty={hasPermissionProperty}
             highlight={this.props.highlight}


### PR DESCRIPTION
This fixes https://github.com/realm/realm-studio/issues/1112 by passing the filtered and sorted results to the `ObjectPermissionSidebar` component and using this instead of the `focus.results` when displaying the object level permissions.