### PR TITLE
[major-5] Handling of ArrayBuffer for JSON serialization. Output as base64 string.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- None
+- When exporting to JSON, `'data'` properties are serialized to base64-strings, and not `{}`. ([#1390](https://github.com/realm/realm-studio/pull/1390), since v5.0.0)
 
 ### Internals
 

--- a/src/services/data-exporter/json.ts
+++ b/src/services/data-exporter/json.ts
@@ -22,6 +22,35 @@ import Realm from 'realm';
 import { IExportEngine } from '.';
 
 const INDENTATION_SPACES = 2;
+const CIRCULAR_ERROR_REGEX_CHECK = /circular|cyclic/i;
+
+// Note: Do not call Realm.JsonSerializationReplacer directly, as it's a getter
+// it will return a new function at each run, bypassing the circular detection.
+const RealmJsonSerializationReplacer = Realm.JsonSerializationReplacer;
+
+type StudioSerializationReplacer = (
+  this: StudioSerializationReplacer,
+  key: string,
+  value: any,
+) => any;
+
+function standardReplacer(_: string, value: any) {
+  return value instanceof ArrayBuffer
+    ? Buffer.from(value).toString('base64')
+    : value;
+}
+
+function circularReplacer(
+  this: StudioSerializationReplacer,
+  key: string,
+  value: any,
+) {
+  return RealmJsonSerializationReplacer.call(
+    this,
+    key,
+    standardReplacer(key, value),
+  );
+}
 
 type ResultMap = {
   [key: string]: Realm.Results<Realm.Object>;
@@ -31,15 +60,11 @@ const serialize = (map: ResultMap) => {
   try {
     // First try default stringify to avoid Realm.JsonSerializationReplacer
     // adding unnecessary `$refId` to the output.
-    return JSON.stringify(map, null, INDENTATION_SPACES);
+    return JSON.stringify(map, standardReplacer, INDENTATION_SPACES);
   } catch (err) {
-    if (err instanceof TypeError && err.message.match(/circular|cyclic/i)) {
+    if (CIRCULAR_ERROR_REGEX_CHECK.test(err.message ?? err.toString())) {
       // If a circular structure is detected, serialize using Realm.JsonSerializationReplacer
-      return JSON.stringify(
-        map,
-        Realm.JsonSerializationReplacer,
-        INDENTATION_SPACES,
-      );
+      return JSON.stringify(map, circularReplacer, INDENTATION_SPACES);
     }
     throw err;
   }


### PR DESCRIPTION
Implemented using a replacer for JSON.stringify (extending Realm.JsonSerializationReplacer when necessary).
(Same as https://github.com/realm/realm-studio/pull/1367, for channel/major-5)