### PR TITLE
Fix opening files without .realm extension (#1409)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 
-- None
+- Added the ability to choose "All Files" when opening a Realm file, enabling opening files regardless of their file extension. ([#1410](https://github.com/realm/realm-studio/pull/1410))
 
 ### Fixed
 

--- a/src/main/Application.ts
+++ b/src/main/Application.ts
@@ -138,7 +138,10 @@ export class Application {
   public async showOpenLocalRealm() {
     const response = await dialog.showOpenDialog({
       properties: ['openFile', 'multiSelections'],
-      filters: [{ name: 'Realm Files', extensions: ['realm'] }],
+      filters: [
+        { name: 'Realm Files', extensions: ['realm'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
     });
     const realmsLoaded = response.filePaths.map(filePath =>
       this.openLocalRealmAtPath(filePath),


### PR DESCRIPTION
Maybe add an _"All Files"_ option can work.