### PR TITLE
Create & edit Decimal128 values

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,6 +10,8 @@
 - Added support for creating & generating `ObjectId` when creating objects. ([#1291](https://github.com/realm/realm-studio/pull/1291))
 - Added support for editing existing `ObjectId` values. ([#1290](https://github.com/realm/realm-studio/pull/1290))
 - Primary keys in Class/Schema creation now defaults to an `ObjectId` property named `_id`.
+- Added support for creating `Decimal128` in create-flow. ([#1292](https://github.com/realm/realm-studio/pull/1292))
+- Added support for editing existing `Decimal128` values. ([#1292](https://github.com/realm/realm-studio/pull/1292))
 
 ### Fixed
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,7 +10,7 @@
 - Added support for creating & generating `ObjectId` when creating objects. ([#1291](https://github.com/realm/realm-studio/pull/1291))
 - Added support for editing existing `ObjectId` values. ([#1290](https://github.com/realm/realm-studio/pull/1290))
 - Primary keys in Class/Schema creation now defaults to an `ObjectId` property named `_id`.
-- Added support for creating `Decimal128` in create-flow. ([#1292](https://github.com/realm/realm-studio/pull/1292))
+- Added support for creating `Decimal128` when creating objects. ([#1292](https://github.com/realm/realm-studio/pull/1292))
 - Added support for editing existing `Decimal128` values. ([#1292](https://github.com/realm/realm-studio/pull/1292))
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -10674,9 +10674,9 @@
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
     "needle": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.1.tgz",
-      "integrity": "sha512-x/gi6ijr4B7fwl6WYL9FwlCvRQKGlUNvnceho8wxkwXqN8jvVmmmATTmZPRRG7b/yC1eode26C2HO9jl78Du9g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
+      "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -12753,9 +12753,9 @@
       }
     },
     "realm": {
-      "version": "10.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-10.0.0-alpha.6.tgz",
-      "integrity": "sha512-h7UJSyExXuOlDcfaOCR8G2QBKzEXyZnaqIjN13CSoiPw5Hqwu0WPUUBFdIX80fnVfw2O3mMrD8cbtgMP1st22A==",
+      "version": "10.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-10.0.0-alpha.9.tgz",
+      "integrity": "sha512-mg27c58ORpt6iYpue812Tu1WJsN34cp31gixEbSrPOGhUrn1kFuhI4W9ITJnRhiVbKoJ829H00qzgVLVMRP9Kg==",
       "requires": {
         "abort-controller": "^3.0.0",
         "bson": "^4.0.3",
@@ -15982,9 +15982,9 @@
       }
     },
     "unbzip2-stream": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.2.tgz",
-      "integrity": "sha512-pZMVAofMrrHX6Ik39hCk470kulCbmZ2SWfQLPmTWqfJV/oUm0gn1CblvHdUu4+54Je6Jq34x8kY6XjTy6dMkOg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "requires": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "react-sortable-hoc": "^1.11.0",
     "react-virtualized": "^9.21.2",
     "reactstrap": "^8.4.1",
-    "realm": "^10.0.0-alpha.6",
+    "realm": "^10.0.0-alpha.9",
     "semver": "^7.3.2",
     "subscriptions-transport-ws": "^0.9.16",
     "uuid": "^8.0.0"

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/CreateObjectDialog.scss
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/CreateObjectDialog.scss
@@ -66,6 +66,7 @@
   }
 
   &__ObjectIdControl,
+  &__Decimal128Control,
   &__StringControl,
   &__DateControl,
   &__NummericControl {

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/index.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/index.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import Realm from 'realm';
-import { ObjectId } from 'bson';
+import { ObjectId, Decimal128 } from 'bson';
 import { v4 as uuid } from 'uuid';
 
 import { CreateObjectHandler } from '..';
@@ -108,6 +108,8 @@ class CreateObjectDialogContainer extends React.PureComponent<
       property.type === 'double'
     ) {
       return 0;
+    } else if (property.type === 'decimal') {
+      return Decimal128.fromString('0');
     } else if (property.type === 'string') {
       return '';
     } else if (property.type === 'bool') {

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/index.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/index.tsx
@@ -101,6 +101,7 @@ class CreateObjectDialogContainer extends React.PureComponent<
     } else if (property.optional) {
       return null;
     } else if (property.type === 'object id') {
+      // TODO: should this instead return same default as Object Store? e.g.: ObjectId.createFromHexString('000000000000000000000000')
       return new ObjectId();
     } else if (
       property.type === 'int' ||

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/index.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/index.tsx
@@ -101,7 +101,6 @@ class CreateObjectDialogContainer extends React.PureComponent<
     } else if (property.optional) {
       return null;
     } else if (property.type === 'object id') {
-      // TODO: should this instead return same default as Object Store? e.g.: ObjectId.createFromHexString('000000000000000000000000')
       return new ObjectId();
     } else if (
       property.type === 'int' ||

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/types/Decimal128Control.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/types/Decimal128Control.tsx
@@ -28,16 +28,12 @@ interface IDecimal128ControlState {
 }
 
 export class Decimal128Control extends React.PureComponent<
-  IBaseControlProps,
+  IBaseControlProps<Decimal128 | null>,
   IDecimal128ControlState
 > {
-  constructor(props: IBaseControlProps) {
-    super(props);
-
-    this.state = {
-      internalValue: props.value,
-    };
-  }
+  state: IDecimal128ControlState = {
+    internalValue: this.props.value?.toString() ?? null,
+  };
 
   render() {
     const { children, property, value } = this.props;
@@ -66,22 +62,23 @@ export class Decimal128Control extends React.PureComponent<
   }
 
   private inputChangeEventHandler = (e: React.ChangeEvent<HTMLInputElement>) =>
-    this.internalChangeHandler(e.target.value);
+    this.changeHandler(e.target.value);
 
-  private clearValue = () => this.internalChangeHandler(null);
+  private clearValue = () => this.changeHandler(null);
 
-  private internalChangeHandler = (val: string | null) => {
+  private changeHandler = (value: string | null) => {
     const { property, onChange } = this.props;
 
-    this.setState({ internalValue: val });
+    this.setState({ internalValue: value });
 
     let parsedDecimal: Decimal128 | null = null;
 
-    if (val) {
+    if (value) {
       try {
-        parsedDecimal = parseDecimal128(val, property);
-      } catch (_) {
-        // ignored
+        parsedDecimal = parseDecimal128(value, property);
+      } catch (err) {
+        // tslint:disable-next-line:no-console
+        console.warn(err.message);
       }
     }
 

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/types/Decimal128Control.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/types/Decimal128Control.tsx
@@ -51,7 +51,7 @@ export class Decimal128Control extends React.PureComponent<
         />
         {internalValue && property.optional && (
           <InputGroupAddon addonType="append">
-            <Button size="sm" onClick={this.clearValue}>
+            <Button size="sm" onClick={this.handleClearValue}>
               <i className="fa fa-close" />
             </Button>
           </InputGroupAddon>
@@ -64,7 +64,7 @@ export class Decimal128Control extends React.PureComponent<
   private inputChangeEventHandler = (e: React.ChangeEvent<HTMLInputElement>) =>
     this.changeHandler(e.target.value);
 
-  private clearValue = () => this.changeHandler(null);
+  private handleClearValue = () => this.changeHandler(null);
 
   private changeHandler = (value: string | null) => {
     const { property, onChange } = this.props;

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/types/Decimal128Control.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/types/Decimal128Control.tsx
@@ -1,0 +1,90 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import React from 'react';
+import { Decimal128 } from 'bson';
+import { Button, Input, InputGroup, InputGroupAddon } from 'reactstrap';
+
+import { IBaseControlProps } from './TypeControl';
+import { parseDecimal128 } from '../../../parsers';
+
+interface IDecimal128ControlState {
+  internalValue: string | null;
+}
+
+export class Decimal128Control extends React.PureComponent<
+  IBaseControlProps,
+  IDecimal128ControlState
+> {
+  constructor(props: IBaseControlProps) {
+    super(props);
+
+    this.state = {
+      internalValue: props.value,
+    };
+  }
+
+  render() {
+    const { children, property, value } = this.props;
+    const { internalValue } = this.state;
+
+    return (
+      <InputGroup className="CreateObjectDialog__Decimal128Control">
+        <Input
+          className="CreateObjectDialog__Decimal128Control__Input"
+          onChange={this.inputChangeEventHandler}
+          placeholder={value === null ? 'null' : ''}
+          value={internalValue ?? ''}
+          required={!property.optional}
+          invalid={(!!internalValue || !property.optional) && value === null}
+        />
+        {internalValue && property.optional && (
+          <InputGroupAddon addonType="append">
+            <Button size="sm" onClick={this.clearValue}>
+              <i className="fa fa-close" />
+            </Button>
+          </InputGroupAddon>
+        )}
+        {children}
+      </InputGroup>
+    );
+  }
+
+  private inputChangeEventHandler = (e: React.ChangeEvent<HTMLInputElement>) =>
+    this.internalChangeHandler(e.target.value);
+
+  private clearValue = () => this.internalChangeHandler(null);
+
+  private internalChangeHandler = (val: string | null) => {
+    const { property, onChange } = this.props;
+
+    this.setState({ internalValue: val });
+
+    let parsedId: Decimal128 | null = null;
+
+    if (val) {
+      try {
+        parsedId = parseDecimal128(val, property);
+      } catch (_) {
+        // ignored
+      }
+    }
+
+    onChange(parsedId);
+  };
+}

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/types/Decimal128Control.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/types/Decimal128Control.tsx
@@ -75,16 +75,16 @@ export class Decimal128Control extends React.PureComponent<
 
     this.setState({ internalValue: val });
 
-    let parsedId: Decimal128 | null = null;
+    let parsedDecimal: Decimal128 | null = null;
 
     if (val) {
       try {
-        parsedId = parseDecimal128(val, property);
+        parsedDecimal = parseDecimal128(val, property);
       } catch (_) {
         // ignored
       }
     }
 
-    onChange(parsedId);
+    onChange(parsedDecimal);
   };
 }

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/types/TypeControl.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/types/TypeControl.tsx
@@ -24,6 +24,7 @@ import { IClassFocus } from '../../../focus';
 import { BooleanControl } from './BooleanControl';
 import { DataControl } from './DataControl';
 import { DateControl } from './DateControl';
+import { Decimal128Control } from './Decimal128Control';
 import { DefaultControl } from './DefaultControl';
 import { ListControl } from './ListControl';
 import { NummericControl } from './NummericControl';
@@ -86,6 +87,15 @@ export const TypeControl = ({
   ) {
     return (
       <NummericControl
+        children={children}
+        property={property}
+        value={value as number | null}
+        onChange={onChange}
+      />
+    );
+  } else if (property.type === 'decimal') {
+    return (
+      <Decimal128Control
         children={children}
         property={property}
         value={value as number | null}

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/types/TypeControl.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/types/TypeControl.tsx
@@ -31,7 +31,7 @@ import { NummericControl } from './NummericControl';
 import { ObjectControl } from './ObjectControl';
 import { ObjectIdControl } from './ObjectIdControl';
 import { StringControl } from './StringControl';
-import { ObjectId } from 'bson';
+import { ObjectId, Decimal128 } from 'bson';
 
 export interface IBaseControlProps<ValueType = any> {
   children?: React.ReactNode;
@@ -98,7 +98,7 @@ export const TypeControl = ({
       <Decimal128Control
         children={children}
         property={property}
-        value={value as number | null}
+        value={value as Decimal128 | null}
         onChange={onChange}
       />
     );

--- a/src/ui/RealmBrowser/Content/Table/Cell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/Cell.tsx
@@ -60,6 +60,7 @@ const getCellContent = ({
     case 'int':
     case 'float':
     case 'double':
+    case 'decimal':
     case 'bool':
     case 'string':
     case 'date': {

--- a/src/ui/RealmBrowser/parsers.ts
+++ b/src/ui/RealmBrowser/parsers.ts
@@ -46,7 +46,8 @@ export const parseDecimal128 = (
     try {
       // Note: thousand separators are not supported by Decimal128, so we can help out the user by converting ',' to '.'.
       return Decimal128.fromString(value.replace(',', '.'));
-    } catch (_) {
+    } catch (err) {
+      console.error(err);
       throw new Error(`"${value}" is not a proper ${property.type}`);
     }
   }

--- a/src/ui/RealmBrowser/parsers.ts
+++ b/src/ui/RealmBrowser/parsers.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import moment from 'moment';
-import { ObjectId } from 'bson';
+import { ObjectId, Decimal128 } from 'bson';
 
 export const parseObjectId = (
   value: string,
@@ -32,6 +32,22 @@ export const parseObjectId = (
       throw new Error(
         `"${value}" is not a proper ${property.type}:\nUse a 24 character hexadecimal string`,
       );
+    }
+  }
+};
+
+export const parseDecimal128 = (
+  value: string,
+  property: Realm.ObjectSchemaProperty,
+) => {
+  if (value === '' && property.optional) {
+    return null;
+  } else {
+    try {
+      // Note: thousand separators are not supported by Decimal128, so we can help out the user by converting ',' to '.'.
+      return Decimal128.fromString(value.replace(',', '.'));
+    } catch (_) {
+      throw new Error(`"${value}" is not a proper ${property.type}`);
     }
   }
 };
@@ -104,12 +120,12 @@ export const parse = (value: string, property: Realm.ObjectSchemaProperty) => {
       return parseObjectId(value, property);
     case 'int':
     case 'float':
-    case 'double': {
+    case 'double':
       return parseNumber(value, property);
-    }
-    case 'bool': {
+    case 'decimal':
+      return parseDecimal128(value, property);
+    case 'bool':
       return parseBoolean(value, property);
-    }
     case 'date':
       return parseDate(value, property);
     case 'string':

--- a/src/ui/RealmBrowser/parsers.ts
+++ b/src/ui/RealmBrowser/parsers.ts
@@ -47,7 +47,6 @@ export const parseDecimal128 = (
       // Note: thousand separators are not supported by Decimal128, so we can help out the user by converting ',' to '.'.
       return Decimal128.fromString(value.replace(',', '.'));
     } catch (err) {
-      console.error(err);
       throw new Error(`"${value}" is not a proper ${property.type}`);
     }
   }

--- a/src/ui/RealmBrowser/primitives.ts
+++ b/src/ui/RealmBrowser/primitives.ts
@@ -17,12 +17,12 @@
 ////////////////////////////////////////////////////////////////////////////
 
 export const TYPES: string[] = [
-  'decimal',
   'object id',
   'bool',
   'int',
   'float',
   'double',
+  'decimal',
   'string',
   'data',
   'date',


### PR DESCRIPTION
Known issue:
- Realm throws an error for decimals of > 19 digits (Studio will just display a warning and roll back the value) - see: https://github.com/realm/realm-core/pull/3679

Potential optimisations:
- `Decimal128Control` & `ObjectIdControl` shared quite a lot of code, and could inherit from a shared generic base-component (I think we should keep this in a refactoring round?).