### PR TITLE
New datatypes viewing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ spectron.log
 
 # Sentry cache folder
 .electron-symbols/
+
+# Products
+*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,3 @@ spectron.log
 
 # Sentry cache folder
 .electron-symbols/
-
-# Products
-*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -12052,9 +12052,9 @@
       }
     },
     "react-clone-referenced-element": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/react-clone-referenced-element/-/react-clone-referenced-element-1.1.0.tgz",
-      "integrity": "sha512-FKOsfKbBkPxYE8576EM6uAfHC4rnMpLyH6/TJUL4WcHUEB3EUn8AxPjnnV/IiwSSzsClvHYK+sDELKN/EJ0WYg=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-clone-referenced-element/-/react-clone-referenced-element-1.1.1.tgz",
+      "integrity": "sha512-LZBPvQV8W0B5dFzXFu+D3Tpil8YHS8tO00iFsfXcTLdtpuH7XyvaHqHcoz4hd4uNPQCZ30fceh+s7mLznzMXvg=="
     },
     "react-dom": {
       "version": "17.0.2",
@@ -12343,9 +12343,9 @@
       }
     },
     "realm": {
-      "version": "10.5.0-alpha.16",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-10.5.0-alpha.16.tgz",
-      "integrity": "sha512-hhj/eYFAlqL+Q84oVa1IW1toj9wqN8dVOJ+g8SdFntOdJqn5Ps1bgaST+XKUcdqlumgnFg267QUdt2tksVj2Qw==",
+      "version": "10.5.0-beta.1",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-10.5.0-beta.1.tgz",
+      "integrity": "sha512-7uK4h1mnZ/GCEVWo+b3TumcC76lKvg7O6qEbHtmMsrlVlySDBbDf5riAzYzvwRNCjGn+GnT+lIESODQ1f1ZG9w==",
       "requires": {
         "bindings": "^1.5.0",
         "bson": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2159,12 +2159,9 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-back": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-      "requires": {
-        "typical": "^2.6.1"
-      }
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -3715,13 +3712,14 @@
       }
     },
     "command-line-args": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
-      "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
       "requires": {
-        "array-back": "^2.0.0",
-        "find-replace": "^1.0.3",
-        "typical": "^2.6.1"
+        "array-back": "^3.0.1",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
       }
     },
     "commander": {
@@ -7137,22 +7135,11 @@
       }
     },
     "find-replace": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-      "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
       "requires": {
-        "array-back": "^1.0.4",
-        "test-value": "^2.1.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "requires": {
-            "typical": "^2.6.0"
-          }
-        }
+        "array-back": "^3.0.1"
       }
     },
     "find-up": {
@@ -9340,6 +9327,11 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "lodash.capitalize": {
       "version": "4.2.1",
@@ -12343,13 +12335,13 @@
       }
     },
     "realm": {
-      "version": "10.5.0-beta.1",
-      "resolved": "https://registry.npmjs.org/realm/-/realm-10.5.0-beta.1.tgz",
-      "integrity": "sha512-7uK4h1mnZ/GCEVWo+b3TumcC76lKvg7O6qEbHtmMsrlVlySDBbDf5riAzYzvwRNCjGn+GnT+lIESODQ1f1ZG9w==",
+      "version": "10.5.0-beta.2",
+      "resolved": "https://registry.npmjs.org/realm/-/realm-10.5.0-beta.2.tgz",
+      "integrity": "sha512-2Mfbt9AuVKiDb+npeTM7FlVVrp0V6AKRu74Wim/lQejBD/r/9epvL9YzxaiZcH8Lrt7/Np+HOpEb0bqWPkj7Dg==",
       "requires": {
         "bindings": "^1.5.0",
         "bson": "^4.3.0",
-        "command-line-args": "^4.0.6",
+        "command-line-args": "^5.1.1",
         "deepmerge": "2.1.0",
         "deprecated-react-native-listview": "0.0.6",
         "fs-extra": "^4.0.3",
@@ -12358,7 +12350,7 @@
         "node-addon-api": "^3.1.0",
         "node-fetch": "^2.6.1",
         "node-machine-id": "^1.1.10",
-        "prebuild-install": "^5.3.5",
+        "prebuild-install": "^6.1.1",
         "progress": "^2.0.3",
         "prop-types": "^15.6.2",
         "realm-network-transport": "^0.7.0",
@@ -12413,9 +12405,9 @@
           }
         },
         "prebuild-install": {
-          "version": "5.3.6",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
-          "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.2.tgz",
+          "integrity": "sha512-PzYWIKZeP+967WuKYXlTOhYBgGOvTRSfaKI89XnfJ0ansRAH7hDU45X+K+FZeI1Wb/7p/NnuctPH3g0IqKUuSQ==",
           "requires": {
             "detect-libc": "^1.0.3",
             "expand-template": "^2.0.3",
@@ -12423,15 +12415,14 @@
             "minimist": "^1.2.3",
             "mkdirp-classic": "^0.5.3",
             "napi-build-utils": "^1.0.1",
-            "node-abi": "^2.7.0",
+            "node-abi": "^2.21.0",
             "noop-logger": "^0.1.1",
             "npmlog": "^4.0.1",
             "pump": "^3.0.0",
             "rc": "^1.2.7",
             "simple-get": "^3.0.3",
             "tar-fs": "^2.0.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
+            "tunnel-agent": "^0.6.0"
           }
         },
         "universalify": {
@@ -14942,25 +14933,6 @@
         }
       }
     },
-    "test-value": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-      "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
-      "requires": {
-        "array-back": "^1.0.3",
-        "typical": "^2.6.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "requires": {
-            "typical": "^2.6.0"
-          }
-        }
-      }
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -15431,9 +15403,9 @@
       "dev": true
     },
     "typical": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
     },
     "ua-parser-js": {
       "version": "0.7.23",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "react-sortable-hoc": "^2.0.0",
     "react-virtualized": "^9.22.3",
     "reactstrap": "^8.9.0",
-    "realm": "^10.5.0-beta.1",
+    "realm": "^10.5.0-beta.2",
     "semver": "^7.3.5",
     "subscriptions-transport-ws": "^0.9.18",
     "uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "react-sortable-hoc": "^2.0.0",
     "react-virtualized": "^9.22.3",
     "reactstrap": "^8.9.0",
-    "realm": "10.5.0-alpha.16",
+    "realm": "^10.5.0-beta.1",
     "semver": "^7.3.5",
     "subscriptions-transport-ws": "^0.9.18",
     "uuid": "^8.3.2"

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/CreateObjectDialog.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/CreateObjectDialog.tsx
@@ -23,7 +23,7 @@ import Realm from 'realm';
 import { IClassFocus } from '../../focus';
 
 import { PropertyRow } from './PropertyRow';
-import { IsEmbeddedTypeChecker } from '../..';
+import { IsEmbeddedTypeChecker, JsonViewerDialogExecutor } from '../..';
 
 interface IBaseCreateObjectDialogProps {
   generateInitialValue: (property: Realm.ObjectSchemaProperty) => any;
@@ -44,6 +44,7 @@ export interface IOpenCreateObjectDialogProps
   isOpen: true;
   schema: Realm.ObjectSchema;
   isEmbeddedType: IsEmbeddedTypeChecker;
+  onShowJsonViewerDialog: JsonViewerDialogExecutor;
 }
 
 export type ICreateObjectDialogProps =
@@ -79,6 +80,7 @@ export const CreateObjectDialog = ({
               propertyName={propertyName}
               value={values[propertyName]}
               isEmbeddedType={props.isEmbeddedType}
+              onShowJsonViewerDialog={props.onShowJsonViewerDialog}
             />
           ))
         : null}

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/PropertyRow.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/PropertyRow.tsx
@@ -23,7 +23,7 @@ import Realm from 'realm';
 import { IClassFocus } from '../../focus';
 
 import { TypeControl } from './types/TypeControl';
