### PR TITLE
Fixing client resync of Realms opened in the browser

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- None
+- Fixed an issue occurring if a Realm had been opened from a server, deleted from the server and reopened in Studio. A local cache of the Realm would exist and instead of discarding the local copy entirely, the schema of the local copy would be written to the realm and uploaded to the server. ([#1238](https://github.com/realm/realm-studio/pull/1238)
 
 ### Internals
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9743,9 +9743,12 @@
       "dev": true
     },
     "npm-bundled": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
     },
     "npm-install-package": {
       "version": "2.1.0",
@@ -9753,10 +9756,15 @@
       "integrity": "sha1-1+/jz816sAYUuJbqUxGdyaslkSU=",
       "dev": true
     },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+    },
     "npm-packlist": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.6.tgz",
-      "integrity": "sha512-u65uQdb+qwtGvEJh/DgQgW1Xg7sqeNbmxYyrvlNznaVTjV3E5P6F/EFjM+BVHXl7JJlsdG8A64M0XI8FI/IOlg==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.7.tgz",
+      "integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
       "requires": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1"
@@ -11278,16 +11286,16 @@
       }
     },
     "realm": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-3.3.0.tgz",
-      "integrity": "sha512-t+mqeJyMFOsLb8mEDsZo4dJTiLnyygKqwLHzFO+XD3cArXkQwatYPiCInWegH0ulczF05sYwW70o4toPI9/fwg==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-3.6.2.tgz",
+      "integrity": "sha512-//akrAT+4FDogANhmWiB2og5MajrJYKSglC3iDGUVjdEr0VvUgJm3g0rLEGDM9M/WQGEz/21eNV/MV16e7pUCg==",
       "requires": {
         "command-line-args": "^4.0.6",
         "decompress": "^4.2.0",
         "deepmerge": "2.1.0",
         "deprecated-react-native-listview": "0.0.6",
         "fs-extra": "^4.0.3",
-        "https-proxy-agent": "^2.2.1",
+        "https-proxy-agent": "^2.2.4",
         "ini": "^1.3.5",
         "nan": "^2.12.1",
         "node-fetch": "^1.7.3",
@@ -11309,6 +11317,15 @@
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+          "requires": {
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
           }
         },
         "node-fetch": {

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "react-sortable-hoc": "^1.10.1",
     "react-virtualized": "^9.21.2",
     "reactstrap": "^8.2.0",
-    "realm": "3.3.0",
+    "realm": "^3.6.2",
     "semver": "^6.3.0",
     "subscriptions-transport-ws": "^0.9.16",
     "uuid": "^3.3.3"

--- a/src/services/ros/realms.ts
+++ b/src/services/ros/realms.ts
@@ -59,7 +59,7 @@ export const open = async (params: {
       url,
       user: params.user,
       error: ssl.errorCallback || defaultSyncErrorCallback,
-      clientResyncMode: Realm.Sync.ClientResyncMode.Discard,
+      clientResyncMode: 'discard' as Realm.Sync.ClientResyncMode.Discard,
       validate_ssl: ssl.validateCertificates,
       ssl_trust_certificate_path: ssl.certificatePath,
       _disableQueryBasedSyncUrlChecks: true,

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -637,10 +637,7 @@ class RealmBrowserContainer
 
   private addListeners() {
     ipcRenderer.addListener('export-schema', this.onExportSchema);
-    window.addEventListener<'beforeunload'>(
-      'beforeunload',
-      this.onBeforeUnload,
-    );
+    window.addEventListener('beforeunload', this.onBeforeUnload);
   }
 
   private removeListeners() {

--- a/src/ui/reusable/RealmLoadingComponent/index.tsx
+++ b/src/ui/reusable/RealmLoadingComponent/index.tsx
@@ -143,10 +143,6 @@ export abstract class RealmLoadingComponent<
     this.setState({ progress: { message, status: 'failed' } });
   }
 
-  protected isSslCertificateRelated(err: Error) {
-    return err && err.message === 'SSL server certificate rejected';
-  }
-
   protected onSyncError = (
     session: Realm.Sync.Session,
     error: Realm.Sync.SyncError,


### PR DESCRIPTION
This fixes #1230 when a fix for https://jira.mongodb.org/projects/RJS/issues/RJS-348 has been released.