### PR TITLE
Shallow mode of displaying objects and lists of objects

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- None
+- Implemented a simpler and shallow way of serializing objects (and lists of objects) in the browser. ([#1452](https://github.com/realm/realm-studio/pull/1452), since v11.0.0)
 
 ### Internals
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2019",
     "moduleResolution": "node",
     "module": "esnext",
     "esModuleInterop": true,


### PR DESCRIPTION
This will skip other objects and lists when building the string representation of objects and lists in the browser.

![Screenshot 2021-09-16 at 15 00 40](https://user-images.githubusercontent.com/1243959/133616703-6090661d-2520-4409-96b3-790ad255a841.png)
