### PR TITLE
Reading schema from Realm file when importing CSV (v5)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- None
+- Fixed CSV importing into an existing Realm. The schema declared by the Realm file was not used, but instead generated from the in the CSV file data. ([#1381](https://github.com/realm/realm-studio/pull/1381), since 1.12.0)
 
 ### Internals
 

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -776,9 +776,12 @@ class RealmBrowserContainer
     const paths = dataImporter.showOpenDialog(format);
     if (this.realm && paths && paths.length > 0) {
       try {
-        const schema = dataImporter.generateSchema(format, paths);
         try {
-          const importer = dataImporter.getDataImporter(format, paths, schema);
+          const importer = dataImporter.getDataImporter(
+            format,
+            paths,
+            this.realm.schema,
+          );
           importer.import(this.realm);
         } catch (err) {
           showError('Faild to import data', err);


### PR DESCRIPTION
Fixed CSV importing into an existing Realm. The schema declared by the Realm file was not used, but instead generated from the in the CSV file data. This fixes #1372.