### PR TITLE
Java & Kotlin schema export fixed

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - Fixed displaying object level permissions for the correct object when the table of objects were filtered or sorted. ([#1180](https://github.com/realm/realm-studio/pull/1180))
+- Fixed exporting schemas to Java and Kotlin. The @Required annotation was incorrectly applied to lists of non-primitives. ([#1181](https://github.com/realm/realm-studio/pull/1181), since v1.8.0)
 
 ### Internals
 

--- a/src/services/schema-export/languages/java.ts
+++ b/src/services/schema-export/languages/java.ts
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { ISchemaFile, SchemaExporter } from '../schemaExporter';
+import { isPrimitive } from '../utils';
 
 export default class JavaSchemaExporter extends SchemaExporter {
   private static readonly PADDING = '    ';
@@ -65,10 +66,7 @@ export default class JavaSchemaExporter extends SchemaExporter {
           this.realmImports.add('import io.realm.annotations.Index;');
         }
 
-        if (
-          !prop.optional &&
-          this.javaPropertyTypeCanBeMarkedRequired(prop.type)
-        ) {
+        if (!prop.optional && this.javaPropertyTypeCanBeMarkedRequired(prop)) {
           this.realmImports.add('import io.realm.annotations.Required;');
         }
       }
@@ -109,7 +107,7 @@ export default class JavaSchemaExporter extends SchemaExporter {
     } else if (prop.indexed) {
       this.fieldsContent += `${JavaSchemaExporter.PADDING}@Index\n`;
     }
-    if (!prop.optional && this.javaPropertyTypeCanBeMarkedRequired(prop.type)) {
+    if (!prop.optional && this.javaPropertyTypeCanBeMarkedRequired(prop)) {
       this.fieldsContent += `${JavaSchemaExporter.PADDING}@Required\n`;
     }
 
@@ -132,8 +130,10 @@ export default class JavaSchemaExporter extends SchemaExporter {
     }; }\n\n`;
   }
 
-  private javaPropertyTypeCanBeMarkedRequired(type: any): boolean {
-    switch (type) {
+  private javaPropertyTypeCanBeMarkedRequired(
+    property: Realm.ObjectSchemaProperty,
+  ): boolean {
+    switch (property.type) {
       case 'bool':
       case 'int':
       case 'float':
@@ -143,8 +143,9 @@ export default class JavaSchemaExporter extends SchemaExporter {
       case 'string':
       case 'data':
       case 'date':
-      case 'list':
         return true;
+      case 'list':
+        return isPrimitive(property.objectType);
     }
     return false;
   }

--- a/src/services/schema-export/languages/kotlin.ts
+++ b/src/services/schema-export/languages/kotlin.ts
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { ISchemaFile, SchemaExporter } from '../schemaExporter';
+import { isPrimitive } from '../utils';
 
 export default class KotlinSchemaExporter extends SchemaExporter {
   private static readonly PADDING = '    ';
@@ -62,7 +63,11 @@ export default class KotlinSchemaExporter extends SchemaExporter {
         if (prop.indexed && prop.name !== schema.primaryKey) {
           this.realmImports.add('import io.realm.annotations.Index');
         }
-        if (!prop.optional && prop.type === 'list') {
+        if (
+          !prop.optional &&
+          prop.type === 'list' &&
+          isPrimitive(prop.objectType)
+        ) {
           this.realmImports.add('import io.realm.annotations.Required');
         }
       }
@@ -99,7 +104,11 @@ export default class KotlinSchemaExporter extends SchemaExporter {
     } else if (prop.indexed) {
       this.fieldsContent += `${KotlinSchemaExporter.PADDING}@Index\n`;
     }
-    if (!prop.optional && prop.type === 'list') {
+    if (
+      !prop.optional &&
+      prop.type === 'list' &&
+      isPrimitive(prop.objectType)
+    ) {
       this.fieldsContent += `${KotlinSchemaExporter.PADDING}@Required\n`;
     }
     this.fieldsContent += `${KotlinSchemaExporter.PADDING}var ${

--- a/src/services/schema-export/tests/models/all/java/LinkTypes.java
+++ b/src/services/schema-export/tests/models/all/java/LinkTypes.java
@@ -3,12 +3,10 @@ package your.package.name.here;
 
 import io.realm.RealmObject;
 import io.realm.RealmList;
-import io.realm.annotations.Required;
 
 public class LinkTypes extends RealmObject {
     private ReverseType objectType;
     private ReverseType objectType2;
-    @Required
     private RealmList<ReverseType> listType;
 
     public ReverseType getObjectType() { return objectType; }

--- a/src/services/schema-export/tests/models/all/java/RequiredTypes.java
+++ b/src/services/schema-export/tests/models/all/java/RequiredTypes.java
@@ -31,7 +31,6 @@ public class RequiredTypes extends RealmObject {
     private RealmList<Date> dateRequiredArray;
     @Required
     private RealmList<byte[]> dataRequiredArray;
-    @Required
     private RealmList<RequiredTypes> objectRequiredArray;
 
     public boolean isBoolRequired() { return boolRequired; }

--- a/src/services/schema-export/tests/models/all/kotlin/LinkTypes.kt
+++ b/src/services/schema-export/tests/models/all/kotlin/LinkTypes.kt
@@ -3,13 +3,11 @@ package your.package.name.here
 
 import io.realm.RealmObject
 import io.realm.RealmList
-import io.realm.annotations.Required
 
 open class LinkTypes : RealmObject() {
 
     var objectType: ReverseType? = null
     var objectType2: ReverseType? = null
-    @Required
     var listType: RealmList<ReverseType> = RealmList()
 
 }

--- a/src/services/schema-export/tests/models/all/kotlin/RequiredTypes.kt
+++ b/src/services/schema-export/tests/models/all/kotlin/RequiredTypes.kt
@@ -29,7 +29,6 @@ open class RequiredTypes : RealmObject() {
     var dateRequiredArray: RealmList<Date> = RealmList()
     @Required
     var dataRequiredArray: RealmList<ByteArray> = RealmList()
-    @Required
     var objectRequiredArray: RealmList<RequiredTypes> = RealmList()
 
 }

--- a/src/services/schema-export/tests/models/sample/java/SampleTypes.java
+++ b/src/services/schema-export/tests/models/sample/java/SampleTypes.java
@@ -18,7 +18,6 @@ public class SampleTypes extends RealmObject {
     @Index
     private long indexedInt;
     private SampleTypes linkToObject;
-    @Required
     private RealmList<SampleTypes> listOfObjects;
 
     public long getPrimary() { return primary; }

--- a/src/services/schema-export/tests/models/sample/kotlin/SampleTypes.kt
+++ b/src/services/schema-export/tests/models/sample/kotlin/SampleTypes.kt
@@ -19,7 +19,6 @@ open class SampleTypes : RealmObject() {
     @Index
     var indexedInt: Long = 0
     var linkToObject: SampleTypes? = null
-    @Required
     var listOfObjects: RealmList<SampleTypes> = RealmList()
 
 }

--- a/src/services/schema-export/utils.ts
+++ b/src/services/schema-export/utils.ts
@@ -1,0 +1,14 @@
+export function isPrimitive(type: string | undefined) {
+  switch (type) {
+    case 'bool':
+    case 'int':
+    case 'float':
+    case 'double':
+    case 'string':
+    case 'data':
+    case 'date':
+      return true;
+    default:
+      return false;
+  }
+}


### PR DESCRIPTION
This fixes https://github.com/realm/realm-studio/issues/1163 by ensuring that the `@Required` annotation is only used on lists of primitives when exporting schemas to either Java or Kotlin.