### PR TITLE
Lock file format mismatch notice

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 
-- None
+- Improved error message when opening a Realm file which is already opened by another process opening the lock file with an mismatching format version.
 
 ### Fixed
 

--- a/src/ui/RealmBrowser/index.tsx
+++ b/src/ui/RealmBrowser/index.tsx
@@ -90,6 +90,8 @@ export type JsonViewerDialogExecutor = (value: unknown) => void;
 const EDIT_MODE_STORAGE_KEY = 'realm-browser-edit-mode';
 const FILE_UPGRADE_NEEDED_MESSAGE =
   'The Realm file format must be allowed to be upgraded in order to proceed.';
+const ARCHITECTURE_MISMATCH_MESSAGE =
+  'Realm file is currently open in another process which cannot share access with this process. All processes sharing a single file must be the same architecture.';
 
 export interface IRealmBrowserState extends IRealmLoadingComponentState {
   // A number that we can use to make components update on changes to data
@@ -396,6 +398,12 @@ class RealmBrowserContainer
       } else {
         window.close();
       }
+    } else if (err.message === ARCHITECTURE_MISMATCH_MESSAGE) {
+      const improvedError = new Error(
+        'The file is already opened by another process, with an incompatible lock file format. Try up- or downgrading Realm Studio or SDK to match their versions of Realm Core.\n\nSee Realm Studio changelog on GitHub for details on compatibility between versions.',
+      );
+      showError('Failed to open Realm', improvedError);
+      window.close();
     } else {
       delete this.props.realm.encryptionKey;
       super.loadingRealmFailed(err);

--- a/src/ui/reusable/errors.ts
+++ b/src/ui/reusable/errors.ts
@@ -55,8 +55,8 @@ export const showError = (
   // Show a message box ...
   if (process.type === 'renderer') {
     const remote = getRemote();
-    remote.dialog.showMessageBox(remote.getCurrentWindow(), messageOptions);
+    remote.dialog.showMessageBoxSync(remote.getCurrentWindow(), messageOptions);
   } else {
-    electron.dialog.showMessageBox(messageOptions);
+    electron.dialog.showMessageBoxSync(messageOptions);
   }
 };


### PR DESCRIPTION
Adding a better error message when opening a file with a mismatching lock file format.

This also updates `showError` to use the sync version of Electron's `showMessageBox` to block when errors are shown to the user, as I believe this has been an oversight when upgrading Electron at some point.

<img width="1082" alt="Screenshot 2022-06-02 at 13 26 47" src="https://user-images.githubusercontent.com/1243959/171621973-3a699cc8-0633-45fd-a342-b8df1cc14190.png">
