### PR TITLE
Fixed opening synced Realms devices

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- None
+- Fixed opening synced Realms devices. ([#1378](https://github.com/realm/realm-studio/pull/1378))
 
 ### Internals
 

--- a/src/ui/reusable/LoadingOverlay/LoadingOverlay.scss
+++ b/src/ui/reusable/LoadingOverlay/LoadingOverlay.scss
@@ -57,8 +57,8 @@
     display: flex;
     flex-direction: column;
     font-size: .9rem;
-    justify-content: center;
     height: 100%;
+    justify-content: center;
     width: 100%;
   }
 
@@ -89,10 +89,10 @@
   }
 
   &__Details {
+    color: $dove;
     overflow: auto;
     text-align: left;
     width: 100%;
-    color: $dove;
   }
 
   &__RetryButton {

--- a/src/ui/reusable/RealmLoadingComponent/index.tsx
+++ b/src/ui/reusable/RealmLoadingComponent/index.tsx
@@ -119,7 +119,7 @@ export abstract class RealmLoadingComponent<
       } catch (error) {
         if (
           error instanceof Error &&
-          error.message.includes('Incompatible histories.') &&
+          (error.message.includes('Incompatible histories.') || error.message.startsWith("History type (as specified by the Replication implementation passed to the DB constructor) was not consistent across the session")) &&
           realm.sync !== true
         ) {
           // Try to open the Realm locally with a sync history mode.

--- a/src/ui/reusable/RealmLoadingComponent/index.tsx
+++ b/src/ui/reusable/RealmLoadingComponent/index.tsx
@@ -119,7 +119,10 @@ export abstract class RealmLoadingComponent<
       } catch (error) {
         if (
           error instanceof Error &&
-          (error.message.includes('Incompatible histories.') || error.message.startsWith("History type (as specified by the Replication implementation passed to the DB constructor) was not consistent across the session")) &&
+          (error.message.includes('Incompatible histories.') ||
+            error.message.startsWith(
+              'History type (as specified by the Replication implementation passed to the DB constructor) was not consistent across the session',
+            )) &&
           realm.sync !== true
         ) {
           // Try to open the Realm locally with a sync history mode.


### PR DESCRIPTION
This changes adopts to the change in Realm core error message when opening a synced file.
Tested locally with a synced file from a running simulator.

This fixes #1362 and RSTUDIO-425.