### PR TITLE
v10: Checking for one more message to detect encryption

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- None
+- When opening an encrypted Realm, users was shown an error instead of the prompt to enter an encryption key. ([#1351](https://github.com/realm/realm-studio/pull/1351), since v10.0.0)
 
 ### Internals
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- When opening an encrypted Realm, users was shown an error instead of the prompt to enter an encryption key. ([#1351](https://github.com/realm/realm-studio/pull/1351), since v10.0.0)
+- When opening an encrypted Realm, users were shown an error instead of the prompt to enter an encryption key. ([#1351](https://github.com/realm/realm-studio/pull/1351), since v10.0.0)
 
 ### Internals
 

--- a/scripts/check-auto-update-files.js
+++ b/scripts/check-auto-update-files.js
@@ -37,12 +37,12 @@ try {
       // This is one of the auto updating "latest-*" json / yml files
 
       // 1. Check that the version matches that of the package.json and package-lock.json
-      assert.equal(
+      assert.strictEqual(
         autoUpdateContent.version,
         packageJson.version,
         'Expected version to equal that of package.json',
       );
-      assert.equal(
+      assert.strictEqual(
         autoUpdateContent.version,
         packageLockJson.version,
         'Expected version to equal that of package-lock.json',

--- a/scripts/check-package-lock.js
+++ b/scripts/check-package-lock.js
@@ -17,8 +17,8 @@ function checkVersion(name, version, lockVersion) {
 }
 
 try {
-  assert.equal(package.name, packageLock.name, "Name changed");
-  assert.equal(package.version, packageLock.version, "Version changed");
+  assert.strictEqual(package.name, packageLock.name, "Name changed");
+  assert.strictEqual(package.version, packageLock.version, "Version changed");
   // Check that all package.json dependencies are semantically compatible with the lock
   Object.keys(package.dependencies).forEach(name => {
     const version = package.dependencies[name];

--- a/src/actions/index.test.ts
+++ b/src/actions/index.test.ts
@@ -88,7 +88,7 @@ describe('Actions', () => {
 
     it('can send a message and receive the result', async () => {
       const response = await sender.test('Hello');
-      assert.equal(response, 'Hello World!');
+      assert.strictEqual(response, 'Hello World!');
     });
 
     it('rejects if an error happens', async () => {
@@ -97,7 +97,7 @@ describe('Actions', () => {
         await sender.fail('Reason for failure');
       } catch (err) {
         assert(err instanceof Error);
-        assert.equal(err.message, 'Reason for failure');
+        assert.strictEqual(err.message, 'Reason for failure');
         threw = true;
       } finally {
         assert(threw, 'Expected a rejected promise');

--- a/src/services/data-importer/tests/index.test.ts
+++ b/src/services/data-importer/tests/index.test.ts
@@ -30,32 +30,35 @@ const TESTS_PATH = './src/services/data-importer/tests';
 describe('Import CSV tests', () => {
   describe('Util helper methods', () => {
     it('parses strings to booleans', () => {
-      assert.equal(Util.isBoolean('true'), true);
-      assert.equal(Util.isBoolean('TRUE'), true);
-      assert.equal(Util.isBoolean('TrUe'), true);
+      assert.strictEqual(Util.isBoolean('true'), true);
+      assert.strictEqual(Util.isBoolean('TRUE'), true);
+      assert.strictEqual(Util.isBoolean('TrUe'), true);
 
-      assert.equal(Util.isBoolean('false'), true);
-      assert.equal(Util.isBoolean('FALSE'), true);
-      assert.equal(Util.isBoolean('FaLse'), true);
+      assert.strictEqual(Util.isBoolean('false'), true);
+      assert.strictEqual(Util.isBoolean('FALSE'), true);
+      assert.strictEqual(Util.isBoolean('FaLse'), true);
 
-      assert.equal(Util.isBoolean('123'), false);
-      assert.equal(Util.isBoolean(' false'), false);
-      assert.equal(Util.isBoolean('true '), false);
+      assert.strictEqual(Util.isBoolean('123'), false);
+      assert.strictEqual(Util.isBoolean(' false'), false);
+      assert.strictEqual(Util.isBoolean('true '), false);
     });
 
     it('parses strings to ints', () => {
-      assert.equal(Util.isInt('123'), true);
-      assert.equal(Util.isInt('3.14'), false);
-      assert.equal(Util.isInt('true'), false);
-      assert.equal(Util.isInt('A094E453-46FD-4F13-AD2F-7333E2C4ABCA'), false);
+      assert.strictEqual(Util.isInt('123'), true);
+      assert.strictEqual(Util.isInt('3.14'), false);
+      assert.strictEqual(Util.isInt('true'), false);
+      assert.strictEqual(
+        Util.isInt('A094E453-46FD-4F13-AD2F-7333E2C4ABCA'),
+        false,
+      );
     });
 
     it('parses strings to doubles', () => {
-      assert.equal(Util.isDouble('3.14'), true);
-      assert.equal(Util.isDouble('3.0'), true);
-      assert.equal(Util.isDouble('3'), true); // always check isInt before isDouble when parsing!
-      assert.equal(Util.isDouble('true'), false);
-      assert.equal(Util.isDouble('0XCAFEBABE'), false);
+      assert.strictEqual(Util.isDouble('3.14'), true);
+      assert.strictEqual(Util.isDouble('3.0'), true);
+      assert.strictEqual(Util.isDouble('3'), true); // always check isInt before isDouble when parsing!
+      assert.strictEqual(Util.isDouble('true'), false);
+      assert.strictEqual(Util.isDouble('0XCAFEBABE'), false);
     });
   });
 
@@ -64,17 +67,21 @@ describe('Import CSV tests', () => {
 
     const schema = generateSchema(ImportFormat.CSV, files);
 
-    assert.equal(schema.length, 1, 'Expected to parse one schema (Cat)');
+    assert.strictEqual(schema.length, 1, 'Expected to parse one schema (Cat)');
     const catSchema = schema[0];
-    assert.equal(catSchema.name, 'Cat', 'Expected to parse schema named (Cat)');
-    assert.equal(catSchema.properties.name, 'string?');
-    assert.equal(catSchema.properties.age, 'int?');
-    assert.equal(catSchema.properties.height, 'double?');
-    assert.equal(catSchema.properties.weight, 'int?');
-    assert.equal(catSchema.properties.hasTail, 'bool?');
-    assert.equal(catSchema.properties.birthday, 'string?');
-    assert.equal(catSchema.properties.owner, 'string?');
-    assert.equal(catSchema.properties.scaredOfDog, 'string?');
+    assert.strictEqual(
+      catSchema.name,
+      'Cat',
+      'Expected to parse schema named (Cat)',
+    );
+    assert.strictEqual(catSchema.properties.name, 'string?');
+    assert.strictEqual(catSchema.properties.age, 'int?');
+    assert.strictEqual(catSchema.properties.height, 'double?');
+    assert.strictEqual(catSchema.properties.weight, 'int?');
+    assert.strictEqual(catSchema.properties.hasTail, 'bool?');
+    assert.strictEqual(catSchema.properties.birthday, 'string?');
+    assert.strictEqual(catSchema.properties.owner, 'string?');
+    assert.strictEqual(catSchema.properties.scaredOfDog, 'string?');
   });
 
   describe('Creating and populating the Realm', () => {
@@ -94,72 +101,79 @@ describe('Import CSV tests', () => {
       // open the Realm and make sure the schema matches
       const realm = new Realm({ path: REALM_FILE_PATH, schema });
 
-      assert.equal(
+      assert.strictEqual(
         fs.existsSync(REALM_FILE_PATH),
         true,
         `Realm file was not found at the expected path: ${REALM_FILE_PATH}`,
       );
 
-      assert.equal(realm.schema.length, 1, 'Expected to find one schema (Cat)');
+      assert.strictEqual(
+        realm.schema.length,
+        1,
+        'Expected to find one schema (Cat)',
+      );
       const catSchema = realm.schema[0];
-      assert.equal(
+      assert.strictEqual(
         catSchema.name,
         'Cat',
         'Expected Schema name to match (Cat)',
       );
 
-      assert.equal(catSchema.properties.hasOwnProperty('name'), true);
+      assert.strictEqual(catSchema.properties.hasOwnProperty('name'), true);
       const nameProperty = catSchema.properties.name as ObjectSchemaProperty;
-      assert.equal(nameProperty.type, 'string');
-      assert.equal(nameProperty.optional, true);
-      assert.equal(nameProperty.indexed, false);
+      assert.strictEqual(nameProperty.type, 'string');
+      assert.strictEqual(nameProperty.optional, true);
+      assert.strictEqual(nameProperty.indexed, false);
 
-      assert.equal(catSchema.properties.hasOwnProperty('age'), true);
+      assert.strictEqual(catSchema.properties.hasOwnProperty('age'), true);
       const ageProperty = catSchema.properties.age as ObjectSchemaProperty;
-      assert.equal(ageProperty.type, 'int');
-      assert.equal(ageProperty.optional, true);
-      assert.equal(ageProperty.indexed, false);
+      assert.strictEqual(ageProperty.type, 'int');
+      assert.strictEqual(ageProperty.optional, true);
+      assert.strictEqual(ageProperty.indexed, false);
 
-      assert.equal(catSchema.properties.hasOwnProperty('height'), true);
+      assert.strictEqual(catSchema.properties.hasOwnProperty('height'), true);
       const heightProperty = catSchema.properties
         .height as ObjectSchemaProperty;
-      assert.equal(heightProperty.type, 'double');
-      assert.equal(heightProperty.optional, true);
-      assert.equal(heightProperty.indexed, false);
+      assert.strictEqual(heightProperty.type, 'double');
+      assert.strictEqual(heightProperty.optional, true);
+      assert.strictEqual(heightProperty.indexed, false);
 
-      assert.equal(catSchema.properties.hasOwnProperty('weight'), true);
+      assert.strictEqual(catSchema.properties.hasOwnProperty('weight'), true);
       const weightProperty = catSchema.properties
         .weight as ObjectSchemaProperty;
-      assert.equal(weightProperty.type, 'int');
-      assert.equal(weightProperty.optional, true);
-      assert.equal(weightProperty.indexed, false);
+      assert.strictEqual(weightProperty.type, 'int');
+      assert.strictEqual(weightProperty.optional, true);
+      assert.strictEqual(weightProperty.indexed, false);
 
-      assert.equal(catSchema.properties.hasOwnProperty('hasTail'), true);
+      assert.strictEqual(catSchema.properties.hasOwnProperty('hasTail'), true);
       const hasTailProperty = catSchema.properties
         .hasTail as ObjectSchemaProperty;
-      assert.equal(hasTailProperty.type, 'bool');
-      assert.equal(hasTailProperty.optional, true);
-      assert.equal(hasTailProperty.indexed, false);
+      assert.strictEqual(hasTailProperty.type, 'bool');
+      assert.strictEqual(hasTailProperty.optional, true);
+      assert.strictEqual(hasTailProperty.indexed, false);
 
-      assert.equal(catSchema.properties.hasOwnProperty('birthday'), true);
+      assert.strictEqual(catSchema.properties.hasOwnProperty('birthday'), true);
       const birthdayProperty = catSchema.properties
         .birthday as ObjectSchemaProperty;
-      assert.equal(birthdayProperty.type, 'string');
-      assert.equal(birthdayProperty.optional, true);
-      assert.equal(birthdayProperty.indexed, false);
+      assert.strictEqual(birthdayProperty.type, 'string');
+      assert.strictEqual(birthdayProperty.optional, true);
+      assert.strictEqual(birthdayProperty.indexed, false);
 
-      assert.equal(catSchema.properties.hasOwnProperty('owner'), true);
+      assert.strictEqual(catSchema.properties.hasOwnProperty('owner'), true);
       const ownerProperty = catSchema.properties.owner as ObjectSchemaProperty;
-      assert.equal(ownerProperty.type, 'string');
-      assert.equal(ownerProperty.optional, true);
-      assert.equal(ownerProperty.indexed, false);
+      assert.strictEqual(ownerProperty.type, 'string');
+      assert.strictEqual(ownerProperty.optional, true);
+      assert.strictEqual(ownerProperty.indexed, false);
 
-      assert.equal(catSchema.properties.hasOwnProperty('scaredOfDog'), true);
+      assert.strictEqual(
+        catSchema.properties.hasOwnProperty('scaredOfDog'),
+        true,
+      );
       const scaredOfDogProperty = catSchema.properties
         .scaredOfDog as ObjectSchemaProperty;
-      assert.equal(scaredOfDogProperty.type, 'string');
-      assert.equal(scaredOfDogProperty.optional, true);
-      assert.equal(scaredOfDogProperty.indexed, false);
+      assert.strictEqual(scaredOfDogProperty.type, 'string');
+      assert.strictEqual(scaredOfDogProperty.optional, true);
+      assert.strictEqual(scaredOfDogProperty.indexed, false);
 
       realm.close();
     });
@@ -173,26 +187,26 @@ describe('Import CSV tests', () => {
       csvImporter.import(realm);
 
       const cats = realm.objects('Cat').sorted('name');
-      assert.equal(cats.length, 2);
+      assert.strictEqual(cats.length, 2);
       let cat = cats[0] as any;
-      assert.equal(cat.name, 'Kitty');
-      assert.equal(cat.age, 3);
-      assert.equal(cat.height, 22.1);
-      assert.equal(cat.weight, 0);
-      assert.equal(cat.hasTail, false);
-      assert.equal(cat.birthday, '<null>');
-      assert.equal(cat.owner, '<null>');
-      assert.equal(cat.scaredOfDog, '<null>');
+      assert.strictEqual(cat.name, 'Kitty');
+      assert.strictEqual(cat.age, 3);
+      assert.strictEqual(cat.height, 22.1);
+      assert.strictEqual(cat.weight, 0);
+      assert.strictEqual(cat.hasTail, false);
+      assert.strictEqual(cat.birthday, '<null>');
+      assert.strictEqual(cat.owner, '<null>');
+      assert.strictEqual(cat.scaredOfDog, '<null>');
 
       cat = cats[1] as any;
-      assert.equal(cat.name, 'Ninneko');
-      assert.equal(cat.age, 4);
-      assert.equal(cat.height, 21.0);
-      assert.equal(cat.weight, 0);
-      assert.equal(cat.hasTail, true);
-      assert.equal(cat.birthday, '<null>');
-      assert.equal(cat.owner, '<null>');
-      assert.equal(cat.scaredOfDog, '<null>');
+      assert.strictEqual(cat.name, 'Ninneko');
+      assert.strictEqual(cat.age, 4);
+      assert.strictEqual(cat.height, 21.0);
+      assert.strictEqual(cat.weight, 0);
+      assert.strictEqual(cat.hasTail, true);
+      assert.strictEqual(cat.birthday, '<null>');
+      assert.strictEqual(cat.owner, '<null>');
+      assert.strictEqual(cat.scaredOfDog, '<null>');
 
       realm.close();
     });
@@ -226,8 +240,8 @@ describe('Import CSV tests', () => {
 
       const people = realm.objects('people');
       const dogs = realm.objects('dogs');
-      assert.equal(people.length, 2);
-      assert.equal(dogs.length, 2);
+      assert.strictEqual(people.length, 2);
+      assert.strictEqual(dogs.length, 2);
       realm.close();
     });
 
@@ -241,13 +255,13 @@ describe('Import CSV tests', () => {
       csvImporter.import(realm);
 
       const optionals: any = realm.objects('optional').sorted('integerValue');
-      assert.equal(optionals.length, 5);
+      assert.strictEqual(optionals.length, 5);
 
       // checking null values
-      assert.equal(optionals[0].integerValue, null);
-      assert.equal(optionals[2].boolValue, null);
-      assert.equal(optionals[3].doubleValue, null);
-      assert.equal(optionals[4].stringValue, null);
+      assert.strictEqual(optionals[0].integerValue, null);
+      assert.strictEqual(optionals[2].boolValue, null);
+      assert.strictEqual(optionals[3].doubleValue, null);
+      assert.strictEqual(optionals[4].stringValue, null);
       realm.close();
     });
 
@@ -261,7 +275,7 @@ describe('Import CSV tests', () => {
       const realm = new Realm({ path: REALM_FILE_PATH, schema });
 
       csvImporter.import(realm);
-      assert.equal(realm.objects('inspections').length, 18480);
+      assert.strictEqual(realm.objects('inspections').length, 18480);
 
       realm.close();
     });
@@ -278,7 +292,7 @@ describe('Import CSV tests', () => {
 
       // Open existing Realm file containing schema for Dog, Cat, Owner and DogPromaryKey
       const assetRealm = new Realm({ path: temporaryPath });
-      assert.equal(assetRealm.schema.length, 4);
+      assert.strictEqual(assetRealm.schema.length, 4);
       assert.notEqual(
         assetRealm.schema.find(objectSchema => objectSchema.name === 'Dog'),
         undefined,
@@ -288,23 +302,23 @@ describe('Import CSV tests', () => {
       assetRealm.delete(assetRealm.objects('Dog'));
       assetRealm.commitTransaction();
 
-      assert.equal(assetRealm.objects('Dog').length, 0);
+      assert.strictEqual(assetRealm.objects('Dog').length, 0);
 
       csvImporter.import(assetRealm);
 
       // Check new rows were added
       const dogs: any = assetRealm.objects('Dog').sorted('name');
-      assert.equal(dogs.length, 2);
-      assert.equal(dogs[0].name, 'Caesar');
-      assert.equal(dogs[1].name, 'Rex');
-      assert.equal(dogs[0].age, 3);
-      assert.equal(dogs[1].age, 5);
-      assert.equal(dogs[0].height, 6);
-      assert.equal(dogs[1].height.toPrecision(3), 3.14);
-      assert.equal(dogs[0].weight, 16);
-      assert.equal(dogs[1].weight, 17);
-      assert.equal(dogs[0].hasTail, true);
-      assert.equal(dogs[1].hasTail, false);
+      assert.strictEqual(dogs.length, 2);
+      assert.strictEqual(dogs[0].name, 'Caesar');
+      assert.strictEqual(dogs[1].name, 'Rex');
+      assert.strictEqual(dogs[0].age, 3);
+      assert.strictEqual(dogs[1].age, 5);
+      assert.strictEqual(dogs[0].height, 6);
+      assert.strictEqual(dogs[1].height.toPrecision(3), '3.14');
+      assert.strictEqual(dogs[0].weight, 16);
+      assert.strictEqual(dogs[1].weight, 17);
+      assert.strictEqual(dogs[0].hasTail, true);
+      assert.strictEqual(dogs[1].hasTail, false);
 
       assetRealm.close();
     });

--- a/src/services/schema-export/tests/index.test.ts
+++ b/src/services/schema-export/tests/index.test.ts
@@ -53,7 +53,7 @@ const assertGeneratedSchemaAreValid = (
   generatedFilePaths: string[],
   realm: Realm,
 ) => {
-  assert.equal(expectedFilePaths.length, generatedFilePaths.length);
+  assert.strictEqual(expectedFilePaths.length, generatedFilePaths.length);
 
   const exporter = SchemaExporter(language);
   exporter.exportSchema(realm);
@@ -62,7 +62,7 @@ const assertGeneratedSchemaAreValid = (
   for (let i = 0; i < expectedFilePaths.length; i++) {
     const expected = fs.readFileSync(expectedFilePaths[i], 'utf8');
     const generated = fs.readFileSync(generatedFilePaths[i], 'utf8');
-    assert.equal(generated, expected);
+    assert.strictEqual(generated, expected);
   }
 };
 

--- a/src/testing/all-type-realm.ts
+++ b/src/testing/all-type-realm.ts
@@ -20,6 +20,8 @@ import { resolve } from 'path';
 import Realm from 'realm';
 import tmp from 'tmp';
 
+import { ITestRealm } from './index';
+
 import { TYPES as primitiveTypes } from '../ui/RealmBrowser/primitives';
 
 const CustomClass: Realm.ObjectSchema = {
@@ -81,10 +83,6 @@ function generateSchema() {
   schema.push(CustomClass);
   // Return the list of object schemas
   return schema;
-}
-
-export interface ITestRealm extends Realm {
-  closeAndDelete: () => void;
 }
 
 export const create = () => {

--- a/src/testing/encrypted-realm.ts
+++ b/src/testing/encrypted-realm.ts
@@ -1,0 +1,43 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import { resolve } from 'path';
+import Realm from 'realm';
+import tmp from 'tmp';
+
+import { ITestRealm } from './index';
+
+export const create = (key: string) => {
+  const encryptionKey = Buffer.from(key, 'hex');
+  const schema = [{ name: 'Item', properties: { title: 'string' } }];
+  const tempDirectory = tmp.dirSync();
+  const path = resolve(tempDirectory.name, 'encrypted-types.realm');
+  const realm = new Realm({ path, schema, encryptionKey }) as ITestRealm;
+  // Implement a method to close and delete the Realm
+  realm.closeAndDelete = () => {
+    realm.close();
+    // Delete the Realm file
+    Realm.deleteFile({
+      path: realm.path,
+    });
+    // Delete the temporary directory
+    tempDirectory.removeCallback();
+  };
+  // Return the Realm
+  return realm;
+};

--- a/src/testing/encrypted-realm.ts
+++ b/src/testing/encrypted-realm.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2018 Realm Inc.
+// Copyright 2020 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,0 +1,3 @@
+export interface ITestRealm extends Realm {
+  closeAndDelete: () => void;
+}

--- a/src/testing/post-packaging/index.ts
+++ b/src/testing/post-packaging/index.ts
@@ -102,7 +102,7 @@ function buildMockedRealmStudio() {
   }
 }
 
-assert.equal(
+assert.strictEqual(
   os.platform(),
   'darwin',
   'Currently, the post-package tests can only run on MacOS',
@@ -113,7 +113,7 @@ assert(
   'Build the app before running the post-package tests',
 );
 
-assert.equal(typeof productName, 'string', 'Expected a product name');
+assert.strictEqual(typeof productName, 'string', 'Expected a product name');
 
 describe('Realm Studio packaged', () => {
   let mockedS3: http.Server;
@@ -186,13 +186,13 @@ describe('Realm Studio packaged', () => {
       function readySignalChanged(currentStat: fs.Stats) {
         if (updateCount === 0) {
           updateCount++;
-          assert.equal(currentStat.size, 0);
+          assert.strictEqual(currentStat.size, 0);
         } else if (updateCount === 1) {
           updateCount++;
           const content = fs.readFileSync(readySignalPath, {
             encoding: 'utf8',
           });
-          assert.equal(content, `Hello from a future ${productName}!`);
+          assert.strictEqual(content, `Hello from a future ${productName}!`);
           // Stop watching the file
           fs.unwatchFile(readySignalPath, readySignalChanged);
           resolve();

--- a/src/ui/RealmBrowser/index.test.tsx
+++ b/src/ui/RealmBrowser/index.test.tsx
@@ -108,8 +108,8 @@ describeIfBuilt('<RealmBrowser /> via Spectron', function() {
   describe('opening Realm file', () => {
     before(async () => {
       // Await the Greeting window
-      assert.equal(await app.client.getWindowCount(), 1);
-      assert.equal(await app.client.getTitle(), 'Realm Studio');
+      assert.strictEqual(await app.client.getWindowCount(), 1);
+      assert.strictEqual(await app.client.getTitle(), 'Realm Studio');
       // Mock the open dialog to return the Realm path
       fakeDialog.mock([
         {
@@ -125,7 +125,7 @@ describeIfBuilt('<RealmBrowser /> via Spectron', function() {
 
     it('shows the Realm Browser', async () => {
       // Wait for the browser window to open and change focus to that
-      assert.equal(await app.client.getWindowCount(), 2);
+      assert.strictEqual(await app.client.getWindowCount(), 2);
       // Wait for the left sidebar to exist
       await app.client.waitForExist('span=Classes');
     });
@@ -159,7 +159,7 @@ describeIfBuilt('<RealmBrowser /> via Spectron', function() {
           // Assert something about the header
           const headerCells = await app.client.elements(selectors.headerCell);
           // Assert that is has the same number of header cells as it has properties
-          assert.equal(
+          assert.strictEqual(
             headerCells.value.length,
             Object.keys(schema.properties).length,
           );
@@ -169,7 +169,7 @@ describeIfBuilt('<RealmBrowser /> via Spectron', function() {
           before(async () => {
             // Expect no cells
             const cells = await app.client.elements(selectors.cell);
-            assert.equal(cells.value.length, 0);
+            assert.strictEqual(cells.value.length, 0);
             // Create a row
             await app.client.click(`button=Create ${className}`);
             await app.client.waitForVisible('button=Create');
@@ -181,7 +181,7 @@ describeIfBuilt('<RealmBrowser /> via Spectron', function() {
           // Assert something about the row that was just created
           it('creates a row in the table', async () => {
             const cells = await app.client.elements(selectors.cell);
-            assert.equal(
+            assert.strictEqual(
               cells.value.length,
               Object.keys(schema.properties).length,
             );

--- a/src/ui/RealmBrowser/index.test.tsx
+++ b/src/ui/RealmBrowser/index.test.tsx
@@ -120,11 +120,13 @@ describeIfBuilt('<RealmBrowser /> via Spectron', function() {
       await app.client.windowByIndex(1);
     });
 
-    after(() => {
+    after(async () => {
       if (realm) {
         // Close the Realm file
         realm.closeAndDelete();
       }
+      // Close the window ...
+      await app.client.close();
     });
 
     it('shows the Realm Browser', async () => {
@@ -230,11 +232,13 @@ describeIfBuilt('<RealmBrowser /> via Spectron', function() {
       await app.client.windowByIndex(1);
     });
 
-    after(() => {
+    after(async () => {
       if (realm) {
         // Close the Realm file
         realm.closeAndDelete();
       }
+      // Close the window ...
+      await app.client.close();
     });
 
     it('shows the Realm Browser (with the encryption key modal)', async () => {

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -316,8 +316,9 @@ class RealmBrowserContainer
   protected loadingRealmFailed(err: Error) {
     const message = err.message || '';
     const mightBeEncrypted =
-      message.indexOf('Not a Realm file.') >= 0 ||
-      message.indexOf('Invalid mnemonic') >= 0;
+      message.includes('Not a Realm file.') ||
+      message.includes('Invalid mnemonic') ||
+      message.includes('Realm file initial open failed');
     const realm = this.props.realm;
     if (mightBeEncrypted) {
       this.setState({

--- a/src/ui/reusable/RealmLoadingComponent/index.test.tsx
+++ b/src/ui/reusable/RealmLoadingComponent/index.test.tsx
@@ -72,8 +72,8 @@ describe('<RealmLoadingComponent />', () => {
         <TestRealmLoadingComponent />,
       );
       assert(element);
-      assert.equal(changes, 0, 'Expected no changes');
-      assert.equal(loads, 0, 'Expected no loads');
+      assert.strictEqual(changes, 0, 'Expected no changes');
+      assert.strictEqual(loads, 0, 'Expected no loads');
     });
   });
 
@@ -132,8 +132,8 @@ describe('<RealmLoadingComponent />', () => {
       const element = ReactTestUtils.renderIntoDocument(
         <AdminRealmLoadingComponent />,
       );
-      assert.equal(changes, 0, 'Expected no changes');
-      assert.equal(loads, 0, 'Expected no loads');
+      assert.strictEqual(changes, 0, 'Expected no changes');
+      assert.strictEqual(loads, 0, 'Expected no loads');
     });
   });
 

--- a/src/utils/menu.test.ts
+++ b/src/utils/menu.test.ts
@@ -43,10 +43,10 @@ describe('menu utilities', () => {
       id: 'item-b',
       items: [{ id: 'item-b-replaced', label: 'Item B Replaced' }],
     });
-    assert.equal(before.length, 3);
-    assert.equal(after.length, 3);
-    assert.equal(after[1].id, 'item-b-replaced');
-    assert.equal(after[1].label, 'Item B Replaced');
+    assert.strictEqual(before.length, 3);
+    assert.strictEqual(after.length, 3);
+    assert.strictEqual(after[1].id, 'item-b-replaced');
+    assert.strictEqual(after[1].label, 'Item B Replaced');
   });
 
   it('can append', () => {
@@ -55,10 +55,10 @@ describe('menu utilities', () => {
       id: 'item-b',
       items: [{ id: 'item-after-b', label: 'Item After B' }],
     });
-    assert.equal(before.length, 3);
-    assert.equal(after.length, 4);
-    assert.equal(after[2].id, 'item-after-b');
-    assert.equal(after[2].label, 'Item After B');
+    assert.strictEqual(before.length, 3);
+    assert.strictEqual(after.length, 4);
+    assert.strictEqual(after[2].id, 'item-after-b');
+    assert.strictEqual(after[2].label, 'Item After B');
   });
 
   it('can prepend', () => {
@@ -67,12 +67,12 @@ describe('menu utilities', () => {
       id: 'item-b',
       items: [{ id: 'item-before-b', label: 'Item Before B' }],
     });
-    assert.equal(before.length, 3);
-    assert.equal(after.length, 4);
-    assert.equal(after[1].id, 'item-before-b');
-    assert.equal(after[1].label, 'Item Before B');
-    assert.equal(after[2].id, 'item-b');
-    assert.equal(after[2].label, 'Item B');
+    assert.strictEqual(before.length, 3);
+    assert.strictEqual(after.length, 4);
+    assert.strictEqual(after[1].id, 'item-before-b');
+    assert.strictEqual(after[1].label, 'Item Before B');
+    assert.strictEqual(after[2].id, 'item-b');
+    assert.strictEqual(after[2].label, 'Item B');
   });
 
   it('can perform multiple modifications in submenus', () => {
@@ -106,9 +106,9 @@ describe('menu utilities', () => {
         ],
       },
     ]);
-    assert.equal(before.length, 3);
+    assert.strictEqual(before.length, 3);
     const itemC = after[2];
-    assert.equal(itemC.id, 'item-c');
+    assert.strictEqual(itemC.id, 'item-c');
     assert.deepStrictEqual(itemC.submenu, [
       { id: 'item-c-1', label: 'Item C 1' },
       { id: 'item-before-c-2', label: 'Item Before C 2' },

--- a/src/utils/process-directories.ts
+++ b/src/utils/process-directories.ts
@@ -37,7 +37,7 @@ function changeProcessDirectory(relativePath: string) {
 }
 
 export function changeRendererProcessDirectory() {
-  assert.equal(
+  assert.strictEqual(
     process.type,
     'renderer',
     'This should only be called from a renderer process',
@@ -49,7 +49,7 @@ export function changeRendererProcessDirectory() {
 }
 
 export function changeMainProcessDirectory() {
-  assert.equal(
+  assert.strictEqual(
     process.type,
     'browser',
     'This should only be called from a main process',

--- a/src/utils/promise-handle.test.ts
+++ b/src/utils/promise-handle.test.ts
@@ -23,16 +23,16 @@ import { createPromiseHandle } from './promise-handle';
 describe('promise handle', () => {
   it('can create a handle', () => {
     const handle = createPromiseHandle();
-    assert.equal(typeof handle.resolve, 'function');
-    assert.equal(typeof handle.reject, 'function');
-    assert.equal(typeof handle.promise, 'object');
+    assert.strictEqual(typeof handle.resolve, 'function');
+    assert.strictEqual(typeof handle.reject, 'function');
+    assert.strictEqual(typeof handle.promise, 'object');
     assert(handle.promise instanceof Promise);
   });
 
   it('can resolve the promise', done => {
     const handle = createPromiseHandle();
     handle.promise.then(result => {
-      assert.equal(result, 'w00t');
+      assert.strictEqual(result, 'w00t');
       done();
     });
     process.nextTick(() => {
@@ -43,7 +43,7 @@ describe('promise handle', () => {
   it('can reject the promise', done => {
     const handle = createPromiseHandle();
     handle.promise.catch(result => {
-      assert.equal(result, 'w00t');
+      assert.strictEqual(result, 'w00t');
       done();
     });
     process.nextTick(() => {


### PR DESCRIPTION
This fixes #1349 by adding a message to the possible messages thrown by Realm core, when detecting an encrypted Realm.