### PR TITLE
post cmake upgrade correction

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
       "./package.json",
       "./static/**/*",
       "!node_modules/realm/android${/*}",
-      "!node_modules/realm/build${/*}",
       "!node_modules/realm/react-native${/*}",
       "!node_modules/realm/scripts${/*}",
       "!node_modules/realm/src${/*}",


### PR DESCRIPTION
`node_modules/realm/build/*` (re-)included when packaging.

This closes #1420