### PR TITLE
File format upgrade dialog

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,10 +1,13 @@
 [Changes since {PREVIOUS_VERSION}](https://github.com/realm/realm-studio/compare/{PREVIOUS_VERSION}...{CURRENT_VERSION})
 
 ### Enhancements
-- None
+
+- Added a prompt to upgrade (and optionally backup) when opening a Realm file which uses an outdated file format. This disables automatically upgrading local Realm files when opening them. ([#1236](https://github.com/realm/realm-studio/pull/1236))
 
 ### Fixed
+
 - None
 
 ### Internals
+
 - None

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { ipcRenderer, MenuItemConstructorOptions, remote } from 'electron';
+import fs from 'fs-extra';
 import path from 'path';
 import React from 'react';
 import Realm from 'realm';
@@ -24,7 +25,7 @@ import Realm from 'realm';
 import { DataExporter, DataExportFormat } from '../../services/data-exporter';
 import * as dataImporter from '../../services/data-importer';
 import { Language, SchemaExporter } from '../../services/schema-export';
-import { menu } from '../../utils';
+import { menu, realms } from '../../utils';
 import {
   IMenuGenerator,
   IMenuGeneratorProps,
@@ -297,6 +298,7 @@ class RealmBrowserContainer
     const mightBeEncrypted =
       message.indexOf('Not a Realm file.') >= 0 ||
       message.indexOf('Invalid mnemonic') >= 0;
+    const realm = this.props.realm;
     if (mightBeEncrypted) {
       this.setState({
         isEncryptionDialogVisible: true,
@@ -304,16 +306,52 @@ class RealmBrowserContainer
           status: 'done',
         },
       });
-    } else if (message === FILE_UPGRADE_NEEDED_MESSAGE) {
-      const answer = remote.dialog.showMessageBox({
+    } else if (
+      message === FILE_UPGRADE_NEEDED_MESSAGE &&
+      realm.mode === realms.RealmLoadingMode.Local
+    ) {
+      const buttons = ['Cancel', 'Upgrade in-place', 'Backup and upgrade'];
+      const answerIndex = remote.dialog.showMessageBox({
         type: 'question',
-        buttons: ['Cancel', 'Upgrade in-place', 'Backup and upgrade'],
+        buttons,
         defaultId: 2,
         title: 'Realm file needs an upgrade',
         message: 'The Realm file stores data in an outdated format',
         detail:
           'This file needs to be upgraded to a newer file format before it can be opened. Would you like a backup of the file, before performing an irreversible upgrade of the file?',
       });
+      const answer = buttons[answerIndex];
+
+      if (answer === 'Upgrade in-place' || answer === 'Backup and upgrade') {
+        try {
+          if (answer === 'Backup and upgrade') {
+            // Create a backup first
+            const backupDirectory = path.dirname(realm.path);
+            const backupFileName = path.basename(realm.path, '.realm');
+            const backupPath = path.resolve(
+              backupDirectory,
+              backupFileName + '.backup.realm',
+            );
+            // Copy, but ensure we don't override an existing file
+            fs.copyFileSync(realm.path, backupPath, fs.constants.COPYFILE_EXCL);
+            remote.dialog.showMessageBox({
+              title: 'Backup saved',
+              message: 'The backup Realm file was saved to:',
+              detail: backupPath,
+            });
+          }
+          // Reopen, enabling format upgrades an upgrade
+          this.loadRealm({
+            ...realm,
+            enableFormatUpgrade: true,
+          });
+        } catch (err) {
+          showError('Failed upgrading Realm', err);
+          window.close();
+        }
+      } else {
+        window.close();
+      }
     } else {
       delete this.props.realm.encryptionKey;
       super.loadingRealmFailed(err);

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -62,6 +62,8 @@ export type ClassFocussedHandler = (
 ) => void;
 
 const EDIT_MODE_STORAGE_KEY = 'realm-browser-edit-mode';
+const FILE_UPGRADE_NEEDED_MESSAGE =
+  'The Realm file format must be allowed to be upgraded in order to proceed.';
 
 export interface IRealmBrowserState extends IRealmLoadingComponentState {
   // A number that we can use to make components update on changes to data
@@ -302,8 +304,18 @@ class RealmBrowserContainer
           status: 'done',
         },
       });
+    } else if (message === FILE_UPGRADE_NEEDED_MESSAGE) {
+      const answer = remote.dialog.showMessageBox({
+        type: 'question',
+        buttons: ['Cancel', 'Upgrade in-place', 'Backup and upgrade'],
+        defaultId: 2,
+        title: 'Realm file needs an upgrade',
+        message: 'The Realm file stores data in an outdated format',
+        detail:
+          'This file needs to be upgraded to a newer file format before it can be opened. Would you like a backup of the file, before performing an irreversible upgrade of the file?',
+      });
     } else {
-      this.props.realm.encryptionKey = undefined;
+      delete this.props.realm.encryptionKey;
       super.loadingRealmFailed(err);
     }
   }

--- a/src/ui/reusable/RealmLoadingComponent/index.tsx
+++ b/src/ui/reusable/RealmLoadingComponent/index.tsx
@@ -177,6 +177,7 @@ export abstract class RealmLoadingComponent<
         return new Realm({
           path: realm.path,
           encryptionKey: realm.encryptionKey,
+          disableFormatUpgrade: realm.enableFormatUpgrade ? false : true,
           sync: realm.sync as any,
           schema,
           schemaVersion,

--- a/src/utils/realms.ts
+++ b/src/utils/realms.ts
@@ -35,6 +35,7 @@ export interface ISyncedRealmToLoad extends IRealmToLoad {
 
 export interface ILocalRealmToLoad extends IRealmToLoad {
   mode: RealmLoadingMode.Local;
+  enableFormatUpgrade?: boolean;
   sync?: boolean;
 }
 


### PR DESCRIPTION
This solves #8 & #309 by adding a dialog prompting the user to choose if they want to upgrade (optionally making a backup first).

![upgrade-prompt](https://user-images.githubusercontent.com/1243959/70983289-c5091700-20b8-11ea-995d-41b08cadb2c4.png)
![upgrade-backup-saved](https://user-images.githubusercontent.com/1243959/70983287-c4708080-20b8-11ea-81eb-ee90af09b682.png)

Will fail if a file exists at the location that the backup would be stored:
![upgrade-file-exists](https://user-images.githubusercontent.com/1243959/70983288-c5091700-20b8-11ea-9f0b-07859793e1cd.png)
