### PR TITLE
ROS 3.19.0 compatibility

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - Fixed auto updating, to ask before downloading enabling users to say "no", quit and restart Studio without getting the new update. ([#1209](https://github.com/realm/realm-studio/pull/1209), since v0.0.1-alpha.8)
+- Fixed prompting users to download the 3.8.1-ros-3-19-0 compatibility version when connecting to ROS < 3.20.1. ([#1211](https://github.com/realm/realm-studio/pull/1211), since v3.8.0)
 
 ### Internals
 

--- a/src/ui/ServerAdministration/index.tsx
+++ b/src/ui/ServerAdministration/index.tsx
@@ -103,6 +103,7 @@ class ServerAdministrationContainer
   }> = [
     { rosVersion: '3.0.0', studioVersion: '1.19.2-ros2' },
     { rosVersion: '3.11.0', studioVersion: '2.9.1-ros3.10.7' },
+    { rosVersion: '3.20.1', studioVersion: '3.8.1-ros-3-19-0' },
   ];
 
   public async componentDidMount() {


### PR DESCRIPTION
This fixes #1207 by adding the new release to the list of compatibility versions.