### PR TITLE
Fixed showing fatal errors

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,7 +8,8 @@
 
 - Fixed displaying object level permissions for the correct object when the table of objects were filtered or sorted. ([#1180](https://github.com/realm/realm-studio/pull/1180))
 - Fixed exporting schemas to Java and Kotlin. The @Required annotation was incorrectly applied to lists of non-primitives. ([#1181](https://github.com/realm/realm-studio/pull/1181), since v1.8.0)
-- On Windows, ensure there'll be no unnecessary local path collisions when browsing multiple Realm Cloud instances. The effect would have been that Realms with the same name that resided on different servers would need to be redownloaded every time you switched servers. ([#1183](https://github.com/realm/realm-studio/issues/1183), since v3.7.0)
+- On Windows, ensure there'll be no unnecessary local path collisions when browsing multiple Realm Cloud instances. The effect would have been that Realms with the same name that resided on different servers would need to be redownloaded every time you switched servers. ([#1184](https://github.com/realm/realm-studio/pull/1184), since v3.7.0)
+- Fixed displaying fatal errors in the Realm Browser. ([#1189](https://github.com/realm/realm-studio/pull/1189), since v1.0.0-rc.2)
 
 ### Internals
 

--- a/src/ui/reusable/RealmLoadingComponent/index.tsx
+++ b/src/ui/reusable/RealmLoadingComponent/index.tsx
@@ -224,13 +224,16 @@ export abstract class RealmLoadingComponent<
   }
 
   private progressChanged = (transferred: number, transferable: number) => {
-    this.setState({
-      progress: {
-        message: 'Downloading Realm',
-        status: transferred >= transferable ? 'done' : 'in-progress',
-        transferred,
-        transferable,
-      },
-    });
+    // Don't change the progress if a failure has occurred
+    if (this.state.progress.status !== 'failed') {
+      this.setState({
+        progress: {
+          message: 'Downloading Realm',
+          status: transferred >= transferable ? 'done' : 'in-progress',
+          transferred,
+          transferable,
+        },
+      });
+    }
   };
 }


### PR DESCRIPTION
Download progress events can get emitted after the sync error callback is called. This PR ensures no progress events can update the state after the fatal error has updated the `progress` state.