### PR TITLE
Schema updates fixed

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,10 +1,13 @@
 [Changes since {PREVIOUS_VERSION}](https://github.com/realm/realm-studio/compare/{PREVIOUS_VERSION}...{CURRENT_VERSION})
 
 ### Enhancements
+
 - None
 
 ### Fixed
-- None
+
+- Fixed updating to the browser UI when another client updates the schema of a Realm. ([#1256](https://github.com/realm/realm-studio/pull/1256))
 
 ### Internals
+
 - None

--- a/docs/RELEASENOTES.template.md
+++ b/docs/RELEASENOTES.template.md
@@ -1,10 +1,13 @@
 [Changes since {PREVIOUS_VERSION}](https://github.com/realm/realm-studio/compare/{PREVIOUS_VERSION}...{CURRENT_VERSION})
 
 ### Enhancements
+
 - None
 
 ### Fixed
+
 - None
 
 ### Internals
+
 - None

--- a/src/ui/RealmBrowser/Content/Table/index.tsx
+++ b/src/ui/RealmBrowser/Content/Table/index.tsx
@@ -201,9 +201,6 @@ class TableContainer extends React.PureComponent<
     if (this.tableElement) {
       this.tableElement.removeEventListener('keydown', this.onKeyDown);
     }
-    // Save the column widths for later
-    const focusKey = generateKey(this.props.focus);
-    TableContainer.columnWidthCache[focusKey] = this.state.columnWidths;
   }
 
   public componentWillMount() {
@@ -224,15 +221,6 @@ class TableContainer extends React.PureComponent<
           rowIndex: this.props.highlight.scrollTo.row,
         });
       }
-    }
-
-    // Set the column with if the focus or properties changed
-    const focusChanged =
-      generateKey(this.props.focus) !== generateKey(prevProps.focus);
-    const propertiesChanged =
-      this.props.focus.properties.length !== prevProps.focus.properties.length;
-    if (focusChanged || propertiesChanged) {
-      this.setColumnWidths();
     }
 
     if (this.state.columnWidths !== prevState.columnWidths) {
@@ -269,7 +257,11 @@ class TableContainer extends React.PureComponent<
   private onColumnWidthChanged = (index: number, width: number) => {
     const columnWidths = Array.from(this.state.columnWidths);
     columnWidths[index] = Math.max(width, MINIMUM_COLUMN_WIDTH);
-    this.setState({ columnWidths });
+    this.setState({ columnWidths }, () => {
+      // Save the column widths for later
+      const focusKey = generateKey(this.props.focus);
+      TableContainer.columnWidthCache[focusKey] = this.state.columnWidths;
+    });
   };
 
   private onKeyDown = (e: KeyboardEvent) => {

--- a/src/ui/RealmBrowser/focus.ts
+++ b/src/ui/RealmBrowser/focus.ts
@@ -73,9 +73,16 @@ export function getClassName(focus: Focus): string {
   }
 }
 
-export function generateKey(focus: Focus | null) {
+/**
+ * Generates a string which can uniquely identify a focus
+ * @param focus The focus to generate the key from
+ * @param prependPropertyCount Should the number of properties be prepended the key?
+ */
+export function generateKey(focus: Focus | null, prependPropertyCount = false) {
+  const propertiesSuffix =
+    prependPropertyCount && focus ? `(${focus.properties.length})` : '';
   if (focus && focus.kind === 'class') {
-    return `class:${focus.className}`;
+    return `class:${focus.className}${propertiesSuffix}`;
   } else if (focus && focus.kind === 'list') {
     // The `[key: string]: any;` is needed because if Realm JS types
     const parent: Realm.Object & {
@@ -85,7 +92,7 @@ export function generateKey(focus: Focus | null) {
     const propertyName = focus.property.name;
     const id =
       parent.isValid() && schema.primaryKey ? parent[schema.primaryKey] : '?';
-    return `list:${schema.name}[${id}]:${propertyName}`;
+    return `list:${schema.name}[${id}]:${propertyName}${propertiesSuffix}`;
   } else {
     return 'null';
   }

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -119,7 +119,9 @@ class RealmBrowserContainer
   }
 
   public render() {
-    const contentKey = generateKey(this.state.focus);
+    const { focus } = this.state;
+    // Generating a key for the content component (includes length of properties to update when the schema changes)
+    const contentKey = generateKey(focus) + `(${focus ? focus.properties.length : 0})`;
     return (
       <RealmBrowser
         classes={this.state.classes}
@@ -360,6 +362,19 @@ class RealmBrowserContainer
 
   protected onRealmChanged = () => {
     this.setState({ dataVersion: this.state.dataVersion + 1 });
+  };
+
+  protected onRealmSchemaChanged = () => {
+    if (this.realm) {
+      let { focus } = this.state;
+      // Update the classes and derive properties for the active focus
+      if (focus && focus.kind === 'class') {
+        focus = this.getClassFocus(focus.className);
+      } else if (focus && focus.kind === 'list') {
+        focus = this.getListFocus(focus.parent, focus.property);
+      }
+      this.setState({ classes: this.realm.schema, focus });
+    }
   };
 
   protected onRealmLoaded = () => {

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -121,7 +121,7 @@ class RealmBrowserContainer
   public render() {
     const { focus } = this.state;
     // Generating a key for the content component (includes length of properties to update when the schema changes)
-    const contentKey = generateKey(focus) + `(${focus ? focus.properties.length : 0})`;
+    const contentKey = generateKey(focus, true);
     return (
       <RealmBrowser
         classes={this.state.classes}

--- a/src/ui/reusable/RealmLoadingComponent/index.test.tsx
+++ b/src/ui/reusable/RealmLoadingComponent/index.test.tsx
@@ -58,6 +58,10 @@ describe('<RealmLoadingComponent />', () => {
         changes++;
       };
 
+      protected onRealmSchemaChanged = () => {
+        changes++;
+      };
+
       protected onRealmLoaded = () => {
         loads++;
       };

--- a/src/ui/reusable/RealmLoadingComponent/index.tsx
+++ b/src/ui/reusable/RealmLoadingComponent/index.tsx
@@ -35,6 +35,7 @@ export abstract class RealmLoadingComponent<
   S extends IRealmLoadingComponentState
 > extends React.Component<P, S> {
   protected abstract onRealmChanged: () => void;
+  protected abstract onRealmSchemaChanged: () => void;
   protected abstract onRealmLoaded: () => void;
 
   protected realm?: Realm;
@@ -42,13 +43,6 @@ export abstract class RealmLoadingComponent<
   protected certificateWasRejected: boolean = false;
 
   public componentWillUnmount() {
-    // Closing and remove any existing a change listeners
-    if (this.realm) {
-      this.realm.removeListener('change', this.onRealmChanged);
-      this.realm.close();
-      // Deleting indicates we've closed it
-      delete this.realm;
-    }
     this.closeRealm();
     this.cancelLoadingRealms();
   }
@@ -92,6 +86,7 @@ export abstract class RealmLoadingComponent<
 
         // Register change listeners
         this.realm.addListener('change', this.onRealmChanged);
+        this.realm.addListener('schema', this.onRealmSchemaChanged);
         this.onRealmLoaded();
         // Update the state, to indicate we're done loading
         this.setState({ progress: { status: 'done' } });
@@ -130,9 +125,10 @@ export abstract class RealmLoadingComponent<
   }
 
   protected closeRealm() {
-    // Remove any existing a change listeners
+    // Closing and remove any existing a change listeners
     if (this.realm) {
       this.realm.removeListener('change', this.onRealmChanged);
+      this.realm.removeListener('schema', this.onRealmSchemaChanged);
       this.realm.close();
       delete this.realm;
     }


### PR DESCRIPTION
The Browser UI didn't update when the schema got updated by another client, this fixes the issue by updating the list of classes and remounting the `Content` component when the number of properties change.

This has the drawback of resetting the state of the `Content` component (object creation form, scrolling, etc.) when a schema change happens for the class currently in focus.
