### PR TITLE
Implemented TypeScript schema export

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 
-- None
+- Added TypeScript schema exporter ([#1185](https://github.com/realm/realm-studio/pull/1185))
 
 ### Fixed
 

--- a/src/services/schema-export/index.ts
+++ b/src/services/schema-export/index.ts
@@ -21,6 +21,7 @@ import JavaSchemaExporter from './languages/java';
 import JSSchemaExporter from './languages/javascript';
 import KotlinSchemaExporter from './languages/kotlin';
 import SwiftSchemaExporter from './languages/swift';
+import TSSchemaExporter from './languages/typescript';
 
 import { ISchemaExporter } from './schemaExporter';
 
@@ -40,6 +41,8 @@ export const SchemaExporter = (language: Language): ISchemaExporter => {
       return new SwiftSchemaExporter();
     case Language.JS:
       return new JSSchemaExporter();
+    case Language.TS:
+      return new TSSchemaExporter();
     case Language.Java:
       return new JavaSchemaExporter();
     case Language.Kotlin:

--- a/src/services/schema-export/languages/javascript.ts
+++ b/src/services/schema-export/languages/javascript.ts
@@ -20,8 +20,32 @@ import * as fsPath from 'path';
 import { ISchemaFile, SchemaExporter } from '../schemaExporter';
 
 export default class JSSchemaExporter extends SchemaExporter {
-  constructor() {
-    super();
+  public static propertyLine(prop: any, primaryKey: boolean): string {
+    // Name of the type
+    let typeStr = '';
+    switch (prop.type) {
+      case 'list':
+      case 'object':
+        typeStr = prop.objectType;
+        break;
+      default:
+        typeStr = prop.type;
+    }
+    if (prop.optional && prop.type !== 'object') {
+      typeStr += '?';
+    }
+    if (prop.type === 'list') {
+      typeStr += '[]';
+    }
+
+    // Make line
+    let line = prop.name + ': ';
+    if (prop.indexed && !primaryKey) {
+      line += `{ type: '${typeStr}', indexed: true }`;
+    } else {
+      line += `'${typeStr}'`;
+    }
+    return line;
   }
 
   public exportSchema(realm: Realm): ISchemaFile[] {
@@ -55,7 +79,7 @@ export default class JSSchemaExporter extends SchemaExporter {
         if (prop.type === 'linkingObjects') {
           continue;
         }
-        line = '    ' + this.propertyLine(prop, primaryKey);
+        line = '    ' + JSSchemaExporter.propertyLine(prop, primaryKey);
         if (i++ < lastIdx) {
           line += ',';
         }
@@ -64,33 +88,5 @@ export default class JSSchemaExporter extends SchemaExporter {
     }
 
     this.appendLine('  }\n}\n');
-  }
-
-  public propertyLine(prop: any, primaryKey: boolean): string {
-    // Name of the type
-    let typeStr = '';
-    switch (prop.type) {
-      case 'list':
-      case 'object':
-        typeStr = prop.objectType;
-        break;
-      default:
-        typeStr = prop.type;
-    }
-    if (prop.optional && prop.type !== 'object') {
-      typeStr += '?';
-    }
-    if (prop.type === 'list') {
-      typeStr += '[]';
-    }
-
-    // Make line
-    let line = prop.name + ': ';
-    if (prop.indexed && !primaryKey) {
-      line += `{ type: '${typeStr}', indexed: true }`;
-    } else {
-      line += `'${typeStr}'`;
-    }
-    return line;
   }
 }

--- a/src/services/schema-export/languages/typescript.ts
+++ b/src/services/schema-export/languages/typescript.ts
@@ -132,7 +132,7 @@ export default class TSSchemaExporter extends SchemaExporter {
   public propertyLine(prop: INamedObjectSchemaProperty): string {
     return (
       prop.name +
-      (prop.optional ? '?' : '') +
+      (prop.optional && prop.type !== 'list' ? '?' : '') +
       ': ' +
       this.getTypeFromProperty(prop) +
       ';'

--- a/src/services/schema-export/languages/typescript.ts
+++ b/src/services/schema-export/languages/typescript.ts
@@ -1,0 +1,141 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import * as fsPath from 'path';
+import { ISchemaFile, SchemaExporter } from '../schemaExporter';
+import JSSchemaExporter from './javascript';
+
+interface INamedObjectSchemaProperty extends Realm.ObjectSchemaProperty {
+  name: string;
+}
+
+export default class TSSchemaExporter extends SchemaExporter {
+  public exportSchema(realm: Realm): ISchemaFile[] {
+    this.appendLine('import * as Realm from "realm";\n');
+
+    realm.schema.forEach(schema => {
+      this.makeSchema(schema);
+    });
+
+    const schemaNames = realm.schema.map(schema => schema.name + 'Schema');
+    this.appendLine(`export const Schema = [${schemaNames.join(', ')}];`);
+
+    this.addFile(fsPath.parse(realm.path).name + '-model.ts', this.content);
+
+    return this.files;
+  }
+
+  public makeSchema(schema: Realm.ObjectSchema) {
+    // TypeScript Type
+
+    this.appendLine(`export type ${schema.name} = {`);
+    for (const key in schema.properties) {
+      if (schema.properties.hasOwnProperty(key)) {
+        const prop = schema.properties[key] as INamedObjectSchemaProperty;
+        // Ignoring 'linkingObjects' https://github.com/realm/realm-js/issues/1519
+        // happens only tests, when opening a Realm using schema that includes 'linkingObjects'
+        if (prop.type === 'linkingObjects') {
+          continue;
+        }
+        this.appendLine('    ' + this.propertyLine(prop));
+      }
+    }
+    this.appendLine(`};\n`);
+
+    // JavaScript Schema
+
+    this.appendLine(`export const ${schema.name}Schema = {`);
+    this.appendLine(`  name: '${schema.name}',`);
+
+    if (schema.primaryKey) {
+      this.appendLine(`  primaryKey: '${schema.primaryKey}',`);
+    }
+
+    // properties
+    this.appendLine(`  properties: {`);
+    let i = 1;
+    const lastIdx = Object.keys(schema.properties).length;
+    let line: string;
+    for (const key in schema.properties) {
+      if (schema.properties.hasOwnProperty(key)) {
+        const primaryKey = key === schema.primaryKey;
+        const prop: any = schema.properties[key];
+        // Ignoring 'linkingObjects' https://github.com/realm/realm-js/issues/1519
+        // happens only tests, when opening a Realm using schema that includes 'linkingObjects'
+        if (prop.type === 'linkingObjects') {
+          continue;
+        }
+        line = '    ' + JSSchemaExporter.propertyLine(prop, primaryKey);
+        if (i++ < lastIdx) {
+          line += ',';
+        }
+        this.appendLine(line);
+      }
+    }
+
+    this.appendLine('  }\n};\n');
+  }
+
+  /**
+   * Maps from a singular Realm type to a TypeScript type.
+   * @see https://realm.io/docs/javascript/latest/#supported-types
+   * @param prop The property to produce a TypeScript type for.
+   */
+  public getTypeFromPropertyType(type: Realm.PropertyType | undefined) {
+    switch (type) {
+      case 'bool':
+        return 'boolean';
+      case 'int':
+      case 'float':
+      case 'double':
+        return 'number';
+      case 'data':
+        return 'ArrayBuffer';
+      case 'date':
+        return 'Date';
+      default:
+        return type;
+    }
+  }
+
+  /**
+   * Maps from the Realm type to a TypeScript type.
+   * @see https://realm.io/docs/javascript/latest/#supported-types
+   * @param prop The property to produce a TypeScript type for.
+   */
+  public getTypeFromProperty(prop: Realm.ObjectSchemaProperty) {
+    if (prop.type === 'list') {
+      const typeStr = this.getTypeFromPropertyType(prop.objectType);
+      return `Array<${typeStr}${prop.optional ? ' | undefined' : ''}>`;
+    } else if (prop.type === 'object') {
+      return this.getTypeFromPropertyType(prop.objectType);
+    } else {
+      return this.getTypeFromPropertyType(prop.type);
+    }
+  }
+
+  public propertyLine(prop: INamedObjectSchemaProperty): string {
+    return (
+      prop.name +
+      (prop.optional ? '?' : '') +
+      ': ' +
+      this.getTypeFromProperty(prop) +
+      ';'
+    );
+  }
+}

--- a/src/services/schema-export/tests/index.test.ts
+++ b/src/services/schema-export/tests/index.test.ts
@@ -102,6 +102,24 @@ describe('Export schema tests', () => {
     );
   });
 
+  it('TS export with sample types', () => {
+    assertGeneratedSchemaIsValid(
+      Language.TS,
+      `${TESTS_PATH}/models/sample/ts/SampleTypes.ts.unformatted`,
+      `${TESTS_PATH}/temporal/${Language.TS}/SampleTypes-model.ts`,
+      sampleRealm as Realm,
+    );
+  });
+
+  it('TS export with all types', () => {
+    assertGeneratedSchemaIsValid(
+      Language.TS,
+      `${TESTS_PATH}/models/all/ts/AllTypes.ts.unformatted`,
+      `${TESTS_PATH}/temporal/${Language.TS}/AllTypes-model.ts`,
+      allRealm as Realm,
+    );
+  });
+
   it('Swift export with sample types', () => {
     assertGeneratedSchemaIsValid(
       Language.Swift,

--- a/src/services/schema-export/tests/models/all/ts/AllTypes.ts.unformatted
+++ b/src/services/schema-export/tests/models/all/ts/AllTypes.ts.unformatted
@@ -1,0 +1,125 @@
+import * as Realm from "realm";
+
+export type IndexedTypes = {
+    boolIndexed: boolean;
+    intIndexed: number;
+    stringIndexed: string;
+    dateIndexed: Date;
+};
+
+export const IndexedTypesSchema = {
+  name: 'IndexedTypes',
+  primaryKey: 'intIndexed',
+  properties: {
+    boolIndexed: { type: 'bool', indexed: true },
+    intIndexed: 'int',
+    stringIndexed: { type: 'string', indexed: true },
+    dateIndexed: { type: 'date', indexed: true }
+  }
+};
+
+export type LinkTypes = {
+    objectType?: ReverseType;
+    objectType2?: ReverseType;
+    listType: Array<ReverseType>;
+};
+
+export const LinkTypesSchema = {
+  name: 'LinkTypes',
+  properties: {
+    objectType: 'ReverseType',
+    objectType2: 'ReverseType',
+    listType: 'ReverseType[]',
+  }
+};
+
+export type OptionalTypes = {
+    boolOptional?: boolean;
+    intOptional?: number;
+    floatOptional?: number;
+    doubleOptional?: number;
+    stringOptional?: string;
+    dateOptional?: Date;
+    dataOptional?: ArrayBuffer;
+    objectOptional?: RequiredTypes;
+    boolOptionalArray?: Array<boolean | undefined>;
+    intOptionalArray?: Array<number | undefined>;
+    floatOptionalArray?: Array<number | undefined>;
+    doubleOptionalArray?: Array<number | undefined>;
+    stringOptionalArray?: Array<string | undefined>;
+    dateOptionalArray?: Array<Date | undefined>;
+    dataOptionalArray?: Array<ArrayBuffer | undefined>;
+};
+
+export const OptionalTypesSchema = {
+  name: 'OptionalTypes',
+  properties: {
+    boolOptional: 'bool?',
+    intOptional: 'int?',
+    floatOptional: 'float?',
+    doubleOptional: 'double?',
+    stringOptional: 'string?',
+    dateOptional: 'date?',
+    dataOptional: 'data?',
+    objectOptional: 'RequiredTypes',
+    boolOptionalArray: 'bool?[]',
+    intOptionalArray: 'int?[]',
+    floatOptionalArray: 'float?[]',
+    doubleOptionalArray: 'double?[]',
+    stringOptionalArray: 'string?[]',
+    dateOptionalArray: 'date?[]',
+    dataOptionalArray: 'data?[]'
+  }
+};
+
+export type RequiredTypes = {
+    boolRequired: boolean;
+    intRequired: number;
+    floatRequired: number;
+    doubleRequired: number;
+    stringRequired: string;
+    dateRequired: Date;
+    dataRequired: ArrayBuffer;
+    boolRequiredArray: Array<boolean>;
+    intRequiredArray: Array<number>;
+    floatRequiredArray: Array<number>;
+    doubleRequiredArray: Array<number>;
+    stringRequiredArray: Array<string>;
+    dateRequiredArray: Array<Date>;
+    dataRequiredArray: Array<ArrayBuffer>;
+    objectRequiredArray: Array<RequiredTypes>;
+};
+
+export const RequiredTypesSchema = {
+  name: 'RequiredTypes',
+  properties: {
+    boolRequired: 'bool',
+    intRequired: 'int',
+    floatRequired: 'float',
+    doubleRequired: 'double',
+    stringRequired: 'string',
+    dateRequired: 'date',
+    dataRequired: 'data',
+    boolRequiredArray: 'bool[]',
+    intRequiredArray: 'int[]',
+    floatRequiredArray: 'float[]',
+    doubleRequiredArray: 'double[]',
+    stringRequiredArray: 'string[]',
+    dateRequiredArray: 'date[]',
+    dataRequiredArray: 'data[]',
+    objectRequiredArray: 'RequiredTypes[]'
+  }
+};
+
+export type ReverseType = {
+    links?: LinkTypes;
+};
+
+export const ReverseTypeSchema = {
+  name: 'ReverseType',
+  properties: {
+    links: 'LinkTypes'
+  }
+};
+
+export const Schema = [IndexedTypesSchema, LinkTypesSchema, OptionalTypesSchema, RequiredTypesSchema, ReverseTypeSchema];

--- a/src/services/schema-export/tests/models/all/ts/AllTypes.ts.unformatted
+++ b/src/services/schema-export/tests/models/all/ts/AllTypes.ts.unformatted
@@ -42,13 +42,13 @@ export type OptionalTypes = {
     dateOptional?: Date;
     dataOptional?: ArrayBuffer;
     objectOptional?: RequiredTypes;
-    boolOptionalArray?: Array<boolean | undefined>;
-    intOptionalArray?: Array<number | undefined>;
-    floatOptionalArray?: Array<number | undefined>;
-    doubleOptionalArray?: Array<number | undefined>;
-    stringOptionalArray?: Array<string | undefined>;
-    dateOptionalArray?: Array<Date | undefined>;
-    dataOptionalArray?: Array<ArrayBuffer | undefined>;
+    boolOptionalArray: Array<boolean | undefined>;
+    intOptionalArray: Array<number | undefined>;
+    floatOptionalArray: Array<number | undefined>;
+    doubleOptionalArray: Array<number | undefined>;
+    stringOptionalArray: Array<string | undefined>;
+    dateOptionalArray: Array<Date | undefined>;
+    dataOptionalArray: Array<ArrayBuffer | undefined>;
 };
 
 export const OptionalTypesSchema = {

--- a/src/services/schema-export/tests/models/sample/ts/SampleTypes.ts.unformatted
+++ b/src/services/schema-export/tests/models/sample/ts/SampleTypes.ts.unformatted
@@ -4,7 +4,7 @@ export type SampleTypes = {
     primary: number;
     ArrayFloatValue?: number;
     listOfStrings: Array<string>;
-    listOfOptionalDates?: Array<Date | undefined>;
+    listOfOptionalDates: Array<Date | undefined>;
     indexedInt: number;
     linkToObject?: SampleTypes;
     listOfObjects: Array<SampleTypes>;

--- a/src/services/schema-export/tests/models/sample/ts/SampleTypes.ts.unformatted
+++ b/src/services/schema-export/tests/models/sample/ts/SampleTypes.ts.unformatted
@@ -1,0 +1,27 @@
+import * as Realm from "realm";
+
+export type SampleTypes = {
+    primary: number;
+    ArrayFloatValue?: number;
+    listOfStrings: Array<string>;
+    listOfOptionalDates?: Array<Date | undefined>;
+    indexedInt: number;
+    linkToObject?: SampleTypes;
+    listOfObjects: Array<SampleTypes>;
+};
+
+export const SampleTypesSchema = {
+  name: 'SampleTypes',
+  primaryKey: 'primary',
+  properties: {
+    primary: 'int',
+    ArrayFloatValue: 'float?',
+    listOfStrings: 'string[]',
+    listOfOptionalDates: 'date?[]',
+    indexedInt: { type: 'int', indexed: true },
+    linkToObject: 'SampleTypes',
+    listOfObjects: 'SampleTypes[]',
+  }
+};
+
+export const Schema = [SampleTypesSchema];

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -175,6 +175,10 @@ class RealmBrowserContainer
           click: () => this.onExportSchema(Language.JS),
         },
         {
+          label: 'TypeScript',
+          click: () => this.onExportSchema(Language.TS),
+        },
+        {
           label: 'Java',
           click: () => this.onExportSchema(Language.Java),
         },


### PR DESCRIPTION
I (thought I) needed the TypeScript definition of the `/__admin` Realm while I was working on #1171, so I implemented the TypeScript schema exporter: Fixing #435 for now.