### PR TITLE
Using `app.name` instead of "Realm Studio"

### DIFF
--- a/src/main/Updater.ts
+++ b/src/main/Updater.ts
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import electron from 'electron';
+import { app, dialog } from 'electron';
 import { autoUpdater, UpdateInfo } from 'electron-updater';
 
 import { WindowManager } from './WindowManager';
@@ -190,10 +190,10 @@ export class Updater {
     if (process.env.REALM_STUDIO_DISABLE_UPDATE_PROMPT) {
       return true;
     } else {
-      const appName = electron.app.name;
-      const currentVersion = electron.app.getVersion();
+      const appName = app.name;
+      const currentVersion = app.getVersion();
       return (
-        electron.dialog.showMessageBoxSync({
+        dialog.showMessageBoxSync({
           type: 'info',
           message: `A new version of ${appName} is available!`,
           detail: `${appName} ${lastestVersion} is available – you have ${currentVersion}.\nWould you like to update it now?`,
@@ -209,9 +209,9 @@ export class Updater {
     if (process.env.REALM_STUDIO_DISABLE_UPDATE_PROMPT) {
       return true;
     } else {
-      const appName = electron.app.name;
+      const appName = app.name;
       return (
-        electron.dialog.showMessageBoxSync({
+        dialog.showMessageBoxSync({
           type: 'info',
           message: `A new version of ${appName} is downloaded!`,
           detail: `${appName} ${lastestVersion} is downloaded.\nClick "Ok" to quit and restart Realm Studio.`,
@@ -245,7 +245,7 @@ export class Updater {
   }
 
   private showError(message: string, detail: string = '') {
-    electron.dialog.showMessageBox({
+    dialog.showMessageBox({
       type: 'error',
       message,
       detail,

--- a/src/main/WindowManager.ts
+++ b/src/main/WindowManager.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import * as sentry from '@sentry/electron';
-import { BrowserWindow, screen, shell } from 'electron';
+import { app, BrowserWindow, screen, shell } from 'electron';
 import path from 'path';
 import url from 'url';
 
@@ -101,7 +101,7 @@ export class WindowManager {
     // Combine these with general default options
     const combinedWindowOptions: IWindowConstructorOptions = {
       // Starting with the default options
-      title: 'Realm Studio',
+      title: app.name,
       width: 800,
       height: 600,
       vibrancy: 'light',

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -18,13 +18,14 @@
 
 import './services/mixpanel';
 
-import electron from 'electron';
+import { remote } from 'electron';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
 // This is needed to prevent Realm JS from writing to directories it doesn't have access to
 import './utils/process-directories';
 
+const { app } = remote;
 const isDevelopment = process.env.NODE_ENV === 'development';
 
 // Don't report Realm JS analytics data
@@ -78,7 +79,7 @@ process.nextTick(() => {
   if (Realm.Sync) {
     Realm.Sync.setLogLevel(process.env.REALM_LOG_LEVEL || 'error');
     Realm.Sync.setUserAgent(
-      `Realm Studio ${electron.remote.app.getVersion() || 'unknown'}`,
+      `${app.name} ${app.getVersion() || 'unknown'}`,
     );
   }
 });

--- a/src/services/mixpanel/index.ts
+++ b/src/services/mixpanel/index.ts
@@ -16,13 +16,15 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import electron from 'electron';
+import { remote } from 'electron';
 import fs from 'fs-extra';
 import mixpanel from 'mixpanel-browser';
 import path from 'path';
 import { v4 as uuid } from 'uuid';
 
 import { store } from '../../store';
+
+const { app } = remote;
 
 // Ensure that this is only called from the renderer process.
 if (process.type === 'renderer') {
@@ -51,8 +53,8 @@ if (process.type === 'renderer') {
   ]);
 
   const browserParams = {
-    $browser: 'Realm Studio',
-    $browser_version: electron.remote.app.getVersion() || 'unknown',
+    $browser: app.name,
+    $browser_version: app.getVersion() || 'unknown',
   };
 
   // Sends the browser version on every request
@@ -66,7 +68,7 @@ if (process.type === 'renderer') {
     } else {
       // Try migrating from the old settings
       const settingsPath = path.resolve(
-        electron.remote.app.getPath('userData'),
+        app.getPath('userData'),
         'settings.json',
       );
       if (fs.existsSync(settingsPath)) {

--- a/src/ui/Greeting/Greeting.tsx
+++ b/src/ui/Greeting/Greeting.tsx
@@ -16,6 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import { remote } from 'electron';
 import os from 'os';
 import React from 'react';
 import { Button } from 'reactstrap';
@@ -31,6 +32,8 @@ import { SignupOverlay } from './SignupOverlay';
 import { UpdateStatusIndicator } from './UpdateStatusIndicator';
 
 import './Greeting.scss';
+
+const { app } = remote;
 
 export const Greeting = ({
   cloudStatus,
@@ -71,7 +74,7 @@ export const Greeting = ({
         <svg className="Greeting__Logo" viewBox={realmLogo.viewBox}>
           <use xlinkHref={`#${realmLogo.id}`} />
         </svg>
-        <h3 className="Greeting__Title">Realm Studio</h3>
+        <h3 className="Greeting__Title">{app.name}</h3>
         <div>Version {version}</div>
       </div>
       <UpdateStatusIndicator

--- a/src/ui/Greeting/HistoryPanel/HistoryPanel.tsx
+++ b/src/ui/Greeting/HistoryPanel/HistoryPanel.tsx
@@ -16,30 +16,16 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import { remote } from "electron";
 import React from 'react';
-import { Button } from 'reactstrap';
 
-import { main } from '../../../actions/main';
 import { HistoryEntry, IHistoryEntry } from './HistoryEntry';
+
+const { app } = remote;
 
 const Empty = () => (
   <div className="Greeting__HistoryPanel__Empty">
-    <p>Welcome to Realm Studio!</p>
-    <p>Sync your data and objects in real-time via Realm Cloud:</p>
-    <p>
-      <Button
-        size="sm"
-        color="primary"
-        onClick={() => main.showCloudAuthentication({ mode: 'sign-up' })}
-      >
-        Sign up (free trial)
-      </Button>
-      <br />
-      {' or '}
-      <a href="https://realm.io/pricing" target="_blank">
-        view plans
-      </a>
-    </p>
+    <p>Welcome to {app.name}!</p>
   </div>
 );
 

--- a/src/ui/Greeting/MarketingPanel/MarketingPanel.tsx
+++ b/src/ui/Greeting/MarketingPanel/MarketingPanel.tsx
@@ -16,6 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import { remote } from 'electron';
 import classNames from 'classnames';
 import React from 'react';
 import { Carousel, CarouselIndicators, CarouselItem } from 'reactstrap';
@@ -28,12 +29,14 @@ import { MessageSlide } from './MessageSlide';
 
 import './MarketingPanel.scss';
 
+const { app } = remote;
+
 function getProgress(status: Status, onFetch: () => void): ILoadingProgress {
   if (status === 'loaded') {
     return { status: 'done' };
   } else if (status === 'loading') {
     return {
-      message: 'Welcome to\nRealm Studio',
+      message: `Welcome to\n${app.name}`,
       status: 'in-progress',
     };
   } else {

--- a/src/ui/Greeting/SignupOverlay/SignupOverlay.tsx
+++ b/src/ui/Greeting/SignupOverlay/SignupOverlay.tsx
@@ -16,6 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import { remote } from 'electron';
 import React from 'react';
 import {
   Button,
@@ -52,7 +53,7 @@ export const SignupOverlay = ({
       }}
     >
       <ModalBody>
-        <h5>Thanks for using Realm Studio!</h5>
+        <h5>Thanks for using {remote.app.name}!</h5>
         <p>Please enter your email to continue.</p>
         <FormGroup>
           <Input

--- a/src/ui/Greeting/SignupOverlay/index.tsx
+++ b/src/ui/Greeting/SignupOverlay/index.tsx
@@ -16,13 +16,14 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import electron from 'electron';
+import { remote } from 'electron';
 import React from 'react';
 import { mixpanel } from '../../../services/mixpanel';
 
 import { SignupOverlay } from './SignupOverlay';
 
 const HAS_SIGNED_UP_STORAGE_KEY = 'has-signed-up';
+const { app } = remote;
 
 function determineVisibility() {
   return !(
@@ -67,8 +68,8 @@ class SignupOverlayContainer extends React.Component<
   public onSignup = () => {
     mixpanel.people.set(
       {
-        $browser: 'Realm Studio',
-        $browser_version: electron.remote.app.getVersion() || 'unknown',
+        $browser: app.name,
+        $browser_version: app.getVersion() || 'unknown',
         $email: this.state.email,
         newsletter: this.state.newsletter,
         signupDate: new Date(),

--- a/src/windows/GreetingWindow.tsx
+++ b/src/windows/GreetingWindow.tsx
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import { IWindow } from './Window';
+import { app } from 'electron';
 
 // tslint:disable-next-line:no-empty-interface
 export interface IGreetingWindowProps {
@@ -25,7 +26,7 @@ export interface IGreetingWindowProps {
 
 export const GreetingWindow: IWindow = {
   getWindowOptions: () => ({
-    title: `Realm Studio`,
+    title: app.name,
     width: 700,
     height: 400,
     resizable: false,

--- a/src/windows/SentryErrorBoundary/ErrorOverlay.tsx
+++ b/src/windows/SentryErrorBoundary/ErrorOverlay.tsx
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import React from 'react';
+import { remote } from "electron";
 
 import './ErrorOverlay.scss';
 
@@ -32,7 +33,7 @@ export const ErrorOverlay = ({ error, info, eventId }: IErrorOverlayProps) => {
   return (
     <div className="ErrorOverlay">
       <p className="ErrorOverlay__Introduction">
-        💥 Realm Studio encountered an unrecoverable error! 💥
+        💥 {remote.app.name} encountered an unrecoverable error! 💥
       </p>
       {eventId ? <p className="ErrorOverlay__Id">ID: “{eventId}”</p> : null}
       {eventId ? (


### PR DESCRIPTION
This updates relevant usage of a hardcore "Realm Studio" in favor of the more generic `app.name` retrieved via the Electron API.