-import { IsEmbeddedTypeChecker } from '../..';
+import { IsEmbeddedTypeChecker, JsonViewerDialogExecutor } from '../..';
 
 interface IPropertyRowProps {
   generateInitialValue: (property: Realm.ObjectSchemaProperty) => any;
@@ -34,6 +34,7 @@ interface IPropertyRowProps {
   propertyName: string;
   value: any;
   isEmbeddedType: IsEmbeddedTypeChecker;
+  onShowJsonViewerDialog: JsonViewerDialogExecutor;
 }
 
 export const PropertyRow = ({
@@ -45,6 +46,7 @@ export const PropertyRow = ({
   propertyName,
   value,
   isEmbeddedType,
+  onShowJsonViewerDialog,
 }: IPropertyRowProps) => (
   <FormGroup className="CreateObjectDialog__PropertyRow">
     <Label
@@ -65,6 +67,7 @@ export const PropertyRow = ({
       property={property}
       value={value}
       isEmbeddedType={isEmbeddedType}
+      onShowJsonViewerDialog={onShowJsonViewerDialog}
     />
   </FormGroup>
 );

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/index.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/index.tsx
@@ -30,7 +30,7 @@ import {
 } from './CreateObjectDialog';
 
 import './CreateObjectDialog.scss';
-import { IsEmbeddedTypeChecker } from '../..';
+import { IsEmbeddedTypeChecker, JsonViewerDialogExecutor } from '../..';
 
 const { ObjectId, UUID, Decimal128 } = Realm.BSON;
 
@@ -50,6 +50,7 @@ interface IOpenCreateObjectDialogContainerProps {
   schema: Realm.ObjectSchema;
   isEmbeddedType: IsEmbeddedTypeChecker;
   embeddedInfo?: EmbeddedInfo;
+  onShowJsonViewerDialog: JsonViewerDialogExecutor;
 }
 
 export interface ICreateObjectDialogContainerState {
@@ -177,6 +178,7 @@ class CreateObjectDialogContainer extends React.PureComponent<
         isOpen: true,
         getClassFocus: this.props.getClassFocus,
         schema: this.props.schema,
+        onShowJsonViewerDialog: this.props.onShowJsonViewerDialog,
       };
     } else {
       return {

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/types/DefaultControl.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/types/DefaultControl.tsx
@@ -34,6 +34,6 @@ export const DefaultControl = ({
   color = 'warning',
 }: IDefaultControlProps) => (
   <Alert color={color}>
-    {message ?? `Cannot select "${property.type}" yet`}
+    {message ?? `Creation of "${property.type}" is not yet implemented`}
   </Alert>
 );

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/types/ListControl.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/types/ListControl.tsx
@@ -35,6 +35,7 @@ interface IItemProps
     | 'value'
     | 'property'
     | 'isEmbeddedType'
+    | 'onShowJsonViewerDialog'
   > {
   onDelete: () => void;
 }
@@ -47,6 +48,7 @@ const Item = ({
   onDelete,
   value,
   isEmbeddedType,
+  onShowJsonViewerDialog,
 }: IItemProps) => (
   <section className="CreateObjectDialog__ListControl__Item">
     <TypeControl
@@ -56,6 +58,7 @@ const Item = ({
       property={property}
       value={value}
       isEmbeddedType={isEmbeddedType}
+      onShowJsonViewerDialog={onShowJsonViewerDialog}
     >
       <InputGroupAddon addonType="append">
         <Button onClick={onDelete} size="sm">
@@ -76,6 +79,7 @@ interface IListProps
     | 'onChange'
     | 'value'
     | 'isEmbeddedType'
+    | 'onShowJsonViewerDialog'
   > {
   itemProperty: Realm.ObjectSchemaProperty;
 }
@@ -87,6 +91,7 @@ const List = ({
   onChange,
   value,
   isEmbeddedType,
+  onShowJsonViewerDialog,
 }: IListProps) => (
   <section className="CreateObjectDialog__ListControl__Items">
     {Array.isArray(value) ? (
@@ -108,6 +113,7 @@ const List = ({
           property={itemProperty}
           value={value[index]}
           isEmbeddedType={isEmbeddedType}
+          onShowJsonViewerDialog={onShowJsonViewerDialog}
         />
       ))
     ) : (
@@ -144,6 +150,7 @@ export const ListControl = ({
   property,
   value,
   isEmbeddedType,
+  onShowJsonViewerDialog,
 }: ITypeControlProps): React.ReactElement<ITypeControlProps> => {
   if (!property.objectType) {
     return <Alert color="danger">Expected an objectType</Alert>;
@@ -167,6 +174,7 @@ export const ListControl = ({
           onChange={onChange}
           value={value}
           isEmbeddedType={isEmbeddedType}
+          onShowJsonViewerDialog={onShowJsonViewerDialog}
         />
         <section className="CreateObjectDialog__ListControl__Buttons">
           <Button

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/types/ObjectControl/index.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/types/ObjectControl/index.tsx
@@ -23,7 +23,7 @@ import { IClassFocus } from '../../../../focus';
 import { IBaseControlProps } from '../TypeControl';
 
 import { ObjectControl } from './ObjectControl';
-import { IsEmbeddedTypeChecker } from '../../../..';
+import { IsEmbeddedTypeChecker, JsonViewerDialogExecutor } from '../../../..';
 
 export interface IOpenSelectObjectDialog {
   isOpen: true;
@@ -33,6 +33,7 @@ export interface IOpenSelectObjectDialog {
   onCancel: () => void;
   onSelect: (object: any) => void;
   isEmbeddedType: IsEmbeddedTypeChecker;
+  onShowJsonViewerDialog: JsonViewerDialogExecutor;
 }
 
 export type ISelectObjectDialog = IOpenSelectObjectDialog | { isOpen: false };
@@ -40,6 +41,7 @@ export type ISelectObjectDialog = IOpenSelectObjectDialog | { isOpen: false };
 export interface IObjectControlContainerProps extends IBaseControlProps {
   getClassFocus: (className: string) => IClassFocus;
   isEmbeddedType: IsEmbeddedTypeChecker;
+  onShowJsonViewerDialog: JsonViewerDialogExecutor;
 }
 
 export interface IObjectControlContainerState {
@@ -88,6 +90,7 @@ class ObjectControlContainer extends React.Component<
           onCancel: this.onCancelSelectObjectDialog,
           onSelect: this.updateObjectReference,
           isEmbeddedType: this.props.isEmbeddedType,
+          onShowJsonViewerDialog: this.props.onShowJsonViewerDialog,
         },
       });
     }

--- a/src/ui/RealmBrowser/Content/CreateObjectDialog/types/TypeControl.tsx
+++ b/src/ui/RealmBrowser/Content/CreateObjectDialog/types/TypeControl.tsx
@@ -32,7 +32,7 @@ import { ObjectControl } from './ObjectControl';
 import { ObjectIdControl } from './ObjectIdControl';
 import { UUIDControl } from './UUIDControl';
 import { StringControl } from './StringControl';
-import { IsEmbeddedTypeChecker } from '../../..';
+import { IsEmbeddedTypeChecker, JsonViewerDialogExecutor } from '../../..';
 
 export interface IBaseControlProps<ValueType = any> {
   children?: React.ReactNode;
@@ -45,6 +45,7 @@ export interface ITypeControlProps extends IBaseControlProps {
   generateInitialValue: (property: Realm.ObjectSchemaProperty) => any;
   getClassFocus: (className: string) => IClassFocus;
   isEmbeddedType: IsEmbeddedTypeChecker;
+  onShowJsonViewerDialog: JsonViewerDialogExecutor;
 }
 
 export const TypeControl = ({
@@ -55,6 +56,7 @@ export const TypeControl = ({
   property,
   value,
   isEmbeddedType,
+  onShowJsonViewerDialog,
 }: ITypeControlProps) => {
   if (property.type === 'objectId') {
     return (
@@ -151,6 +153,7 @@ export const TypeControl = ({
         property={property}
         value={value}
         isEmbeddedType={isEmbeddedType}
+        onShowJsonViewerDialog={onShowJsonViewerDialog}
       />
     );
   } else if (property.type === 'list') {
@@ -163,6 +166,7 @@ export const TypeControl = ({
         property={property}
         value={value as any[]}
         isEmbeddedType={isEmbeddedType}
+        onShowJsonViewerDialog={onShowJsonViewerDialog}
       />
     );
   } else {

--- a/src/ui/RealmBrowser/Content/SelectObjectDialog/SelectObjectDialog.tsx
+++ b/src/ui/RealmBrowser/Content/SelectObjectDialog/SelectObjectDialog.tsx
@@ -22,7 +22,7 @@ import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
 import { Content, EditMode, HighlightMode } from '..';
 import { IClassFocus } from '../../focus';
 import { IHighlight } from '../Table';
-import { IsEmbeddedTypeChecker } from '../..';
+import { IsEmbeddedTypeChecker, JsonViewerDialogExecutor } from '../..';
 
 interface IBaseSelectObjectDialogProps {
   isOpen: boolean;
@@ -47,6 +47,7 @@ interface IOpenSelectObjectDialogProps extends IBaseSelectObjectDialogProps {
   ) => void;
   multiple: boolean;
   isEmbeddedType: IsEmbeddedTypeChecker;
+  onShowJsonViewerDialog: JsonViewerDialogExecutor;
 }
 
 export type ISelectObjectDialogProps =
@@ -80,6 +81,7 @@ export const SelectObjectDialog = ({
           readOnly={true}
           ref={props.contentRef}
           isEmbeddedType={props.isEmbeddedType}
+          onShowJsonViewerDialog={props.onShowJsonViewerDialog}
         />
       ) : null}
     </ModalBody>

--- a/src/ui/RealmBrowser/Content/SelectObjectDialog/index.tsx
+++ b/src/ui/RealmBrowser/Content/SelectObjectDialog/index.tsx
@@ -26,7 +26,7 @@ import {
   ISelectObjectDialogProps,
   SelectObjectDialog,
 } from './SelectObjectDialog';
-import { IsEmbeddedTypeChecker } from '../..';
+import { IsEmbeddedTypeChecker, JsonViewerDialogExecutor } from '../..';
 
 export interface IClosedSelectObjectDialogContainerProps {
   isOpen: false;
@@ -39,6 +39,7 @@ export interface IOpenSelectObjectDialogContainerProps {
   multiple: boolean;
   onCancel: () => void;
   isEmbeddedType: IsEmbeddedTypeChecker;
+  onShowJsonViewerDialog: JsonViewerDialogExecutor;
 }
 
 export interface IOpenSelectSingleObjectDialogContainerProps
@@ -94,6 +95,7 @@ export class SelectObjectDialogContainer extends React.Component<
         selection: this.state.selection,
         multiple: this.props.multiple,
         isEmbeddedType: this.props.isEmbeddedType,
+        onShowJsonViewerDialog: this.props.onShowJsonViewerDialog,
       };
     } else {
       return {

--- a/src/ui/RealmBrowser/Content/Table/Cell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/Cell.tsx
@@ -28,6 +28,7 @@ import {
   DictionaryCell,
   ListCell,
   ListIndexCell,
+  MixedCell,
   ObjectCell,
   SetCell,
   StringCell,
@@ -36,7 +37,6 @@ import {
 const getCellContent = ({
   editMode,
   isHighlighted,
-  isScrolling,
   onHighlighted,
   onUpdateValue,
   onValidated,
@@ -95,6 +95,8 @@ const getCellContent = ({
       return <DictionaryCell property={property} value={value} />;
     case 'set':
       return <SetCell property={property} value={value} />;
+    case 'mixed':
+      return <MixedCell property={property} value={value} />;
     case 'object':
       return <ObjectCell property={property} value={value} />;
     default:

--- a/src/ui/RealmBrowser/Content/Table/Cell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/Cell.tsx
@@ -29,6 +29,7 @@ import {
   ListCell,
   ListIndexCell,
   ObjectCell,
+  SetCell,
   StringCell,
 } from './types';
 
@@ -92,6 +93,8 @@ const getCellContent = ({
       return <ListCell property={property} value={value} />;
     case 'dictionary':
       return <DictionaryCell property={property} value={value} />;
+    case 'set':
+      return <SetCell property={property} value={value} />;
     case 'object':
       return <ObjectCell property={property} value={value} />;
     default:

--- a/src/ui/RealmBrowser/Content/Table/Cell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/Cell.tsx
@@ -25,6 +25,7 @@ import { IPropertyWithName } from '../..';
 import {
   DataCell,
   DefaultCell,
+  DictionaryCell,
   ListCell,
   ListIndexCell,
   ObjectCell,
@@ -54,6 +55,7 @@ const getCellContent = ({
   if (property.name === '#' && property.type === 'int' && property.readOnly) {
     return <ListIndexCell value={value} />;
   }
+
   // Alternatively - based on type
   switch (property.type) {
     case 'objectId':
@@ -88,6 +90,8 @@ const getCellContent = ({
       );
     case 'list':
       return <ListCell property={property} value={value} />;
+    case 'dictionary':
+      return <DictionaryCell property={property} value={value} />;
     case 'object':
       return <ObjectCell property={property} value={value} />;
     default:

--- a/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
@@ -29,12 +29,16 @@ import { SortClickHandler } from '.';
 // This constant should match the $realm-browser-header-handle-width in scss
 const HANDLE_WIDTH = 5;
 
+const capitalize = (s: string) => {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+};
+
 const getPropertyType = (property: Realm.ObjectSchemaProperty) => {
   switch (property.type) {
     case 'list':
     case 'dictionary':
     case 'set':
-      return property.objectType;
+      return `${capitalize(property.type)}<${property.objectType ?? ''}>`;
     case 'object':
     case 'linkingObjects':
       return property.objectType;
@@ -52,27 +56,10 @@ const getOptionalMark = (property: IPropertyWithName) => {
   return property.optional ? '?' : '';
 };
 
-const getCollectionShorthand = (property: IPropertyWithName) => {
-  switch (property.type) {
-    case 'list':
-      return '[]';
-
-    case 'dictionary':
-      return '{}';
-
-    case 'set':
-      return '<>';
-
-    default:
-      return '';
-  }
-};
-
 export const getPropertyDisplayed = (property: IPropertyWithName) => {
   return [
     getPropertyType(property),
     getOptionalMark(property),
-    getCollectionShorthand(property),
     property.isEmbedded ? ' (Embedded)' : '',
     property.isPrimaryKey ? ' (Primary Key)' : '',
   ].join('');

--- a/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
@@ -38,7 +38,9 @@ const getPropertyType = (property: Realm.ObjectSchemaProperty) => {
     case 'list':
     case 'dictionary':
     case 'set':
-      return `${capitalize(property.type)}<${property.objectType ?? ''}>`;
+      return `${capitalize(property.type)}<${
+        property.objectType ?? 'unknown'
+      }>`;
     case 'object':
     case 'linkingObjects':
       return property.objectType;

--- a/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
@@ -45,7 +45,7 @@ const getPropertyType = (property: Realm.ObjectSchemaProperty) => {
 
 const NON_OPTIONAL_TYPES = ['list', 'dictionary', 'set'];
 const getOptionalMark = (property: IPropertyWithName) => {
-  if (optionalMarkOptOut.includes(property.type)) {
+  if (NON_OPTIONAL_TYPES.includes(property.type)) {
     return '';
   }
 

--- a/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
@@ -32,6 +32,8 @@ const HANDLE_WIDTH = 5;
 const getPropertyType = (property: Realm.ObjectSchemaProperty) => {
   switch (property.type) {
     case 'list':
+    case 'dictionary':
+    case 'set':
       return property.objectType;
     case 'object':
     case 'linkingObjects':
@@ -41,17 +43,42 @@ const getPropertyType = (property: Realm.ObjectSchemaProperty) => {
   }
 };
 
+const optionalMarkOptOut = ['list', 'dictionary', 'set'];
+const getOptionalMark = (property: IPropertyWithName) => {
+  if (optionalMarkOptOut.includes(property.type)) {
+    return '';
+  }
+
+  return property.optional ? '?' : '';
+};
+
+const getCollectionShorthand = (property: IPropertyWithName) => {
+  switch (property.type) {
+    case 'list':
+      return '[]';
+
+    case 'dictionary':
+      return '{}';
+
+    case 'set':
+      return '<>';
+
+    default:
+      return '';
+  }
+};
+
 export const getPropertyDisplayed = (property: IPropertyWithName) => {
   return [
     getPropertyType(property),
-    property.optional ? '?' : '',
-    property.type === 'list' ? '[]' : '',
+    getOptionalMark(property),
+    getCollectionShorthand(property),
     property.isEmbedded ? ' (Embedded)' : '',
     property.isPrimaryKey ? ' (Primary Key)' : '',
   ].join('');
 };
 
-const NON_SORTABLE_TYPES = ['data', 'list', 'object'];
+const NON_SORTABLE_TYPES = ['data', 'list', 'dictionary', 'set', 'object'];
 const isPropertySortable = (property: IPropertyWithName) => {
   if (property.name === '#' || property.name === null) {
     return false;

--- a/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/HeaderCell.tsx
@@ -43,7 +43,7 @@ const getPropertyType = (property: Realm.ObjectSchemaProperty) => {
   }
 };
 
-const optionalMarkOptOut = ['list', 'dictionary', 'set'];
+const NON_OPTIONAL_TYPES = ['list', 'dictionary', 'set'];
 const getOptionalMark = (property: IPropertyWithName) => {
   if (optionalMarkOptOut.includes(property.type)) {
     return '';

--- a/src/ui/RealmBrowser/Content/Table/types/DefaultCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/types/DefaultCell.tsx
@@ -19,10 +19,7 @@
 import classNames from 'classnames';
 import React from 'react';
 import Realm from 'realm';
-import util from 'util';
-import { asSafeJsonString, useJsonViewer } from '../../../../../utils/json';
-
-const VALUE_STRING_LENGTH_LIMIT = 50;
+import { getCellStringRepresentation } from '../../../../../utils/json';
 
 const displayValue = (property: Realm.ObjectSchemaProperty, value: any) => {
   if (value === null || typeof value === 'undefined') {
@@ -33,13 +30,7 @@ const displayValue = (property: Realm.ObjectSchemaProperty, value: any) => {
     return value.toString();
   }
 
-  if (useJsonViewer(property, value)) {
-    return asSafeJsonString(value, {
-      cleanupRefs: true,
-      maxLength: VALUE_STRING_LENGTH_LIMIT,
-    });
-  }
-  return util.inspect(value);
+  return getCellStringRepresentation(property, value);
 };
 
 export const DefaultCell = ({

--- a/src/ui/RealmBrowser/Content/Table/types/DefaultCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/types/DefaultCell.tsx
@@ -20,9 +20,31 @@ import classNames from 'classnames';
 import React from 'react';
 import Realm from 'realm';
 import util from 'util';
+import { asSafeJsonString } from '../../../../../utils/json';
+
+const VALUE_STRING_LENGTH_LIMIT = 50;
+
+const valueForRender = (value: any) => {
+  if (value === null || typeof value === 'undefined') {
+    return 'null';
+  }
+
+  if (value._bsontype) {
+    return value.toString();
+  }
+
+  // eslint-disable-next-line
+  // @ts-ignore the way we expose Realm.Collection
+  if (value instanceof Realm.Object || value instanceof Realm.Collection) {
+    return asSafeJsonString(value, {
+      cleanupRefs: true,
+      maxLength: VALUE_STRING_LENGTH_LIMIT,
+    });
+  }
+  return util.inspect(value);
+};
 
 export const DefaultCell = ({
-  property,
   value,
 }: {
   property: Realm.ObjectSchemaProperty;
@@ -34,6 +56,6 @@ export const DefaultCell = ({
       'RealmBrowser__Table__StringCell--disabled',
     )}
   >
-    {value && value._bsontype ? value.toString() : util.inspect(value)}
+    {valueForRender(value)}
   </div>
 );

--- a/src/ui/RealmBrowser/Content/Table/types/DictionaryCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/types/DictionaryCell.tsx
@@ -1,0 +1,84 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import React from 'react';
+import { Badge } from 'reactstrap';
+import Realm from 'realm';
+
+import * as primitives from '../../../primitives';
+
+// TODO: Get declaration from Realm
+type Dictionary<T = unknown> = { [key: string]: T };
+
+const VALUE_STRING_LENGTH_LIMIT = 50;
+
+const isDictionaryOfPrimitive = (property: Realm.ObjectSchemaProperty) => {
+  return primitives.isPrimitive(property.objectType || '');
+};
+
+const $refMatcher = /\s*\"\$ref[Id]*\" *: *\".*\"(,|(?=\s+\}))/;
+const asJsonString = (value: unknown) => {
+  let json: string;
+  try {
+    json = JSON.stringify(value);
+  } catch {
+    // Clean up added $refId & $ref properties, added by Realm.JsonSerializationReplacer - investigate better solution.
+    const jsonWithRefs = JSON.stringify(value, Realm.JsonSerializationReplacer);
+    json = jsonWithRefs.replace($refMatcher, '');
+  }
+
+  if (json.length > VALUE_STRING_LENGTH_LIMIT) {
+    return json.slice(0, VALUE_STRING_LENGTH_LIMIT) + ' (...)';
+  }
+
+  return json;
+};
+
+const displayValue = (
+  property: Realm.ObjectSchemaProperty,
+  dictionary: Dictionary,
+) => {
+  if (!dictionary) {
+    return 'null';
+  } else if (Object.keys(dictionary).length === 0) {
+    return `[dictionary of ${property.objectType}]`;
+  } else if (isDictionaryOfPrimitive(property)) {
+    return asJsonString(dictionary);
+  } else {
+    return `[dictionary of ${property.objectType}: ${asJsonString(
+      dictionary,
+    )}]`;
+  }
+};
+
+export const DictionaryCell = ({
+  property,
+  value,
+}: {
+  property: Realm.ObjectSchemaProperty;
+  value: any;
+}) => (
+  <div tabIndex={0} className="RealmBrowser__Table__DictionaryCell">
+    <span className="RealmBrowser__Table__DictionaryCell__Value">
+      {displayValue(property, value)}
+    </span>
+    <span className="RealmBrowser__Table__DictionaryCell__Count">
+      <Badge color="primary">{Object.keys(value).length}</Badge>
+    </span>
+  </div>
+);

--- a/src/ui/RealmBrowser/Content/Table/types/DictionaryCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/types/DictionaryCell.tsx
@@ -38,20 +38,15 @@ const displayValue = (
 ) => {
   if (!dictionary) {
     return 'null';
-  } else if (Object.keys(dictionary).length === 0) {
-    return `[dictionary of ${property.objectType}]`;
   } else if (isDictionaryOfPrimitive(property)) {
     return asSafeJsonString(dictionary, {
       maxLength: VALUE_STRING_LENGTH_LIMIT,
     });
   } else {
-    return `[dictionary of ${property.objectType}: ${asSafeJsonString(
-      dictionary,
-      {
-        cleanupRefs: true,
-        maxLength: VALUE_STRING_LENGTH_LIMIT,
-      },
-    )}]`;
+    return asSafeJsonString(dictionary, {
+      cleanupRefs: true,
+      maxLength: VALUE_STRING_LENGTH_LIMIT,
+    });
   }
 };
 

--- a/src/ui/RealmBrowser/Content/Table/types/DictionaryCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/types/DictionaryCell.tsx
@@ -21,16 +21,10 @@ import { Badge } from 'reactstrap';
 import Realm from 'realm';
 import { asSafeJsonString } from '../../../../../utils/json';
 
-import * as primitives from '../../../primitives';
-
 // TODO: Get declaration from Realm
 type Dictionary<T = unknown> = { [key: string]: T };
 
 const VALUE_STRING_LENGTH_LIMIT = 50;
-
-const isDictionaryOfPrimitive = (property: Realm.ObjectSchemaProperty) => {
-  return primitives.isPrimitive(property.objectType || '');
-};
 
 const displayValue = (
   property: Realm.ObjectSchemaProperty,
@@ -38,10 +32,6 @@ const displayValue = (
 ) => {
   if (!dictionary) {
     return 'null';
-  } else if (isDictionaryOfPrimitive(property)) {
-    return asSafeJsonString(dictionary, {
-      maxLength: VALUE_STRING_LENGTH_LIMIT,
-    });
   } else {
     return asSafeJsonString(dictionary, {
       cleanupRefs: true,

--- a/src/ui/RealmBrowser/Content/Table/types/ListCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/types/ListCell.tsx
@@ -19,17 +19,10 @@
 import React from 'react';
 import { Badge } from 'reactstrap';
 import Realm from 'realm';
-
-import * as primitives from '../../../primitives';
-
-import * as DataCell from './DataCell';
+import { getCellStringRepresentation } from '../../../../../utils/json';
 
 const VALUE_LENGTH_LIMIT = 10;
 const VALUE_STRING_LENGTH_LIMIT = 50;
-
-const isListOfPrimitive = (property: Realm.ObjectSchemaProperty) => {
-  return primitives.isPrimitive(property.objectType || '');
-};
 
 const displayValue = (
   property: Realm.ObjectSchemaProperty,
@@ -37,51 +30,24 @@ const displayValue = (
 ) => {
   if (!list) {
     return 'null';
-  } else if (isListOfPrimitive(property) && list.length > 0) {
+  } else {
     // Let's not show all values here - 10 must be enough
     const limitedValues = list.slice(0, VALUE_LENGTH_LIMIT);
-    // Concatinate ", " separated string representations of the elements in the list
+    // Concatenate ", " separated string representations of the elements in the list
     let limitedString = limitedValues
-      .map((v: any) => {
-        // Turn the value into a string representation
-        const representation =
-          property.objectType === 'data' ? DataCell.display(v) : String(v);
-        // If the representation is too long, limit it
-        if (representation.length > VALUE_STRING_LENGTH_LIMIT) {
-          const limited = representation.substring(
-            0,
-            VALUE_STRING_LENGTH_LIMIT,
-          );
-          return `${limited} (...)`;
-        } else {
-          return representation;
-        }
-      })
+      .map((val: any) =>
+        getCellStringRepresentation(property, val).substring(
+          0,
+          VALUE_STRING_LENGTH_LIMIT,
+        ),
+      )
       .join(', ');
-    // Prepending a string if not all values are shown
+
+    // Prepend a string if not all values are shown
     if (list.length > VALUE_LENGTH_LIMIT) {
       limitedString += ' (and more)';
     }
     return limitedString;
-  } else {
-    if (list.length > 0) {
-      // Check if this type of object has a primary key
-      const firstObject: Realm.Object = list[0];
-      const primaryKey = firstObject.objectSchema().primaryKey;
-      if (primaryKey) {
-        let limitedString = list
-          .slice(0, VALUE_LENGTH_LIMIT)
-          .map(element => {
-            return element[primaryKey];
-          })
-          .join(', ');
-        if (list.length > VALUE_LENGTH_LIMIT) {
-          limitedString += ' (and more)';
-        }
-        return `[list of ${property.objectType}: ${limitedString}]`;
-      }
-    }
-    return `[list of ${property.objectType}]`;
   }
 };
 

--- a/src/ui/RealmBrowser/Content/Table/types/MixedCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/types/MixedCell.tsx
@@ -19,22 +19,10 @@
 import classNames from 'classnames';
 import React from 'react';
 import Realm from 'realm';
-import util from 'util';
-import { asSafeJsonString, useJsonViewer } from '../../../../../utils/json';
-
-const VALUE_STRING_LENGTH_LIMIT = 50;
-
-const displayValue = (value: any) => {
-  if (value === null || typeof value === 'undefined') {
-    return 'null';
-  }
-
-  if (value._bsontype) {
-    return value.toString();
-  }
-
-  return util.inspect(value);
-};
+import {
+  canUseJsonViewer,
+  getCellStringRepresentation,
+} from '../../../../../utils/json';
 
 export const MixedCell = ({
   property,
@@ -43,19 +31,14 @@ export const MixedCell = ({
   property: Realm.ObjectSchemaProperty;
   value: any;
 }) => {
-  const showInJsonViewerDialog = useJsonViewer(property, value);
+  const willShowInJsonViewerDialog = canUseJsonViewer(property, value);
 
-  const valueForRender = showInJsonViewerDialog
-    ? asSafeJsonString(value, {
-        cleanupRefs: true,
-        maxLength: VALUE_STRING_LENGTH_LIMIT,
-      })
-    : displayValue(value);
+  const valueForRender = getCellStringRepresentation(property, value);
   return (
     <div
       className={classNames('RealmBrowser__Table__MixedCell', {
-        'RealmBrowser__Table__MixedCell--disabled': !showInJsonViewerDialog,
-        'RealmBrowser__Table__MixedCell--link': showInJsonViewerDialog,
+        'RealmBrowser__Table__MixedCell--disabled': !willShowInJsonViewerDialog,
+        'RealmBrowser__Table__MixedCell--link': willShowInJsonViewerDialog,
       })}
     >
       <span className="RealmBrowser__Table__MixedCell__Value">

--- a/src/ui/RealmBrowser/Content/Table/types/MixedCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/types/MixedCell.tsx
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2018 Realm Inc.
+// Copyright 2021 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import { asSafeJsonString, useJsonViewer } from '../../../../../utils/json';
 
 const VALUE_STRING_LENGTH_LIMIT = 50;
 
-const displayValue = (property: Realm.ObjectSchemaProperty, value: any) => {
+const displayValue = (value: any) => {
   if (value === null || typeof value === 'undefined') {
     return 'null';
   }
@@ -33,28 +33,34 @@ const displayValue = (property: Realm.ObjectSchemaProperty, value: any) => {
     return value.toString();
   }
 
-  if (useJsonViewer(property, value)) {
-    return asSafeJsonString(value, {
-      cleanupRefs: true,
-      maxLength: VALUE_STRING_LENGTH_LIMIT,
-    });
-  }
   return util.inspect(value);
 };
 
-export const DefaultCell = ({
+export const MixedCell = ({
   property,
   value,
 }: {
   property: Realm.ObjectSchemaProperty;
   value: any;
-}) => (
-  <div
-    className={classNames(
-      'RealmBrowser__Table__StringCell',
-      'RealmBrowser__Table__StringCell--disabled',
-    )}
-  >
-    {displayValue(property, value)}
-  </div>
-);
+}) => {
+  const showInJsonViewerDialog = useJsonViewer(property, value);
+
+  const valueForRender = showInJsonViewerDialog
+    ? asSafeJsonString(value, {
+        cleanupRefs: true,
+        maxLength: VALUE_STRING_LENGTH_LIMIT,
+      })
+    : displayValue(value);
+  return (
+    <div
+      className={classNames('RealmBrowser__Table__MixedCell', {
+        'RealmBrowser__Table__MixedCell--disabled': !showInJsonViewerDialog,
+        'RealmBrowser__Table__MixedCell--link': showInJsonViewerDialog,
+      })}
+    >
+      <span className="RealmBrowser__Table__MixedCell__Value">
+        {valueForRender}
+      </span>
+    </div>
+  );
+};

--- a/src/ui/RealmBrowser/Content/Table/types/SetCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/types/SetCell.tsx
@@ -19,16 +19,12 @@
 import React from 'react';
 import { Badge } from 'reactstrap';
 import Realm from 'realm';
-import { asSafeJsonString } from '../../../../../utils/json';
-
-// import * as primitives from '../../../primitives';
-
-import * as DataCell from './DataCell';
+import { getCellStringRepresentation } from '../../../../../utils/json';
 
 const VALUE_LENGTH_LIMIT = 10;
 const VALUE_STRING_LENGTH_LIMIT = 50;
 
-const take = <T extends unknown = any>(
+const setTake = <T extends unknown = any>(
   set: Realm.Set<T>,
   amount: number,
 ): Array<T> => {
@@ -41,24 +37,6 @@ const take = <T extends unknown = any>(
   return arr;
 };
 
-const getStringRepresentation = (
-  property: Realm.ObjectSchemaProperty,
-  val: any,
-) => {
-  if (val._objectId) {
-    return asSafeJsonString(val, {
-      cleanupRefs: true,
-      maxLength: VALUE_STRING_LENGTH_LIMIT,
-    });
-  }
-
-  if (property.objectType === 'data') {
-    return DataCell.display(val);
-  }
-
-  return typeof val === 'string' ? `"${val}"` : String(val);
-};
-
 const displayValue = (
   property: Realm.ObjectSchemaProperty,
   set: Realm.Set<any>,
@@ -67,11 +45,11 @@ const displayValue = (
     return 'null';
   } else {
     // Let's not show all values here - 10 must be enough
-    const limitedValues = take(set, VALUE_LENGTH_LIMIT);
+    const limitedValues = setTake(set, VALUE_LENGTH_LIMIT);
     // Concatenate ", " separated string representations of the elements in the set
     let limitedString = limitedValues
       .map((val: any) =>
-        getStringRepresentation(property, val).substring(
+        getCellStringRepresentation(property, val).substring(
           0,
           VALUE_STRING_LENGTH_LIMIT,
         ),

--- a/src/ui/RealmBrowser/Content/Table/types/SetCell.tsx
+++ b/src/ui/RealmBrowser/Content/Table/types/SetCell.tsx
@@ -1,0 +1,104 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import React from 'react';
+import { Badge } from 'reactstrap';
+import Realm from 'realm';
+import { asSafeJsonString } from '../../../../../utils/json';
+
+// import * as primitives from '../../../primitives';
+
+import * as DataCell from './DataCell';
+
+const VALUE_LENGTH_LIMIT = 10;
+const VALUE_STRING_LENGTH_LIMIT = 50;
+
+const take = <T extends unknown = any>(
+  set: Realm.Set<T>,
+  amount: number,
+): Array<T> => {
+  const it = 0;
+  const arr = [];
+  for (const val of set) {
+    if (it > amount) break;
+    arr.push(val);
+  }
+  return arr;
+};
+
+const getStringRepresentation = (
+  property: Realm.ObjectSchemaProperty,
+  val: any,
+) => {
+  if (val._objectId) {
+    return asSafeJsonString(val, {
+      cleanupRefs: true,
+      maxLength: VALUE_STRING_LENGTH_LIMIT,
+    });
+  }
+
+  if (property.objectType === 'data') {
+    return DataCell.display(val);
+  }
+
+  return typeof val === 'string' ? `"${val}"` : String(val);
+};
+
+const displayValue = (
+  property: Realm.ObjectSchemaProperty,
+  set: Realm.Set<any>,
+) => {
+  if (!set) {
+    return 'null';
+  } else {
+    // Let's not show all values here - 10 must be enough
+    const limitedValues = take(set, VALUE_LENGTH_LIMIT);
+    // Concatenate ", " separated string representations of the elements in the set
+    let limitedString = limitedValues
+      .map((val: any) =>
+        getStringRepresentation(property, val).substring(
+          0,
+          VALUE_STRING_LENGTH_LIMIT,
+        ),
+      )
+      .join(', ');
+
+    // Prepend a string if not all values are shown
+    if (set.size > VALUE_LENGTH_LIMIT) {
+      limitedString += ' (and more)';
+    }
+    return limitedString;
+  }
+};
+
+export const SetCell = ({
+  property,
+  value,
+}: {
+  property: Realm.ObjectSchemaProperty;
+  value: any;
+}) => (
+  <div tabIndex={0} className="RealmBrowser__Table__SetCell">
+    <span className="RealmBrowser__Table__SetCell__Value">
+      {displayValue(property, value)}
+    </span>
+    <span className="RealmBrowser__Table__SetCell__Count">
+      <Badge color="primary">{value.size}</Badge>
+    </span>
+  </div>
+);

--- a/src/ui/RealmBrowser/Content/Table/types/index.ts
+++ b/src/ui/RealmBrowser/Content/Table/types/index.ts
@@ -18,6 +18,7 @@
 
 export { DataCell } from './DataCell';
 export { DefaultCell } from './DefaultCell';
+export { DictionaryCell } from './DictionaryCell';
 export { ListCell } from './ListCell';
 export { ListIndexCell } from './ListIndexCell';
 export { ObjectCell } from './ObjectCell';

--- a/src/ui/RealmBrowser/Content/Table/types/index.ts
+++ b/src/ui/RealmBrowser/Content/Table/types/index.ts
@@ -22,4 +22,5 @@ export { DictionaryCell } from './DictionaryCell';
 export { ListCell } from './ListCell';
 export { ListIndexCell } from './ListIndexCell';
 export { ObjectCell } from './ObjectCell';
+export { SetCell } from './SetCell';
 export { StringCell } from './StringCell';

--- a/src/ui/RealmBrowser/Content/Table/types/index.ts
+++ b/src/ui/RealmBrowser/Content/Table/types/index.ts
@@ -21,6 +21,7 @@ export { DefaultCell } from './DefaultCell';
 export { DictionaryCell } from './DictionaryCell';
 export { ListCell } from './ListCell';
 export { ListIndexCell } from './ListIndexCell';
+export { MixedCell } from './MixedCell';
 export { ObjectCell } from './ObjectCell';
 export { SetCell } from './SetCell';
 export { StringCell } from './StringCell';

--- a/src/ui/RealmBrowser/Content/index.tsx
+++ b/src/ui/RealmBrowser/Content/index.tsx
@@ -31,7 +31,7 @@ import {
 } from '..';
 import { store } from '../../../store';
 import { getRange } from '../../../utils';
-import { useJsonViewer } from '../../../utils/json';
+import { canUseJsonViewer } from '../../../utils/json';
 import { showError } from '../../reusable/errors';
 import { ILoadingProgress } from '../../reusable/LoadingOverlay';
 import { Focus, getClassName, IClassFocus } from '../focus';
@@ -482,7 +482,7 @@ class ContentContainer extends React.Component<
       if (!property) return;
 
       if (
-        useJsonViewer(property, cellValue) &&
+        canUseJsonViewer(property, cellValue) &&
         this.props.onShowJsonViewerDialog
       ) {
         this.props.onShowJsonViewerDialog(cellValue);

--- a/src/ui/RealmBrowser/Content/index.tsx
+++ b/src/ui/RealmBrowser/Content/index.tsx
@@ -478,15 +478,16 @@ class ContentContainer extends React.Component<
       this.props.onCellSingleClick(params, e);
     } else {
       const { property, rowObject, cellValue } = params;
-      if (property?.type === 'list' && this.props.onListFocussed) {
+      if (!property) return;
+
+      if (property.type === 'list' && this.props.onListFocussed) {
         this.props.onListFocussed(rowObject, property);
       } else if (
-        property?.type === 'dictionary' &&
+        (property.type === 'dictionary' || property.type === 'set') &&
         this.props.onShowJsonViewerDialog
       ) {
         this.props.onShowJsonViewerDialog(cellValue);
       } else if (
-        property &&
         property.type === 'object' &&
         property.objectType &&
         (cellValue || property.isEmbedded) &&

--- a/src/ui/RealmBrowser/Content/index.tsx
+++ b/src/ui/RealmBrowser/Content/index.tsx
@@ -31,6 +31,7 @@ import {
 } from '..';
 import { store } from '../../../store';
 import { getRange } from '../../../utils';
+import { useJsonViewer } from '../../../utils/json';
 import { showError } from '../../reusable/errors';
 import { ILoadingProgress } from '../../reusable/LoadingOverlay';
 import { Focus, getClassName, IClassFocus } from '../focus';
@@ -480,13 +481,13 @@ class ContentContainer extends React.Component<
       const { property, rowObject, cellValue } = params;
       if (!property) return;
 
-      if (property.type === 'list' && this.props.onListFocussed) {
-        this.props.onListFocussed(rowObject, property);
-      } else if (
-        (property.type === 'dictionary' || property.type === 'set') &&
+      if (
+        useJsonViewer(property, cellValue) &&
         this.props.onShowJsonViewerDialog
       ) {
         this.props.onShowJsonViewerDialog(cellValue);
+      } else if (property.type === 'list' && this.props.onListFocussed) {
+        this.props.onListFocussed(rowObject, property);
       } else if (
         property.type === 'object' &&
         property.objectType &&

--- a/src/ui/RealmBrowser/Content/index.tsx
+++ b/src/ui/RealmBrowser/Content/index.tsx
@@ -27,6 +27,7 @@ import {
   ListFocussedHandler,
   IsEmbeddedTypeChecker,
   SingleListFocussedHandler,
+  JsonViewerDialogExecutor,
 } from '..';
 import { store } from '../../../store';
 import { getRange } from '../../../utils';
@@ -126,6 +127,7 @@ export interface IBaseContentContainerProps {
   ) => void;
   onListFocussed?: ListFocussedHandler;
   onSingleListFocussed?: SingleListFocussedHandler;
+  onShowJsonViewerDialog: (value: unknown) => void; // TODO: reuse from... elsewhere
   progress?: ILoadingProgress;
   readOnly: boolean;
   isEmbeddedType: IsEmbeddedTypeChecker;
@@ -476,8 +478,13 @@ class ContentContainer extends React.Component<
       this.props.onCellSingleClick(params, e);
     } else {
       const { property, rowObject, cellValue } = params;
-      if (property && property.type === 'list' && this.props.onListFocussed) {
+      if (property?.type === 'list' && this.props.onListFocussed) {
         this.props.onListFocussed(rowObject, property);
+      } else if (
+        property?.type === 'dictionary' &&
+        this.props.onShowJsonViewerDialog
+      ) {
+        this.props.onShowJsonViewerDialog(cellValue);
       } else if (
         property &&
         property.type === 'object' &&
@@ -523,6 +530,7 @@ class ContentContainer extends React.Component<
           className: property.objectType,
           isOptional: property.optional,
           isEmbeddedType: this.props.isEmbeddedType,
+          onShowJsonViewerDialog: this.props.onShowJsonViewerDialog,
         });
       }
     }
@@ -588,6 +596,7 @@ class ContentContainer extends React.Component<
                   className: property.objectType,
                   isOptional: property.optional,
                   isEmbeddedType: this.props.isEmbeddedType,
+                  onShowJsonViewerDialog: this.props.onShowJsonViewerDialog,
                 });
               }
             },
@@ -648,6 +657,7 @@ class ContentContainer extends React.Component<
                 },
                 className: focus.property.objectType,
                 isEmbeddedType: this.props.isEmbeddedType,
+                onShowJsonViewerDialog: this.props.onShowJsonViewerDialog,
               });
             }
           },
@@ -704,6 +714,7 @@ class ContentContainer extends React.Component<
             schema,
             isEmbeddedType,
             embeddedInfo,
+            onShowJsonViewerDialog: this.props.onShowJsonViewerDialog,
           },
         });
       }
@@ -935,6 +946,7 @@ class ContentContainer extends React.Component<
     isOptional?: boolean;
     action: SelectObjectAction;
     isEmbeddedType: IsEmbeddedTypeChecker;
+    onShowJsonViewerDialog: JsonViewerDialogExecutor;
   }) {
     if (!this.props.readOnly) {
       const focus: IClassFocus = this.props.getClassFocus(className);
@@ -950,6 +962,7 @@ class ContentContainer extends React.Component<
           onSelect: this.onObjectSelect,
           propertyName: action.propertyName,
           isEmbeddedType,
+          onShowJsonViewerDialog: this.props.onShowJsonViewerDialog,
         };
         this.setState({ selectObjectDialog });
       } else {
@@ -963,6 +976,7 @@ class ContentContainer extends React.Component<
           onCancel: this.onCancelSelectObjectDialog,
           onSelect: this.onObjectSelect,
           isEmbeddedType,
+          onShowJsonViewerDialog: this.props.onShowJsonViewerDialog,
         };
         this.setState({ selectObjectDialog });
       }

--- a/src/ui/RealmBrowser/JsonViewerDialog/JsonViewerDialog.tsx
+++ b/src/ui/RealmBrowser/JsonViewerDialog/JsonViewerDialog.tsx
@@ -1,0 +1,51 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import React from 'react';
+import {
+  Button,
+  Form,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from 'reactstrap';
+
+export interface IJSonViewerDialogProps {
+  onCancel: () => void;
+  visible: boolean;
+  json: string;
+}
+
+export const JsonViewerDialog = ({
+  onCancel,
+  visible,
+  json,
+}: IJSonViewerDialogProps) => (
+  <Modal isOpen={visible} onExit={onCancel}>
+    <Form>
+      <ModalHeader>JSON Viewer</ModalHeader>
+      <ModalBody>
+        <pre>{json}</pre>
+      </ModalBody>
+      <ModalFooter>
+        <Button onClick={onCancel}>Close</Button>
+      </ModalFooter>
+    </Form>
+  </Modal>
+);

--- a/src/ui/RealmBrowser/JsonViewerDialog/JsonViewerDialog.tsx
+++ b/src/ui/RealmBrowser/JsonViewerDialog/JsonViewerDialog.tsx
@@ -19,6 +19,8 @@
 import React from 'react';
 import {
   Button,
+  CardBody,
+  CardText,
   Form,
   Modal,
   ModalBody,
@@ -37,9 +39,20 @@ export const JsonViewerDialog = ({
   visible,
   json,
 }: IJSonViewerDialogProps) => (
-  <Modal isOpen={visible} onExit={onCancel}>
+  <Modal isOpen={visible} toggle={onCancel}>
     <Form>
       <ModalHeader>JSON Viewer</ModalHeader>
+      {json.includes('"$refId":') && (
+        <CardBody style={{ borderBottom: '1px solid #dee2e6' }}>
+          <CardText>
+            <small>
+              {
+                '"$refId" & "$ref" has been added to the serialized output, to resolve circular structures.'
+              }
+            </small>
+          </CardText>
+        </CardBody>
+      )}
       <ModalBody>
         <pre>{json}</pre>
       </ModalBody>

--- a/src/ui/RealmBrowser/JsonViewerDialog/index.tsx
+++ b/src/ui/RealmBrowser/JsonViewerDialog/index.tsx
@@ -1,0 +1,44 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import React from 'react';
+
+import { JsonViewerDialog } from './JsonViewerDialog';
+import { asSafeJsonString } from '../../../utils/json';
+
+export interface IJsonViewerDialogContainerProps {
+  onHide: () => void;
+  visible: boolean;
+  value: unknown;
+}
+
+class JsonViewerDialogContainer extends React.Component<IJsonViewerDialogContainerProps> {
+  public render() {
+    const json = asSafeJsonString(this.props.value, { pretty: true });
+
+    return (
+      <JsonViewerDialog
+        onCancel={this.props.onHide}
+        json={json}
+        visible={this.props.visible}
+      />
+    );
+  }
+}
+
+export { JsonViewerDialogContainer as JsonViewerDialog };

--- a/src/ui/RealmBrowser/RealmBrowser.scss
+++ b/src/ui/RealmBrowser/RealmBrowser.scss
@@ -270,6 +270,7 @@
       }
     }
 
+    &__MixedCell,
     &__ListCell,
     &__DictionaryCell,
     &__SetCell,
@@ -290,6 +291,7 @@
       }
     }
 
+    &__MixedCell--link,
     &__ListCell,
     &__DictionaryCell,
     &__SetCell,
@@ -310,6 +312,11 @@
       }
     }
 
+    &__MixedCell {
+      &--disabled {
+        color: $elephant;
+      }
+    }
     &__StringCell {
       background: transparent;
       border-radius: 0;

--- a/src/ui/RealmBrowser/RealmBrowser.scss
+++ b/src/ui/RealmBrowser/RealmBrowser.scss
@@ -317,6 +317,7 @@
         color: $elephant;
       }
     }
+
     &__StringCell {
       background: transparent;
       border-radius: 0;

--- a/src/ui/RealmBrowser/RealmBrowser.scss
+++ b/src/ui/RealmBrowser/RealmBrowser.scss
@@ -272,6 +272,7 @@
 
     &__ListCell,
     &__DictionaryCell,
+    &__SetCell,
     &__ObjectCell,
     &__StringCell,
     &__DataCell,
@@ -291,6 +292,7 @@
 
     &__ListCell,
     &__DictionaryCell,
+    &__SetCell,
     &__ObjectCell {
       // Make these look like clickable elements
       color: $primary;
@@ -339,6 +341,7 @@
     }
 
     &__DictionaryCell,
+    &__SetCell,
     &__ListCell {
       display: flex;
 

--- a/src/ui/RealmBrowser/RealmBrowser.scss
+++ b/src/ui/RealmBrowser/RealmBrowser.scss
@@ -271,6 +271,7 @@
     }
 
     &__ListCell,
+    &__DictionaryCell,
     &__ObjectCell,
     &__StringCell,
     &__DataCell,
@@ -289,6 +290,7 @@
     }
 
     &__ListCell,
+    &__DictionaryCell,
     &__ObjectCell {
       // Make these look like clickable elements
       color: $primary;
@@ -336,6 +338,7 @@
       }
     }
 
+    &__DictionaryCell,
     &__ListCell {
       display: flex;
 

--- a/src/ui/RealmBrowser/RealmBrowser.tsx
+++ b/src/ui/RealmBrowser/RealmBrowser.tsx
@@ -27,6 +27,7 @@ import {
   ListFocussedHandler,
   IsEmbeddedTypeChecker,
   SingleListFocussedHandler,
+  JsonViewerDialogExecutor,
 } from '.';
 import { AddClassModal } from './AddClassModal';
 import { AddPropertyModal } from './AddPropertyModal';
@@ -36,6 +37,7 @@ import { Focus, IClassFocus } from './focus';
 import { LeftSidebar } from './LeftSidebar';
 import { NoFocusPlaceholder } from './NoFocusPlaceholder';
 import { ImportDialog } from './ImportDialog';
+import { JsonViewerDialog } from './JsonViewerDialog';
 
 import './RealmBrowser.scss';
 
@@ -58,6 +60,7 @@ export interface IRealmBrowserProps {
   isEncryptionDialogVisible: boolean;
   isLeftSidebarOpen: boolean;
   isPropertyNameAvailable: (name: string) => boolean;
+  jsonViewerDialog: null | { value: unknown };
   onAddClass: (schema: Realm.ObjectSchema) => void;
   onAddProperty: (name: string, type: Realm.PropertyType) => void;
   onCancelTransaction: () => void;
@@ -66,6 +69,8 @@ export interface IRealmBrowserProps {
   onHideEncryptionDialog: () => void;
   onHideImportDialog: () => void;
   onImport: (format: ImportFormat, files: ImportableFile[]) => void;
+  onShowJsonViewerDialog: JsonViewerDialogExecutor;
+  onHideJsonViewerDialog: () => void;
   onLeftSidebarToggle: () => void;
   onListFocussed: ListFocussedHandler;
   onSingleListFocussed: SingleListFocussedHandler;
@@ -96,6 +101,7 @@ export const RealmBrowser = ({
   isEncryptionDialogVisible,
   isLeftSidebarOpen,
   isPropertyNameAvailable,
+  jsonViewerDialog,
   onAddClass,
   onAddProperty,
   onCancelTransaction,
@@ -104,6 +110,8 @@ export const RealmBrowser = ({
   onHideEncryptionDialog,
   onHideImportDialog,
   onImport,
+  onShowJsonViewerDialog,
+  onHideJsonViewerDialog,
   onLeftSidebarToggle,
   onListFocussed,
   onSingleListFocussed,
@@ -148,6 +156,7 @@ export const RealmBrowser = ({
             onListFocussed={onListFocussed}
             onSingleListFocussed={onSingleListFocussed}
             onRealmChanged={onRealmChanged}
+            onShowJsonViewerDialog={onShowJsonViewerDialog}
             permissionSidebar={true}
             progress={progress}
             readOnly={editMode === EditMode.Disabled}
@@ -191,6 +200,12 @@ export const RealmBrowser = ({
         visible={importDialog !== null}
         onHide={onHideImportDialog}
         onImport={onImport}
+      />
+
+      <JsonViewerDialog
+        value={jsonViewerDialog?.value}
+        visible={jsonViewerDialog !== null}
+        onHide={onHideJsonViewerDialog}
       />
 
       <LoadingOverlay progress={progress} fade={true} />

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -80,6 +80,12 @@ type ImportDialogOptions = {
   classNames: string[];
 };
 
+type JsonViewerDialogOptions = {
+  value: unknown;
+};
+
+export type JsonViewerDialogExecutor = (value: unknown) => void;
+
 const EDIT_MODE_STORAGE_KEY = 'realm-browser-edit-mode';
 const FILE_UPGRADE_NEEDED_MESSAGE =
   'The Realm file format must be allowed to be upgraded in order to proceed.';
@@ -96,6 +102,7 @@ export interface IRealmBrowserState extends IRealmLoadingComponentState {
   isEncryptionDialogVisible: boolean;
   isLeftSidebarOpen: boolean;
   importDialog: ImportDialogOptions | null;
+  jsonViewerDialog: JsonViewerDialogOptions | null;
   // The classes are only supposed to be used to produce a list of classes in the sidebar
   classes: Realm.ObjectSchema[];
 }
@@ -118,6 +125,7 @@ class RealmBrowserContainer
     isEncryptionDialogVisible: false,
     isLeftSidebarOpen: true,
     importDialog: null,
+    jsonViewerDialog: null,
     progress: { status: 'idle' },
     classes: [],
   };
@@ -157,6 +165,7 @@ class RealmBrowserContainer
         getClassFocus={this.getClassFocus}
         getSchemaLength={this.getSchemaLength}
         importDialog={this.state.importDialog}
+        jsonViewerDialog={this.state.jsonViewerDialog}
         isAddClassOpen={this.state.isAddClassOpen}
         isAddPropertyOpen={this.state.isAddPropertyOpen}
         isClassNameAvailable={this.isClassNameAvailable}
@@ -170,6 +179,8 @@ class RealmBrowserContainer
         onCommitTransaction={this.onCommitTransaction}
         onHideEncryptionDialog={this.onHideEncryptionDialog}
         onHideImportDialog={this.onHideImportDialog}
+        onShowJsonViewerDialog={this.onShowJsonViewerDialog}
+        onHideJsonViewerDialog={this.onHideJsonViewerDialog}
         onImport={this.handleImport}
         onLeftSidebarToggle={this.onLeftSidebarToggle}
         onListFocussed={this.onListFocussed}
@@ -697,6 +708,14 @@ class RealmBrowserContainer
 
   private onHideImportDialog = () => {
     this.setState({ importDialog: null });
+  };
+
+  private onShowJsonViewerDialog = (value: unknown) => {
+    this.setState({ jsonViewerDialog: { value } });
+  };
+
+  private onHideJsonViewerDialog = () => {
+    this.setState({ jsonViewerDialog: null });
   };
 
   private onLeftSidebarToggle = () => {

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,6 +1,6 @@
 // Regex to clean up added $refId & $ref properties, added by Realm.JsonSerializationReplacer
 // TODO: Investigate better solution.
-const $REF_MATCHER = /\s*\"\$ref[Id]*\" *: *\".*\"(,|(?=\s+\}))/;
+const $REF_MATCHER = /\s*\"\$ref[Id]*\" *: *(\"(.*?)\"(,|\s|)|\s*\{(.*?)\}(,|\s|))/g;
 
 const DEFAULT_POSTFIX = ' (...)';
 const INDENTATION = 2;
@@ -33,14 +33,22 @@ export const asSafeJsonString = (
     }
   }
 
+  console.log('json 1 >>', json);
+
+  if (!json) {
+    return 'null';
+  }
+
   if (options) {
     if (options.cleanupRefs) {
       json = json.replace($REF_MATCHER, '');
+      console.log('json 2 >>', json);
     }
 
     if (options.maxLength && json.length > options.maxLength) {
       json =
         json.slice(0, options.maxLength) + (options.postFix ?? DEFAULT_POSTFIX);
+      console.log('json 3 >>', json);
     }
   }
 

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -33,8 +33,6 @@ export const asSafeJsonString = (
     }
   }
 
-  console.log('json 1 >>', json);
-
   if (!json) {
     return 'null';
   }
@@ -42,15 +40,38 @@ export const asSafeJsonString = (
   if (options) {
     if (options.cleanupRefs) {
       json = json.replace($REF_MATCHER, '');
-      console.log('json 2 >>', json);
     }
 
     if (options.maxLength && json.length > options.maxLength) {
       json =
         json.slice(0, options.maxLength) + (options.postFix ?? DEFAULT_POSTFIX);
-      console.log('json 3 >>', json);
     }
   }
 
   return json;
+};
+
+/**
+ * Utility function to indicate if the JsonViewerDialog should be utilized for a cell
+ */
+export const useJsonViewer = (
+  property: Realm.ObjectSchemaProperty,
+  value: any,
+): boolean => {
+  if (property.type === 'dictionary' || property.type === 'set') {
+    return true;
+  }
+
+  if (
+    property.type === 'mixed' &&
+    (value instanceof Realm.Object ||
+      // eslint-disable-next-line
+      // @ts-ignore The way we expose Realm.Collection does not work for instanceof...
+      value instanceof Realm.Collection ||
+      (value !== null && typeof value === 'object' && !(value instanceof Date)))
+  ) {
+    return true;
+  }
+
+  return false;
 };

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -57,7 +57,7 @@ export const asSafeJsonString = (
 /**
  * Utility function to indicate if the JsonViewerDialog should be utilized for a cell
  */
-export const useJsonViewer = (
+export const canUseJsonViewer = (
   property: Realm.ObjectSchemaProperty,
   value: any,
 ): boolean => {
@@ -93,6 +93,17 @@ export const getCellStringRepresentation = (
     return 'null';
   }
 
+  // If value is a BSON type
+  if (value._bsontype) {
+    return value.toString();
+  }
+
+  // Write a UTC iso string if value is a date
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  // If value is a Realm entity type
   if (value.objectSchema) {
     const { primaryKey, name } = value.objectSchema();
     // prefix with the the Class type, if in mixed context
@@ -105,7 +116,7 @@ export const getCellStringRepresentation = (
         });
   }
 
-  if (useJsonViewer(property, value)) {
+  if (canUseJsonViewer(property, value)) {
     return asSafeJsonString(value, {
       cleanupRefs: true,
       maxLength: VALUE_STRING_LENGTH_LIMIT,

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,0 +1,48 @@
+// Regex to clean up added $refId & $ref properties, added by Realm.JsonSerializationReplacer
+// TODO: Investigate better solution.
+const $REF_MATCHER = /\s*\"\$ref[Id]*\" *: *\".*\"(,|(?=\s+\}))/;
+
+const DEFAULT_POSTFIX = ' (...)';
+const INDENTATION = 2;
+
+type SafeJsonOptions = {
+  pretty?: boolean;
+  cleanupRefs?: boolean;
+  maxLength?: number;
+  postFix?: string;
+};
+
+export const asSafeJsonString = (
+  value: unknown,
+  options?: SafeJsonOptions,
+): string => {
+  let json: string;
+  const indentation = options?.pretty ? INDENTATION : undefined;
+
+  try {
+    json = JSON.stringify(value, null, indentation);
+  } catch {
+    try {
+      json = JSON.stringify(
+        value,
+        Realm.JsonSerializationReplacer,
+        indentation,
+      );
+    } catch (err) {
+      json = err.message ? err.message : err;
+    }
+  }
+
+  if (options) {
+    if (options.cleanupRefs) {
+      json = json.replace($REF_MATCHER, '');
+    }
+
+    if (options.maxLength && json.length > options.maxLength) {
+      json =
+        json.slice(0, options.maxLength) + (options.postFix ?? DEFAULT_POSTFIX);
+    }
+  }
+
+  return json;
+};


### PR DESCRIPTION
This PR is primarily to make the new datatypes (`Set`, `Dictionary` & `Mixed`) _viewable_ in Studio.

**Known issues / Todos:**
- [ ] `Dictionary<Realm.Object>` support (awaiting realm-js fix & release).
- [x] Awaiting `realm@10.5.0-beta.2` release.
- [x] Sets will show up as `Set<unknown>` in the cell header (fixed in next realm beta release - beta.2).
- [x] The view experience of `Mixed` is limited for realm object references.

This closes #1357 #1352 #1356