### PR TITLE
List highlight fixed

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,6 +8,7 @@
 
 - Fixed auto updating, to ask before downloading enabling users to say "no", quit and restart Studio without getting the new update. ([#1209](https://github.com/realm/realm-studio/pull/1209), since v0.0.1-alpha.8)
 - Fixed prompting users to download the 3.8.1-ros-3-19-0 compatibility version when connecting to ROS < 3.20.1. ([#1211](https://github.com/realm/realm-studio/pull/1211), since v3.8.0)
+- Fixed highlighting rows for editing in a `List`. ([#1216](https://github.com/realm/realm-studio/pull/1216), since v2.9.0)
 
 ### Internals
 

--- a/src/ui/RealmBrowser/Content/index.tsx
+++ b/src/ui/RealmBrowser/Content/index.tsx
@@ -769,6 +769,7 @@ class ContentContainer extends React.Component<
         }
         this.setState({ highlight: { rows } });
       } else if (e.button === 0 && focus.kind !== 'list') {
+        // The user left-clicked on a non-list row
         this.contentElement.addEventListener('mousemove', this.onRowMouseMove);
         document.addEventListener('mouseup', this.onRowMouseUp);
         const rect = e.currentTarget.getBoundingClientRect();
@@ -777,6 +778,9 @@ class ContentContainer extends React.Component<
           rowIndex,
         };
         // Highlight the row
+        this.setState({ highlight: { rows: new Set([rowIndex]) } });
+      } else if (e.button === 0 && focus.kind === 'list') {
+        // The user left-clicked on a list row - highlight it
         this.setState({ highlight: { rows: new Set([rowIndex]) } });
       } else if (e.button === 2 && rows.size === 0) {
         // Right clicked when nothing was highlighted:


### PR DESCRIPTION
This fixes https://github.com/realm/realm-studio/issues/1093 by adding a brach to the `onRowMouseDown` code which was previously not implemented.