### PR TITLE
Remove query-based sync CTAs & upgrade button

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,4 +10,4 @@
 
 ### Internals
 
-- None
+- Removed call-to-action and button to upgrade a full Realm to a query-based sync "reference" Realm. ([#1226](https://github.com/realm/realm-studio/pull/1226))

--- a/src/ui/ServerAdministration/RealmsTable/RealmSidebar/RealmSidebar.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmSidebar/RealmSidebar.tsx
@@ -35,7 +35,6 @@ export const RealmSidebar = ({
   isOpen,
   onRealmDeletion,
   onRealmOpened,
-  onRealmTypeUpgrade,
   onClose,
   realms,
   onRealmSizeRecalculate,
@@ -47,7 +46,6 @@ export const RealmSidebar = ({
   isOpen: boolean;
   onRealmDeletion: (realm: RealmFile) => void;
   onRealmOpened: (realm: RealmFile, usingGrahpiql?: boolean) => void;
-  onRealmTypeUpgrade: (realm: RealmFile) => void;
   onRealmSizeRecalculate: (realm: RealmFile) => void;
   onClose: () => void;
   realms: RealmFile[];
@@ -65,7 +63,6 @@ export const RealmSidebar = ({
       <SingleRealmContent
         onRealmDeletion={onRealmDeletion}
         onRealmOpened={onRealmOpened}
-        onRealmTypeUpgrade={onRealmTypeUpgrade}
         permissions={getRealmPermissions(realms[0])}
         realm={realms[0]}
         realmFileSize={getMetric(realms[0], 'RealmFileSize')}

--- a/src/ui/ServerAdministration/RealmsTable/RealmSidebar/SingleRealmContent.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmSidebar/SingleRealmContent.tsx
@@ -33,7 +33,6 @@ import { PermissionsTable } from './PermissionsTable';
 interface ISingleRealmContentProps {
   onRealmDeletion: (realm: RealmFile) => void;
   onRealmOpened: (realm: RealmFile, usingGrahpiql?: boolean) => void;
-  onRealmTypeUpgrade: (realm: RealmFile) => void;
   realm: RealmFile;
   permissions: Realm.Results<ros.IPermission>;
   realmStateSize: IRealmStateSize | undefined;
@@ -45,7 +44,6 @@ interface ISingleRealmContentProps {
 export const SingleRealmContent = ({
   onRealmDeletion,
   onRealmOpened,
-  onRealmTypeUpgrade,
   permissions,
   realm,
   realmStateSize,
@@ -56,17 +54,14 @@ export const SingleRealmContent = ({
   const isSystemRealm = realm && realm.path.startsWith('/__');
   const isFullRealm =
     ['partial', 'reference'].indexOf(realm.realmType || '') === -1;
-  // Determine if the Realm can be upgraded to a "reference" Realm,
-  // It can if its defined and not already "partial" or "reference"
-  const canUpgradeType = realm && !isSystemRealm && isFullRealm;
   // Generate a list of known size labels
   const sizeLabels = [];
   if (shouldShowRealmSize) {
     sizeLabels.push(
-      realmStateSize ? prettyBytes(realmStateSize.value) + ' (data)' : null,
+      realmStateSize ? prettyBytes(realmStateSize.value) + ' (data)' : null
     );
     sizeLabels.push(
-      realmFileSize ? prettyBytes(realmFileSize.value) + ' (file)' : null,
+      realmFileSize ? prettyBytes(realmFileSize.value) + ' (file)' : null
     );
   }
 
@@ -99,25 +94,6 @@ export const SingleRealmContent = ({
           {permissions ? <PermissionsTable permissions={permissions} /> : null}
         </SidebarBody>
       ) : null}
-      {canUpgradeType ? (
-        <SidebarBody className="RealmSidebar__UpgradeTypeBlock">
-          This Realm can be upgraded to a Reference Realm which will enable{' '}
-          <a
-            target="_blank"
-            href="https://docs.realm.io/platform/using-synced-realms/syncing-data"
-          >
-            query-based synchronization
-          </a>{' '}
-          and{' '}
-          <a
-            target="_blank"
-            href="https://docs.realm.io/platform/using-synced-realms/access-control#overview"
-          >
-            Fine-Grained Permissions
-          </a>
-          . Note: Doing so will remove any existing permissions.
-        </SidebarBody>
-      ) : null}
       <SidebarControls>
         <Button size="sm" color="primary" onClick={() => onRealmOpened(realm)}>
           Open
@@ -129,15 +105,6 @@ export const SingleRealmContent = ({
         >
           Open with Graph<i>i</i>QL
         </Button>
-        {canUpgradeType ? (
-          <Button
-            size="sm"
-            color="secondary"
-            onClick={() => onRealmTypeUpgrade(realm)}
-          >
-            Upgrade
-          </Button>
-        ) : null}
         <Button
           size="sm"
           color="secondary"

--- a/src/ui/ServerAdministration/RealmsTable/RealmSidebar/SingleRealmContent.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmSidebar/SingleRealmContent.tsx
@@ -58,10 +58,10 @@ export const SingleRealmContent = ({
   const sizeLabels = [];
   if (shouldShowRealmSize) {
     sizeLabels.push(
-      realmStateSize ? prettyBytes(realmStateSize.value) + ' (data)' : null
+      realmStateSize ? prettyBytes(realmStateSize.value) + ' (data)' : null,
     );
     sizeLabels.push(
-      realmFileSize ? prettyBytes(realmFileSize.value) + ' (file)' : null
+      realmFileSize ? prettyBytes(realmFileSize.value) + ' (file)' : null,
     );
   }
 

--- a/src/ui/ServerAdministration/RealmsTable/RealmSidebar/index.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmSidebar/index.tsx
@@ -31,7 +31,6 @@ export interface IRealmSidebarContainerProps {
   isOpen: boolean;
   onRealmDeletion: (...realms: RealmFile[]) => void;
   onRealmOpened: (realm: RealmFile, usingGrahpiql?: boolean) => void;
-  onRealmTypeUpgrade: (realm: RealmFile) => void;
   onClose: () => void;
   realms: RealmFile[];
   onRealmSizeRecalculate: (realm: RealmFile) => void;
@@ -74,7 +73,6 @@ export class RealmSidebarContainer extends React.Component<
         isOpen={this.props.isOpen}
         onRealmDeletion={this.props.onRealmDeletion}
         onRealmOpened={this.props.onRealmOpened}
-        onRealmTypeUpgrade={this.props.onRealmTypeUpgrade}
         onClose={this.props.onClose}
         realms={validRealms}
         onRealmSizeRecalculate={this.props.onRealmSizeRecalculate}

--- a/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/RealmsTable.tsx
@@ -65,7 +65,6 @@ export const RealmsTable = ({
   onRealmDeletion,
   onRealmOpened,
   onRealmsDeselection,
-  onRealmTypeUpgrade,
   onSearchStringChange,
   realms,
   searchString,
@@ -82,7 +81,6 @@ export const RealmsTable = ({
   onRealmDeletion: (...realms: RealmFile[]) => void;
   onRealmOpened: (realm: RealmFile, usingGrahpiql?: boolean) => void;
   onRealmsDeselection: () => void;
-  onRealmTypeUpgrade: (realm: RealmFile) => void;
   onSearchStringChange: (query: string) => void;
   realms: Realm.Results<RealmFile>;
   searchString: string;
@@ -148,7 +146,6 @@ export const RealmsTable = ({
         isOpen={selectedRealms.length > 0}
         onRealmDeletion={onRealmDeletion}
         onRealmOpened={onRealmOpened}
-        onRealmTypeUpgrade={onRealmTypeUpgrade}
         onClose={onRealmsDeselection}
         realms={selectedRealms}
         onRealmSizeRecalculate={onRealmSizeRecalculate}

--- a/src/ui/ServerAdministration/RealmsTable/index.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/index.tsx
@@ -38,7 +38,7 @@ import { RealmsTable } from './RealmsTable';
 
 export type MetricGetter = (
   realm: RealmFile,
-  name: 'RealmStateSize' | 'RealmFileSize'
+  name: 'RealmStateSize' | 'RealmFileSize',
 ) => IRealmStateSize | IRealmFileSize | undefined;
 
 export type RealmFile = ros.IRealmFile & Realm.Object;
@@ -83,7 +83,7 @@ class RealmsTableContainer extends React.Component<
       adminRealm: Realm,
       searchString: string,
       showPartialRealms: boolean,
-      showSystemRealms: boolean
+      showSystemRealms: boolean,
     ) => {
       let queryError: Error | undefined;
       let realms = adminRealm
@@ -94,7 +94,7 @@ class RealmsTableContainer extends React.Component<
       if (searchString || searchString !== '') {
         const filterQuery = getQueryForFields(
           ['path', 'realmType', 'owner.accounts.providerId'],
-          searchString
+          searchString,
         );
         try {
           realms = realms.filtered(filterQuery);
@@ -118,11 +118,11 @@ class RealmsTableContainer extends React.Component<
             "NOT path ENDSWITH '__management'",
             "NOT path ENDSWITH '__perm'",
             "NOT path ENDSWITH '__permission'",
-          ].join(' AND ')
+          ].join(' AND '),
         );
       }
       return { realms, queryError };
-    }
+    },
   );
 
   private metricsRealm: Realm | null = null;
@@ -138,7 +138,7 @@ class RealmsTableContainer extends React.Component<
 
     // Generate a configuration to open the /__metrics Realm
     const metricsRealmConfig = getMetricsRealmConfig(
-      adminRealm.syncSession.user
+      adminRealm.syncSession.user,
     );
     // Render with the /__metrics Realm only if it was already created by the Server
     return hasMetricsRealm ? (
@@ -172,7 +172,7 @@ class RealmsTableContainer extends React.Component<
   }
 
   public getRealmPermissions = (
-    realm: RealmFile
+    realm: RealmFile,
   ): Realm.Results<ros.IPermission> => {
     const { adminRealm } = this.props;
     return adminRealm
@@ -182,7 +182,7 @@ class RealmsTableContainer extends React.Component<
 
   public getMetric: MetricGetter = (
     realm: RealmFile,
-    name: 'RealmStateSize' | 'RealmFileSize'
+    name: 'RealmStateSize' | 'RealmFileSize',
   ) => {
     if (
       this.metricsRealm &&
@@ -191,7 +191,7 @@ class RealmsTableContainer extends React.Component<
     ) {
       return this.metricsRealm.objectForPrimaryKey<IRealmStateSize>(
         name,
-        realm.path
+        realm.path,
       );
     }
   };
@@ -242,10 +242,10 @@ class RealmsTableContainer extends React.Component<
   };
   public onRealmClick = (
     e: React.MouseEvent<HTMLElement>,
-    realm: RealmFile
+    realm: RealmFile,
   ) => {
     const isCurrentlySelected = !!this.state.selectedRealms.find(
-      r => r.isValid() && r.path === realm.path
+      r => r.isValid() && r.path === realm.path,
     );
     if (e.metaKey) {
       // The user wants to modify the existing selection
@@ -278,7 +278,7 @@ class RealmsTableContainer extends React.Component<
       this.props.adminRealm,
       this.state.searchString,
       this.state.showPartialRealms,
-      this.state.showSystemRealms
+      this.state.showSystemRealms,
     );
     const validSelectedRealms = this.state.selectedRealms.filter(r => {
       // Filter out the Realm objects
@@ -320,7 +320,7 @@ class RealmsTableContainer extends React.Component<
           'Before deleting Realms here, make sure that any / all clients (iOS, Android, Js, etc.) has already deleted the app or database locally. If this is not done, they will try to upload their copy of the database - which might have been replaced in the meantime.',
         title: `Deleting ${paths.join(', ')}`,
         buttons: ['Cancel', 'Delete'],
-      }
+      },
     );
 
     return result === 1;
@@ -339,7 +339,7 @@ class RealmsTableContainer extends React.Component<
   private deselectRealm(realm: RealmFile) {
     this.setState({
       selectedRealms: this.state.selectedRealms.filter(
-        r => r.isValid() && r.path !== realm.path
+        r => r.isValid() && r.path !== realm.path,
       ),
     });
   }
@@ -349,7 +349,7 @@ class RealmsTableContainer extends React.Component<
       this.props.adminRealm,
       this.state.searchString,
       this.state.showPartialRealms,
-      this.state.showSystemRealms
+      this.state.showSystemRealms,
     );
     const realmAIndex = realms.indexOf(realmA);
     const realmBIndex = realms.indexOf(realmB);

--- a/src/ui/ServerAdministration/RealmsTable/index.tsx
+++ b/src/ui/ServerAdministration/RealmsTable/index.tsx
@@ -38,7 +38,7 @@ import { RealmsTable } from './RealmsTable';
 
 export type MetricGetter = (
   realm: RealmFile,
-  name: 'RealmStateSize' | 'RealmFileSize',
+  name: 'RealmStateSize' | 'RealmFileSize'
 ) => IRealmStateSize | IRealmFileSize | undefined;
 
 export type RealmFile = ros.IRealmFile & Realm.Object;
@@ -83,7 +83,7 @@ class RealmsTableContainer extends React.Component<
       adminRealm: Realm,
       searchString: string,
       showPartialRealms: boolean,
-      showSystemRealms: boolean,
+      showSystemRealms: boolean
     ) => {
       let queryError: Error | undefined;
       let realms = adminRealm
@@ -94,7 +94,7 @@ class RealmsTableContainer extends React.Component<
       if (searchString || searchString !== '') {
         const filterQuery = getQueryForFields(
           ['path', 'realmType', 'owner.accounts.providerId'],
-          searchString,
+          searchString
         );
         try {
           realms = realms.filtered(filterQuery);
@@ -118,11 +118,11 @@ class RealmsTableContainer extends React.Component<
             "NOT path ENDSWITH '__management'",
             "NOT path ENDSWITH '__perm'",
             "NOT path ENDSWITH '__permission'",
-          ].join(' AND '),
+          ].join(' AND ')
         );
       }
       return { realms, queryError };
-    },
+    }
   );
 
   private metricsRealm: Realm | null = null;
@@ -138,7 +138,7 @@ class RealmsTableContainer extends React.Component<
 
     // Generate a configuration to open the /__metrics Realm
     const metricsRealmConfig = getMetricsRealmConfig(
-      adminRealm.syncSession.user,
+      adminRealm.syncSession.user
     );
     // Render with the /__metrics Realm only if it was already created by the Server
     return hasMetricsRealm ? (
@@ -172,7 +172,7 @@ class RealmsTableContainer extends React.Component<
   }
 
   public getRealmPermissions = (
-    realm: RealmFile,
+    realm: RealmFile
   ): Realm.Results<ros.IPermission> => {
     const { adminRealm } = this.props;
     return adminRealm
@@ -182,7 +182,7 @@ class RealmsTableContainer extends React.Component<
 
   public getMetric: MetricGetter = (
     realm: RealmFile,
-    name: 'RealmStateSize' | 'RealmFileSize',
+    name: 'RealmStateSize' | 'RealmFileSize'
   ) => {
     if (
       this.metricsRealm &&
@@ -191,7 +191,7 @@ class RealmsTableContainer extends React.Component<
     ) {
       return this.metricsRealm.objectForPrimaryKey<IRealmStateSize>(
         name,
-        realm.path,
+        realm.path
       );
     }
   };
@@ -240,24 +240,12 @@ class RealmsTableContainer extends React.Component<
   public onRealmOpened = (realm: RealmFile, usingGrahpiql = false) => {
     this.props.onRealmOpened(realm.path, usingGrahpiql);
   };
-
-  public onRealmTypeUpgrade = async (realm: RealmFile) => {
-    const confirmed = this.confirmRealmTypeUpgrade(realm.path);
-    if (confirmed) {
-      try {
-        await ros.realms.changeType(this.props.user, realm.path, 'reference');
-      } catch (err) {
-        showError('Failed to upgrade the Realm', err);
-      }
-    }
-  };
-
   public onRealmClick = (
     e: React.MouseEvent<HTMLElement>,
-    realm: RealmFile,
+    realm: RealmFile
   ) => {
     const isCurrentlySelected = !!this.state.selectedRealms.find(
-      r => r.isValid() && r.path === realm.path,
+      r => r.isValid() && r.path === realm.path
     );
     if (e.metaKey) {
       // The user wants to modify the existing selection
@@ -290,7 +278,7 @@ class RealmsTableContainer extends React.Component<
       this.props.adminRealm,
       this.state.searchString,
       this.state.showPartialRealms,
-      this.state.showSystemRealms,
+      this.state.showSystemRealms
     );
     const validSelectedRealms = this.state.selectedRealms.filter(r => {
       // Filter out the Realm objects
@@ -310,7 +298,6 @@ class RealmsTableContainer extends React.Component<
         onRealmOpened={this.onRealmOpened}
         onRealmsDeselection={this.onRealmsDeselection}
         onRealmClick={this.onRealmClick}
-        onRealmTypeUpgrade={this.onRealmTypeUpgrade}
         onSearchStringChange={this.onSearchStringChange}
         realms={realms}
         searchString={this.state.searchString}
@@ -333,22 +320,7 @@ class RealmsTableContainer extends React.Component<
           'Before deleting Realms here, make sure that any / all clients (iOS, Android, Js, etc.) has already deleted the app or database locally. If this is not done, they will try to upload their copy of the database - which might have been replaced in the meantime.',
         title: `Deleting ${paths.join(', ')}`,
         buttons: ['Cancel', 'Delete'],
-      },
-    );
-
-    return result === 1;
-  }
-
-  private confirmRealmTypeUpgrade(path: string): boolean {
-    const result = electron.remote.dialog.showMessageBox(
-      electron.remote.getCurrentWindow(),
-      {
-        type: 'warning',
-        message:
-          'Upgrading the Realm to be a Reference Realm will delete all current permissions for it. WARNING: This operation cannot be reverted.',
-        title: `Upgrading type of ${path}`,
-        buttons: ['Cancel', 'Upgrade to "reference" Realm'],
-      },
+      }
     );
 
     return result === 1;
@@ -367,7 +339,7 @@ class RealmsTableContainer extends React.Component<
   private deselectRealm(realm: RealmFile) {
     this.setState({
       selectedRealms: this.state.selectedRealms.filter(
-        r => r.isValid() && r.path !== realm.path,
+        r => r.isValid() && r.path !== realm.path
       ),
     });
   }
@@ -377,7 +349,7 @@ class RealmsTableContainer extends React.Component<
       this.props.adminRealm,
       this.state.searchString,
       this.state.showPartialRealms,
-      this.state.showSystemRealms,
+      this.state.showSystemRealms
     );
     const realmAIndex = realms.indexOf(realmA);
     const realmBIndex = realms.indexOf(realmB);


### PR DESCRIPTION
This fixes #1224 by removing the section explaining reference Realms & query-based sync as well as the button to upgrade a full Realm to a query-based reference Realm.