### PR TITLE
Prettier failures on loading overlay

### DIFF
--- a/src/ui/reusable/LoadingOverlay/LoadingOverlay.scss
+++ b/src/ui/reusable/LoadingOverlay/LoadingOverlay.scss
@@ -58,7 +58,7 @@
     flex-direction: column;
     font-size: .9rem;
     justify-content: center;
-    min-height: 100%;
+    height: 100%;
     width: 100%;
   }
 
@@ -86,6 +86,13 @@
 
   &__Message {
     padding: $spacer;
+  }
+
+  &__Details {
+    overflow: auto;
+    text-align: left;
+    width: 100%;
+    color: $dove;
   }
 
   &__RetryButton {

--- a/src/ui/reusable/LoadingOverlay/LoadingOverlay.tsx
+++ b/src/ui/reusable/LoadingOverlay/LoadingOverlay.tsx
@@ -71,6 +71,9 @@ export const LoadingOverlay = ({
             {progress.message}
           </section>
         ) : null}
+        {progress && progress.details ? (
+          <code className="LoadingOverlay__Details">{progress.details}</code>
+        ) : null}
         {progress && showProgress && (
           <Progress
             className="LoadingOverlay__Progress"

--- a/src/ui/reusable/LoadingOverlay/index.ts
+++ b/src/ui/reusable/LoadingOverlay/index.ts
@@ -27,6 +27,7 @@ export interface IRetryParams {
 
 export interface ILoadingProgress {
   message?: string;
+  details?: string;
   status: LoadingStatus;
   transferable?: number;
   transferred?: number;

--- a/src/ui/reusable/RealmLoadingComponent/index.tsx
+++ b/src/ui/reusable/RealmLoadingComponent/index.tsx
@@ -91,7 +91,14 @@ export abstract class RealmLoadingComponent<
 
   protected loadingRealmFailed(err: Error) {
     const message = err.message || 'Failed to open the Realm';
-    this.setState({ progress: { message, status: 'failed' } });
+    const backtraceStart = message.indexOf('Exception backtrace:');
+    const summary = message.substring(0, backtraceStart);
+    // Trim off useless information
+    const trimmedSummary = summary.replace(/ Path:$/, '');
+    const details = message.substring(backtraceStart);
+    this.setState({
+      progress: { message: trimmedSummary, details, status: 'failed' },
+    });
   }
 
   private async openRealm(


### PR DESCRIPTION
At some point Realm Core started including a backtrace in the message of errors thrown, which is very inconvenient for an end user of Studio.

I've updated the loading overlay to show a separate (dimmed) scrollable section for the backtrace.

<img width="1012" alt="Screenshot 2021-01-13 at 12 03 14" src="https://user-images.githubusercontent.com/1243959/104445096-00666580-5599-11eb-91d3-6142aee4a08c.png">
