### PR TITLE
[major-10] Handling of ArrayBuffer for JSON serialization. Output as base64 string.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- None
+- When exporting to JSON, `'data'` properties are serialized to base64-strings, and not `{}`. ([#1367](https://github.com/realm/realm-studio/pull/1367), since v10.1.0)
 
 ### Internals
 

--- a/src/services/data-exporter/json.ts
+++ b/src/services/data-exporter/json.ts
@@ -22,6 +22,35 @@ import Realm from 'realm';
 import { IExportEngine } from '.';
 
 const INDENTATION_SPACES = 2;
+const CIRCULAR_ERROR_REGEX_CHECK = /circular|cyclic/i;
+
+// Note: Do not call Realm.JsonSerializationReplacer directly, as it's a getter
+// it will return a new function at each run, bypassing the circular detection.
+const RealmJsonSerializationReplacer = Realm.JsonSerializationReplacer;
+
+type StudioSerializationReplacer = (
+  this: StudioSerializationReplacer,
+  key: string,
+  value: any,
+) => any;
+
+function standardReplacer(_: string, value: any) {
+  return value instanceof ArrayBuffer
+    ? Buffer.from(value).toString('base64')
+    : value;
+}
+
+function circularReplacer(
+  this: StudioSerializationReplacer,
+  key: string,
+  value: any,
+) {
+  return RealmJsonSerializationReplacer.call(
+    this,
+    key,
+    standardReplacer(key, value),
+  );
+}
 
 type ResultMap = {
   [key: string]: Realm.Results<Realm.Object>;
@@ -31,18 +60,11 @@ const serialize = (map: ResultMap) => {
   try {
     // First try default stringify to avoid Realm.JsonSerializationReplacer
     // adding unnecessary `$refId` to the output.
-    return JSON.stringify(map, null, INDENTATION_SPACES);
+    return JSON.stringify(map, standardReplacer, INDENTATION_SPACES);
   } catch (err) {
-    if (
-      err instanceof TypeError &&
-      err.message.startsWith('Converting circular structure to JSON')
-    ) {
+    if (CIRCULAR_ERROR_REGEX_CHECK.test(err.message ?? err.toString())) {
       // If a circular structure is detected, serialize using Realm.JsonSerializationReplacer
-      return JSON.stringify(
-        map,
-        Realm.JsonSerializationReplacer,
-        INDENTATION_SPACES,
-      );
+      return JSON.stringify(map, circularReplacer, INDENTATION_SPACES);
     }
     throw err;
   }
@@ -64,11 +86,3 @@ export class JSONExportEngine implements IExportEngine {
     fs.writeFileSync(destinationPath, serialize(resultMap));
   }
 }
-
-/**
- * Adding serialization in form of base64 string to ArrayBuffer
- */
-// @ts-ignore ArrayBuffer has no toJSON defined/implemented
-ArrayBuffer.prototype.toJSON = function () {
-  return Buffer.from(this).toString('base64');
-};

--- a/src/services/data-exporter/json.ts
+++ b/src/services/data-exporter/json.ts
@@ -64,3 +64,11 @@ export class JSONExportEngine implements IExportEngine {
     fs.writeFileSync(destinationPath, serialize(resultMap));
   }
 }
+
+/**
+ * Adding serialization in form of base64 string to ArrayBuffer
+ */
+// @ts-ignore ArrayBuffer has no toJSON defined/implemented
+ArrayBuffer.prototype.toJSON = function () {
+  return Buffer.from(this).toString('base64');
+};


### PR DESCRIPTION
Implemented using a replacer for `JSON.stringify` (extending `Realm.JsonSerializationReplacer` when necessary).